### PR TITLE
Add pv ownership and diskmaker events

### DIFF
--- a/cmd/diskmaker/diskmaker.go
+++ b/cmd/diskmaker/diskmaker.go
@@ -25,7 +25,8 @@ func printVersion() {
 }
 
 func main() {
-	klog.InitFlags(nil)
+	klogFlags := flag.NewFlagSet("local-storage-diskmaker", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
 	flag.Set("alsologtostderr", "true")
 	flag.Parse()
 

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -22,6 +22,18 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -37,8 +37,9 @@ cat ${repo_dir}/deploy/crd.yaml >> ${global_manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-operator,${IMAGE_LOCAL_STORAGE_OPERATOR}," ${manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-diskmaker,${IMAGE_LOCAL_DISKMAKER}," ${manifest}
 NAMESPACE=${NAMESPACE:-default}
+LOCAL_DISK=${LOCAL_DISK:-""}
 
-TEST_NAMESPACE=${NAMESPACE} go test ./test/e2e/... \
+TEST_NAMESPACE=${NAMESPACE} TEST_LOCAL_DISK=${LOCAL_DISK} go test ./test/e2e/... \
   -root=$(pwd) \
   -kubeconfig=${KUBECONFIG} \
   -globalMan ${global_manifest} \

--- a/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
@@ -55,6 +55,18 @@ spec:
             verbs:
             - "*"
           - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - roles
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
             - apps
             resources:
             - deployments

--- a/pkg/controller/api_updater.go
+++ b/pkg/controller/api_updater.go
@@ -25,6 +25,8 @@ type apiUpdater interface {
 	applyConfigMap(configmap *corev1.ConfigMap) (*corev1.ConfigMap, bool, error)
 	applyClusterRole(clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error)
 	applyClusterRoleBinding(roleBinding *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error)
+	applyRole(role *rbacv1.Role) (*rbacv1.Role, bool, error)
+	applyRoleBinding(roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error)
 	applyStorageClass(required *storagev1.StorageClass) (*storagev1.StorageClass, bool, error)
 	applyDaemonSet(ds *appsv1.DaemonSet, expectedGeneration int64, forceRollout bool) (*appsv1.DaemonSet, bool, error)
 	listStorageClasses(listOptions metav1.ListOptions) (*storagev1.StorageClassList, error)
@@ -66,6 +68,14 @@ func (s *sdkAPIUpdater) applyServiceAccount(sa *corev1.ServiceAccount) (*corev1.
 
 func (s *sdkAPIUpdater) applyConfigMap(configmap *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
 	return resourceapply.ApplyConfigMap(k8sclient.GetKubeClient().CoreV1(), configmap)
+}
+
+func (s *sdkAPIUpdater) applyRole(role *rbacv1.Role) (*rbacv1.Role, bool, error) {
+	return resourceapply.ApplyRole(k8sclient.GetKubeClient().RbacV1(), role)
+}
+
+func (s *sdkAPIUpdater) applyRoleBinding(roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+	return resourceapply.ApplyRoleBinding(k8sclient.GetKubeClient().RbacV1(), roleBinding)
 }
 
 func (s *sdkAPIUpdater) applyClusterRole(clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {

--- a/pkg/diskmaker/api_updater.go
+++ b/pkg/diskmaker/api_updater.go
@@ -1,0 +1,47 @@
+package diskmaker
+
+import (
+	"fmt"
+	"os"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type apiUpdater interface {
+	recordEvent(lv *localv1.LocalVolume, e *event)
+	getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error)
+}
+
+type sdkAPIUpdater struct {
+	recorder record.EventRecorder
+}
+
+func newAPIUpdater() apiUpdater {
+	apiClient := &sdkAPIUpdater{}
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(k8sclient.GetKubeClient().CoreV1().RESTClient()).Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "local-storage-diskmaker"})
+	apiClient.recorder = recorder
+	return apiClient
+}
+
+func (s *sdkAPIUpdater) recordEvent(lv *localv1.LocalVolume, e *event) {
+	nodeName := os.Getenv("MY_NODE_NAME")
+	message := e.message
+	if len(nodeName) != 0 {
+		message = fmt.Sprintf("%s - %s", nodeName, message)
+	}
+
+	s.recorder.Eventf(lv, e.eventType, e.eventReason, message)
+}
+
+func (s *sdkAPIUpdater) getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error) {
+	err := sdk.Get(lv)
+	return lv, err
+}

--- a/pkg/diskmaker/diskconfig.go
+++ b/pkg/diskmaker/diskconfig.go
@@ -36,7 +36,14 @@ func (d *Disks) DeviceIDs() sets.String {
 
 // DiskConfig stores a mapping between StorageClass Name and disks that the storageclass
 // will use on each matached node.
-type DiskConfig map[string]*Disks
+type DiskConfig struct {
+	Disks           map[string]*Disks `json:"disks,omitempty"`
+	OwnerName       string            `json:"ownerName,omitempty"`
+	OwnerNamespace  string            `json:"ownerNamespace,omitempty"`
+	OwnerKind       string            `json:"ownerKind,omitempty"`
+	OwnerUID        string            `json:"ownerUID,omitempty"`
+	OwnerAPIVersion string            `json:ownerAPIVersion,omitempty`
+}
 
 // ToYAML returns yaml representation of diskconfig
 func (d *DiskConfig) ToYAML() (string, error) {

--- a/pkg/diskmaker/diskmaker_test.go
+++ b/pkg/diskmaker/diskmaker_test.go
@@ -1,11 +1,30 @@
 package diskmaker
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
 )
 
+type fakeApiUpdater struct {
+	events []*event
+}
+
+var _ apiUpdater = &fakeApiUpdater{}
+
+func (f *fakeApiUpdater) recordEvent(lv *localv1.LocalVolume, e *event) {
+	f.events = append(f.events, e)
+}
+
+func (f *fakeApiUpdater) getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error) {
+	return lv, nil
+}
+
 func TestFindMatchingDisk(t *testing.T) {
-	d := NewDiskMaker("/tmp/foo", "/mnt/local-storage")
+	d := getFakeDiskMaker("/tmp/foo", "/mnt/local-storage")
 	deviceSet, err := d.findNewDisks(getData())
 	if err != nil {
 		t.Fatalf("error getting data %v", err)
@@ -13,9 +32,11 @@ func TestFindMatchingDisk(t *testing.T) {
 	if len(deviceSet) != 7 {
 		t.Errorf("expected 7 devices got %d", len(deviceSet))
 	}
-	diskConfig := map[string]*Disks{
-		"foo": &Disks{
-			DevicePaths: []string{"xyz"},
+	diskConfig := &DiskConfig{
+		Disks: map[string]*Disks{
+			"foo": &Disks{
+				DevicePaths: []string{"xyz"},
+			},
 		},
 	}
 	allDiskIds := getDeiveIDs()
@@ -26,6 +47,59 @@ func TestFindMatchingDisk(t *testing.T) {
 	if len(deviceMap) != 0 {
 		t.Errorf("expected 0 elements in map got %d", len(deviceMap))
 	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "diskmaker")
+	if err != nil {
+		t.Fatalf("error creating temp directory : %v", err)
+	}
+
+	defer os.RemoveAll(tempDir)
+	diskConfig := &DiskConfig{
+		Disks: map[string]*Disks{
+			"foo": &Disks{
+				DevicePaths: []string{"xyz"},
+			},
+		},
+		OwnerName:       "foobar",
+		OwnerNamespace:  "default",
+		OwnerKind:       localv1.LocalVolumeKind,
+		OwnerUID:        "foobar",
+		OwnerAPIVersion: localv1.SchemeGroupVersion.String(),
+	}
+	yaml, err := diskConfig.ToYAML()
+	if err != nil {
+		t.Fatalf("error marshalling yaml : %v", err)
+	}
+	filename := filepath.Join(tempDir, "config")
+	err = ioutil.WriteFile(filename, []byte(yaml), 0755)
+	if err != nil {
+		t.Fatalf("error writing yaml to disk : %v", err)
+	}
+
+	d := getFakeDiskMaker(filename, "/mnt/local-storage")
+	diskConfigFromDisk, err := d.loadConfig()
+	if err != nil {
+		t.Fatalf("error loading diskconfig from disk : %v", err)
+	}
+	if diskConfigFromDisk == nil {
+		t.Fatalf("expected a diskconfig got nil")
+	}
+	if d.localVolume == nil {
+		t.Fatalf("expected localvolume got nil")
+	}
+
+	if d.localVolume.Name != diskConfig.OwnerName {
+		t.Fatalf("expected owner name to be %s got %s", diskConfig.OwnerName, d.localVolume.Name)
+	}
+}
+
+func getFakeDiskMaker(configLocation, symlinkLocation string) *DiskMaker {
+	d := &DiskMaker{configLocation: configLocation, symlinkLocation: symlinkLocation}
+	d.apiClient = &fakeApiUpdater{}
+	d.er = newEventReporter(d.apiClient)
+	return d
 }
 
 func getData() string {

--- a/pkg/diskmaker/event_reporter.go
+++ b/pkg/diskmaker/event_reporter.go
@@ -1,0 +1,56 @@
+package diskmaker
+
+import (
+	"fmt"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	ErrorRunningBlockList    = "ErrorRunningBlockList"
+	ErrorReadingBlockList    = "ErrorReadingBlockList"
+	ErrorListingDeviceID     = "ErrorListingDeviceID"
+	ErrorFindingMatchingDisk = "ErrorFindingMatchingDisk"
+	ErrorCreatingSymLink     = "ErrorCreatingSymLink"
+
+	FoundMatchingDisk = "FoundMatchingDisk"
+)
+
+type event struct {
+	eventType   string
+	eventReason string
+	disk        string
+	message     string
+}
+
+func newEvent(eventReason, message, disk string) *event {
+	return &event{eventReason: eventReason, disk: disk, message: message, eventType: corev1.EventTypeWarning}
+}
+
+func newSuccessEvent(eventReason, message, disk string) *event {
+	return &event{eventReason: eventReason, disk: disk, message: message, eventType: corev1.EventTypeNormal}
+}
+
+type eventReporter struct {
+	apiClient      apiUpdater
+	reportedEvents sets.String
+}
+
+func newEventReporter(apiClient apiUpdater) *eventReporter {
+	er := &eventReporter{apiClient: apiClient}
+	er.reportedEvents = sets.NewString()
+	return er
+}
+
+// report function is not thread safe
+func (reporter *eventReporter) report(e *event, lv *localv1.LocalVolume) {
+	eventKey := fmt.Sprintf("%s:%s:%s", e.eventReason, e.eventType, e.disk)
+	if reporter.reportedEvents.Has(eventKey) {
+		return
+	}
+
+	reporter.apiClient.recordEvent(lv, e)
+	reporter.reportedEvents.Insert(eventKey)
+}


### PR DESCRIPTION
1. Adds a `local-volume-owner` label to all created PVs by local-storage-operator for easy tracking of created PVs. 
2. Report error events from node back to localvolume CR. Make sure that events aren't spammed.
3. Do not update localvolume if already on latest version and no change.
4. Allow e2e tests to run against plain k8s.

