### PR TITLE
Fix some typos, and clarify docs

### DIFF
--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -4,35 +4,37 @@ The local-storage Operator is avaialble in OLM, this makes it easy to consume lo
 
 ## Pre Requisites
 
-A running OCP cluster (>= 4.1), with unused raw disks.  
+* A running OCP cluster (>= 4.1), with unused raw disks.  This operator also works with upstream raw Kubernetes clusters
+  and has been tested with version 1.14.
+* OLM version >= 0.9.0.
 
-## Install and Subscribe to the local-storage catalog
+## Deploy OLM
 
-### Create a project/namespace to use for the operator:
-
-```bash 
-oc new-project local-storage
-```
+The local-storage-operator is dependent upon OLM, if you're not familiar with OLM, check out the [OLM](https://github.com/operator-framework/operator-lifecycle-manager)
+Github repo.  Grab the [latest release](https://github.com/operator-framework/operator-lifecycle-manager/releases) of OLM and install it on your cluster. 
 
 ### Create and Subscribe to the local-storage Catalog
 
-```bash
-oc create -f https://github.com/openshift/local-storage-operator/blob/master/examples/olm-deploy/catalog-create-subscribe.yaml
-```
+By default the local-storage-operator assumes the `local-storage` namespace for it's resources.  If you're not modifying the example manifests, be sure to create
+the `local-storage` project or namespace: 
+`oc new-project local-storage` or `kubectl create ns local-storage`
 
-The above file uses defaults values and a namespace of ``local-storage`` which is fine in most cases, but download and modify if desired before running oc create.
+
+`oc apply -f https://raw.githubusercontent.com/openshift/local-storage-operator/master/examples/olm/catalog-create-subscribe.yaml`
+For Kubernetes substitute `oc` with `kubectl`
 
 ### Create a CR with Node Selector
 
-The following example assumes that each worker node include a raw disk ``/dev/xvdf`` that we want to allocate for local-storage provisioning.  Of course you can have different devices, or only have disks on a subset of your worker nodes.
+The following example assumes that each worker node includes a raw disk attached at ``/dev/xvdf`` that we want to allocate for local-storage provisioning.  Of course you can have different devices, or only have disks on a subset of your worker nodes.
 
-Gather the kubernetes hostname value for your worker nodes, (in our example we're using all worker nodes):
+Gather the kubernetes hostname value for your nodes, (in our example we're using only worker nodes, you can omit the label selector if you have master nodes you're deploying pods on):
 
 ```bash
 oc describe no -l node-role.kubernetes.io/worker | grep hostname
 	kubernetes.io/hostname=ip-10-0-136-143
 	kubernetes.io/hostname=ip-10-0-140-255
 	kubernetes.io/hostname=ip-10-0-144-180
+	
 ```
 
 Create a LocalVolume manifest named ``create-cr.yaml`` using the hostnames obtained above:
@@ -42,6 +44,7 @@ apiVersion: "local.storage.openshift.io/v1alpha1"
 kind: "LocalVolume"
 metadata:
   name: "local-disks"
+  namespace: "local-storage"
 spec:
   nodeSelector:
     nodeSelectorTerms:
@@ -63,12 +66,13 @@ spec:
 Deploy the local storage CR:
 
 ```bash
-oc create -f crete-cr.yaml
+oc create -f create-cr.yaml
 ```
 
 ### Verify your deployment
 
 ```bash
+oc get all -n local-storage
 NAME                                          READY   STATUS    RESTARTS   AGE
 pod/local-disks-local-provisioner-h97hj       1/1     Running   0          46m
 pod/local-disks-local-provisioner-j4mnn       1/1     Running   0          46m
@@ -106,4 +110,50 @@ local-pv-2ef7cd2a   100Gi      RWO            Delete           Available        
 local-pv-3fa1c73    100Gi      RWO            Delete           Available           local-sc                48m
 ```
 
+### Example Usage
 
+Request a PVC using the local-sc storage class we just created:
+
+```bash
+<< EOF | oc create -f -
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: example-local-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi 
+  storageClassName: local-sc
+EOF
+```
+
+Keep in mind that when using the local-provisioner a claim is held in pending and not bound until a consuming pod is scheduled and created.
+
+
+```bash
+oc get pvc
+NAME                  STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+example-local-claim   Pending                                      local-sc       2s
+```
+```bash
+oc describe pvc example-local-claim
+Name:          example-local-claim
+Namespace:     default
+StorageClass:  local-sc
+Status:        Pending
+Volume:        
+Labels:        <none>
+Annotations:   <none>
+Finalizers:    [kubernetes.io/pvc-protection]
+Capacity:      
+Access Modes:  
+VolumeMode:    Filesystem
+Events:
+  Type       Reason                Age                From                         Message
+----       ------                ----               ----                         -------
+  Normal     WaitForFirstConsumer  13s (x2 over 13s)  persistentvolume-controller  waiting for first consumer to be created before binding
+Mounted By:  <none>
+```


### PR DESCRIPTION
This PR just fixes a couple of typos and clears up some things in the
install doc to make it a bit more explicit.

It also points out that the operator works on upstream kubernetes as
well and adds some notes about how to deploy to a 1.14 Kubernetes
cluster.