### PR TITLE
Add validation (and status subresource) to CRD

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -12,3 +12,103 @@ spec:
     singular: localvolumes
   scope: Namespaced
   version: v1alpha1
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeSelector:
+              description: Nodes on which the provisioner must run
+              type: object
+            storageClassDevices:
+              description: List of storage class and devices they can match
+              items:
+                properties:
+                  storageClassName:
+                    description: StorageClass name to use for set of matched devices
+                    type: string
+                  volumeMode:
+                    description: Volume mode. Block or Filesystem
+                    enum:
+                      - Block
+                      - Filesystem
+                    type: string
+                  fsType:
+                    description: File system type
+                    type: string
+                  deviceNames:
+                    description: 'A list of devices which would be chosen for local storage.
+                    For example - ["/dev/sda", "/dev/sdb"]
+                    Alternately deviceIDs can be also used to selecting
+                    devices which should be considered for local provisioning.'
+                    items:
+                      type: string
+                    type: array
+                  deviceIDs:
+                    description: 'A list of unique device names taken from /dev/disk/by-id/*
+                    For example - ["/dev/disk/by-id/ata-SanDisk_SD7SB7S512G1001_163057401172"]
+                    Either DeviceNames or DevicIDs must be specified while defining
+                    StorageClassDevice but not both.'
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - storageClassName
+                type: object
+              type: array
+            localProvisionerImageVersion:
+              description: Version of external local provisioner to use
+              type: string
+            diskMakerImageVersion:
+              description: DiskMakerImage version
+              type: string
+          required:
+            - storageClassDevices
+          type: object
+        status:
+          properties:
+            children:
+              items:
+                properties:
+                  group:
+                    type: string
+                  resource:
+                    type: string
+                  lastGeneration:
+                    format: int64
+                    type: integer
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - resource
+                - namespace
+                - name
+                - lastGeneration
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+            managementState:
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed"]
+          type: object
+      required:
+        - spec


### PR DESCRIPTION
I think the only missing is if deviceNames and deviceIDs are specified at the same time. Would be nice to catch it at validation time. For now the operator will just ignore IDs.