### PR TITLE
Move the operator examples to stable channel

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -11,11 +11,16 @@ and then update `deploy/operator.yaml` to point to your images and follow rest o
 2. Next we will have to update CSV inside manifests directory to point to those images.
 3. After updating the manifests file, you need to build your own local-registry. You can use `Dockerfile.registry` to do that.
 
+
 ```
-docker build --no-cache -t quay.io/gnufied/local-registry:latest -f ./Dockerfile.registry
+docker build --no-cache -t quay.io/gnufied/local-registry:latest -f ./Dockerfile.registry .
 ```
 
 Push the result image somewhere.
+
+NOTE: When this document was written https://bugzilla.redhat.com/show_bug.cgi?id=1726409 bug prevented local-registry from being usable
+with OLM if manifests contain `image-references` file. So please make sure that `manifests/4.2.0/image-references` file is removed
+before creating local-registry.
 
 4. When creating a catalog from `examples/olm/catalog-create-subscribe.yaml` file, specify your own image of local registry.
 

--- a/examples/olm/catalog-create-subscribe.yaml
+++ b/examples/olm/catalog-create-subscribe.yaml
@@ -16,17 +16,17 @@ metadata:
   namespace: local-storage
 spec:
   sourceType: grpc
-  image: quay.io/gnufied/local-registry:stable
+  image: quay.io/gnufied/local-registry:v4.2.0
 
 ---
 
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: local-storage-subscription-2
+  name: local-storage-subscription
   namespace: local-storage
 spec:
-  channel: alpha
-  name: local-storage
+  channel: stable
+  name: local-storage-operator
   source: local-storage-manifests
   sourceNamespace: local-storage

--- a/manifests/4.2.0/local-volumes.crd.yaml
+++ b/manifests/4.2.0/local-volumes.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumes.local.storage.openshift.io


### PR DESCRIPTION
- Fix bug with API version.
- Delete image-references file. It appears to be the main reason for manifests not working with operator-registry