### PR TITLE
Use default namespace if none available

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -36,6 +36,7 @@ cat ${repo_dir}/deploy/crd.yaml >> ${global_manifest}
 
 sed -i "s,quay.io/openshift/origin-local-storage-operator,${IMAGE_LOCAL_STORAGE_OPERATOR}," ${manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-diskmaker,${IMAGE_LOCAL_DISKMAKER}," ${manifest}
+NAMESPACE=${NAMESPACE:-default}
 
 TEST_NAMESPACE=${NAMESPACE} go test ./test/e2e/... \
   -root=$(pwd) \


### PR DESCRIPTION
Fix namespace in which e2e tests will run.