### PR TITLE
Fix makefile docker build and add push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,29 @@ ifeq ($(VERSION),)
 endif
 
 IMAGE = $(REGISTRY)local-volume-provisioner:$(VERSION)
-MUTABLE_IMAGE = $(REGISTRY)local-volume-provisioner:latest
-DISKMAKER_IMAGE = $(REGISTRY)local-diskmaker:latest
-OPERATOR_IMAGE= $(REGISTRY)local-storage-operator:v0.0.13
+MUTABLE_IMAGE = $(REGISTRY)local-volume-provisioner:$(VERSION)
+DISKMAKER_IMAGE = $(REGISTRY)local-diskmaker:$(VERSION)
+OPERATOR_IMAGE= $(REGISTRY)local-storage-operator:$(VERSION)
 
 all build:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o diskmaker ./cmd/diskmaker
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o local-storage-operator ./cmd/local-storage-operator
 .PHONY: all build
 
+images: diskmaker-container operator-container
+
+push: images push-images
+
+push-images:
+	docker push ${DISKMAKER_IMAGE}
+	docker push ${OPERATOR_IMAGE}
+
 diskmaker-container:
-	docker build --no-cache -t $(DISKMAKER_IMAGE) -f Dockerfile.diskmaker
+	docker build --no-cache -t $(DISKMAKER_IMAGE) -f Dockerfile.diskmaker .
 .PHONY: diskmaker-container
 
 operator-container:
-	docker build --no-cache -t $(OPERATOR_IMAGE) -f Dockerfile
+	docker build --no-cache -t $(OPERATOR_IMAGE) -f Dockerfile .
 .PHONY: operator-container
 
 clean:


### PR DESCRIPTION
The docker build was missing the required `.`, this patch adds it and
also while we're at it we add image push functionality.  So now set 
REGISTRY env variable appropriately and do:
`make images` to build images, and `make push-images` to push the 
image to your registry.  Or, just run `make push` and do it all in one shot.