### PR TITLE
Add local volume finalizer

### DIFF
--- a/cmd/diskmaker/diskmaker.go
+++ b/cmd/diskmaker/diskmaker.go
@@ -25,7 +25,8 @@ func printVersion() {
 }
 
 func main() {
-	klog.InitFlags(nil)
+	klogFlags := flag.NewFlagSet("local-storage-diskmaker", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
 	flag.Set("alsologtostderr", "true")
 	flag.Parse()
 

--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -11,8 +11,6 @@ import (
 	k8sutil "github.com/operator-framework/operator-sdk/pkg/util/k8sutil"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 
-	corev1 "k8s.io/api/core/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog"
 )
 
@@ -39,12 +37,9 @@ func main() {
 	if err != nil {
 		klog.Fatalf("failed to get watch namespace: %v", err)
 	}
-	resyncPeriod := time.Duration(5) * time.Second
+	resyncPeriod := time.Duration(3) * time.Minute
 	klog.Infof("Watching %s, %s, %s, %d", resource, kind, namespace, resyncPeriod)
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
-	sdk.Watch("v1", "ConfigMap", namespace, resyncPeriod)
-	sdk.Watch("apps/v1", "DaemonSet", namespace, resyncPeriod)
-	sdk.Watch("storage.k8s.io/v1", "StorageClass", corev1.NamespaceAll, resyncPeriod)
 	sdk.Handle(controller.NewHandler(namespace))
 	sdk.Run(context.TODO())
 }

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -22,6 +22,18 @@ rules:
   verbs:
   - "*"
 - apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -37,8 +37,9 @@ cat ${repo_dir}/deploy/crd.yaml >> ${global_manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-operator,${IMAGE_LOCAL_STORAGE_OPERATOR}," ${manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-diskmaker,${IMAGE_LOCAL_DISKMAKER}," ${manifest}
 NAMESPACE=${NAMESPACE:-default}
+LOCAL_DISK=${LOCAL_DISK:-""}
 
-TEST_NAMESPACE=${NAMESPACE} go test ./test/e2e/... \
+TEST_NAMESPACE=${NAMESPACE} TEST_LOCAL_DISK=${LOCAL_DISK} go test ./test/e2e/... \
   -root=$(pwd) \
   -kubeconfig=${KUBECONFIG} \
   -globalMan ${global_manifest} \

--- a/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
@@ -55,6 +55,18 @@ spec:
             verbs:
             - "*"
           - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - roles
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
             - apps
             resources:
             - deployments

--- a/manifests/4.2.0/local-volumes.crd.yaml
+++ b/manifests/4.2.0/local-volumes.crd.yaml
@@ -11,6 +11,8 @@ spec:
     singular: localvolume
   scope: Namespaced
   version: v1
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"fmt"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	// LocalVolumeOwnerNameForPV stores name of LocalVolume that created this PV
+	LocalVolumeOwnerNameForPV = "storage.openshift.com/local-volume-owner-name"
+	// LocalVolumeOwnerNamespaceForPV stores namespace of LocalVolume that created this PV
+	LocalVolumeOwnerNamespaceForPV = "storage.openshift.com/local-volume-owner-namespace"
+)
+
+// GetPVOwnerSelector returns selector for selecting pvs owned by given volume
+func GetPVOwnerSelector(lv *localv1.LocalVolume) labels.Selector {
+	pvOwnerLabels := labels.Set{
+		LocalVolumeOwnerNameForPV:      lv.Name,
+		LocalVolumeOwnerNamespaceForPV: lv.Namespace,
+	}
+	return labels.SelectorFromSet(pvOwnerLabels)
+}
+
+// LocalVolumeKey returns key for the localvolume
+func LocalVolumeKey(lv *localv1.LocalVolume) string {
+	return fmt.Sprintf("%s/%s", lv.Namespace, lv.Name)
+}

--- a/pkg/controller/api_updater.go
+++ b/pkg/controller/api_updater.go
@@ -25,6 +25,8 @@ type apiUpdater interface {
 	applyConfigMap(configmap *corev1.ConfigMap) (*corev1.ConfigMap, bool, error)
 	applyClusterRole(clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error)
 	applyClusterRoleBinding(roleBinding *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, bool, error)
+	applyRole(role *rbacv1.Role) (*rbacv1.Role, bool, error)
+	applyRoleBinding(roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error)
 	applyStorageClass(required *storagev1.StorageClass) (*storagev1.StorageClass, bool, error)
 	applyDaemonSet(ds *appsv1.DaemonSet, expectedGeneration int64, forceRollout bool) (*appsv1.DaemonSet, bool, error)
 	listStorageClasses(listOptions metav1.ListOptions) (*storagev1.StorageClassList, error)
@@ -66,6 +68,14 @@ func (s *sdkAPIUpdater) applyServiceAccount(sa *corev1.ServiceAccount) (*corev1.
 
 func (s *sdkAPIUpdater) applyConfigMap(configmap *corev1.ConfigMap) (*corev1.ConfigMap, bool, error) {
 	return resourceapply.ApplyConfigMap(k8sclient.GetKubeClient().CoreV1(), configmap)
+}
+
+func (s *sdkAPIUpdater) applyRole(role *rbacv1.Role) (*rbacv1.Role, bool, error) {
+	return resourceapply.ApplyRole(k8sclient.GetKubeClient().RbacV1(), role)
+}
+
+func (s *sdkAPIUpdater) applyRoleBinding(roleBinding *rbacv1.RoleBinding) (*rbacv1.RoleBinding, bool, error) {
+	return resourceapply.ApplyRoleBinding(k8sclient.GetKubeClient().RbacV1(), roleBinding)
 }
 
 func (s *sdkAPIUpdater) applyClusterRole(clusterRole *rbacv1.ClusterRole) (*rbacv1.ClusterRole, bool, error) {

--- a/pkg/controller/api_updater.go
+++ b/pkg/controller/api_updater.go
@@ -1,10 +1,13 @@
 package controller
 
 import (
+	goctx "context"
 	"fmt"
+	"time"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	commontypes "github.com/openshift/local-storage-operator/pkg/common"
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	appsv1 "k8s.io/api/apps/v1"
@@ -12,13 +15,24 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/kubernetes/scheme"
+	cgoscheme "k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	apiTimeout = time.Minute
 )
 
 type apiUpdater interface {
@@ -38,38 +52,45 @@ type apiUpdater interface {
 }
 
 type sdkAPIUpdater struct {
-	recorder record.EventRecorder
+	recorder  record.EventRecorder
+	dynClient dynclient.Client
 }
 
-func newAPIUpdater() apiUpdater {
+func newAPIUpdater(namespace string) (apiUpdater, error) {
 	apiClient := &sdkAPIUpdater{}
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(k8sclient.GetKubeClient().CoreV1().RESTClient()).Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: componentName})
 	apiClient.recorder = recorder
-	return apiClient
+	err := apiClient.setupDynamicClient(namespace)
+	if err != nil {
+		return apiClient, err
+	}
+	return apiClient, nil
 }
 
 var _ apiUpdater = &sdkAPIUpdater{}
 
 func (s *sdkAPIUpdater) updateLocalVolume(lv *localv1.LocalVolume) error {
-	klog.Infof("Updating localvolume %s", lv.Name)
+	klog.Infof("Updating localvolume %s", commontypes.LocalVolumeKey(lv))
 	err := sdk.Update(lv)
 	if err != nil && errors.IsConflict(err) {
-		msg := fmt.Sprintf("updating localvolume %s failed with %v", lv.Name, err)
+		msg := fmt.Sprintf("updating localvolume %s failed: %v", commontypes.LocalVolumeKey(lv), err)
 		s.recordEvent(lv, corev1.EventTypeWarning, localVolumeUpdateFailed, msg)
 	}
 	return err
 }
 
 func (s *sdkAPIUpdater) syncStatus(oldInstance, newInstance *localv1.LocalVolume) error {
-	klog.V(4).Infof("Syncing LocalVolume.Status of %s/%s", newInstance.Namespace, newInstance.Name)
+	klog.V(4).Infof("Syncing LocalVolume.Status of %s", commontypes.LocalVolumeKey(newInstance))
 
 	if !equality.Semantic.DeepEqual(oldInstance.Status, newInstance.Status) {
-		klog.V(4).Infof("Updating LocalVolume.Status of %s/%s", newInstance.Namespace, newInstance.Name)
-		err := sdk.Update(newInstance)
+		klog.V(4).Infof("Updating LocalVolume.Status of %s", commontypes.LocalVolumeKey(newInstance))
+		ctx, cancel := s.apiContext()
+		defer cancel()
+		err := s.dynClient.Status().Update(ctx, newInstance)
 		if err != nil && errors.IsConflict(err) {
-			msg := fmt.Sprintf("updating localvolume %s failed with %v", newInstance.Name, err)
+			msg := fmt.Sprintf("updating localvolume %s failed: %v", commontypes.LocalVolumeKey(newInstance), err)
 			s.recordEvent(newInstance, corev1.EventTypeWarning, localVolumeUpdateFailed, msg)
 		}
 		return err
@@ -121,4 +142,48 @@ func (s *sdkAPIUpdater) listPersistentVolumes(listOptions metav1.ListOptions) (*
 
 func (s *sdkAPIUpdater) recordEvent(lv *localv1.LocalVolume, eventType, reason, messageFmt string, args ...interface{}) {
 	s.recorder.Eventf(lv, eventType, reason, messageFmt)
+}
+
+// initialize controller-runtime dynamic client so as we can write status subresoure
+func (s *sdkAPIUpdater) setupDynamicClient(namespace string) error {
+	scheme := runtime.NewScheme()
+	cgoscheme.AddToScheme(scheme)
+	extscheme.AddToScheme(scheme)
+	err := localv1.AddToScheme(scheme)
+	if err != nil {
+		return fmt.Errorf("error adding localvolume to scheme: %v", err)
+	}
+
+	cachedDiscoveryClient := cached.NewMemCacheClient(k8sclient.GetKubeClient().Discovery())
+	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	restMapper.Reset()
+	dynClient, err := dynclient.New(k8sclient.GetKubeConfig(), dynclient.Options{Scheme: scheme, Mapper: restMapper})
+	if err != nil {
+		return fmt.Errorf("error initializing dynamic client: %v", err)
+	}
+	localVolumeList := &localv1.LocalVolumeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "LocalVolume",
+			APIVersion: localv1.SchemeGroupVersion.String(),
+		},
+	}
+
+	err = wait.PollImmediate(time.Second, time.Second*10, func() (done bool, err error) {
+		err = dynClient.List(goctx.TODO(), &dynclient.ListOptions{Namespace: namespace}, localVolumeList)
+		if err != nil {
+			restMapper.Reset()
+			return false, nil
+		}
+		return true, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to build dynamic client: %v", err)
+	}
+	s.dynClient = dynClient
+	return nil
+}
+
+func (s *sdkAPIUpdater) apiContext() (goctx.Context, goctx.CancelFunc) {
+	return goctx.WithTimeout(goctx.Background(), apiTimeout)
 }

--- a/pkg/controller/controller_events.go
+++ b/pkg/controller/controller_events.go
@@ -1,5 +1,7 @@
 package controller
 
 const (
-	localVolumeUpdateFailed = "LocalVolumeUpdateFailed"
+	localVolumeUpdateFailed        = "LocalVolumeUpdateFailed"
+	listingPersistentVolumesFailed = "ListingPersistentVolumeFailed"
+	localVolumeDeletionFailed      = "LocalVolumeDeletionFailed"
 )

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -140,6 +140,18 @@ func TestSyncLocalVolumeProvider(t *testing.T) {
 	}
 	newInstance := apiClient.latestInstance
 
+	if len(newInstance.GetFinalizers()) == 0 {
+		t.Fatalf("expected local volume to have finalizers")
+	}
+
+	// rerun the sync again so as rest of the code can run
+	err = handler.syncLocalVolumeProvider(newInstance)
+	if err != nil {
+		t.Fatalf("unexpected error while syncing localvolume: %v", err)
+	}
+
+	newInstance = apiClient.latestInstance
+
 	localVolumeConditions := newInstance.Status.Conditions
 	if len(localVolumeConditions) == 0 {
 		t.Fatalf("expected local volume to be available")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	commontypes "github.com/openshift/local-storage-operator/pkg/common"
 	"github.com/openshift/local-storage-operator/pkg/diskmaker"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
@@ -79,8 +80,17 @@ func (s *fakeApiUpdater) listStorageClasses(listOptions metav1.ListOptions) (*st
 	return &storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil
 }
 
+func (s *fakeApiUpdater) listPersistentVolumes(listOptions metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
+	return &corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil
+}
+
 func (s *fakeApiUpdater) recordEvent(lv *localv1.LocalVolume, eventType, reason, messageFmt string, args ...interface{}) {
 	fmt.Printf("Recording event : %v", eventType)
+}
+
+func (s *fakeApiUpdater) updateLocalVolume(lv *localv1.LocalVolume) error {
+	s.latestInstance = lv
+	return nil
 }
 
 func TestCreateDiskMakerConfig(t *testing.T) {
@@ -173,7 +183,7 @@ func TestSyncLocalVolumeProvider(t *testing.T) {
 		t.Fatalf("error unmarshalling pv labels : %v", err)
 	}
 
-	crOwnerValue, ok := labelsForPVMap["local-volume-owner"]
+	crOwnerValue, ok := labelsForPVMap[commontypes.LocalVolumeOwnerNameForPV]
 	if crOwnerValue != "local-disks" {
 		t.Fatalf("expected cr owner to be %s got %s", "local-disks", crOwnerValue)
 	}

--- a/pkg/diskmaker/api_updater.go
+++ b/pkg/diskmaker/api_updater.go
@@ -1,0 +1,47 @@
+package diskmaker
+
+import (
+	"fmt"
+	"os"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
+	"github.com/operator-framework/operator-sdk/pkg/sdk"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+type apiUpdater interface {
+	recordEvent(lv *localv1.LocalVolume, e *event)
+	getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error)
+}
+
+type sdkAPIUpdater struct {
+	recorder record.EventRecorder
+}
+
+func newAPIUpdater() apiUpdater {
+	apiClient := &sdkAPIUpdater{}
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(k8sclient.GetKubeClient().CoreV1().RESTClient()).Events("")})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "local-storage-diskmaker"})
+	apiClient.recorder = recorder
+	return apiClient
+}
+
+func (s *sdkAPIUpdater) recordEvent(lv *localv1.LocalVolume, e *event) {
+	nodeName := os.Getenv("MY_NODE_NAME")
+	message := e.message
+	if len(nodeName) != 0 {
+		message = fmt.Sprintf("%s - %s", nodeName, message)
+	}
+
+	s.recorder.Eventf(lv, e.eventType, e.eventReason, message)
+}
+
+func (s *sdkAPIUpdater) getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error) {
+	err := sdk.Get(lv)
+	return lv, err
+}

--- a/pkg/diskmaker/diskconfig.go
+++ b/pkg/diskmaker/diskconfig.go
@@ -36,7 +36,14 @@ func (d *Disks) DeviceIDs() sets.String {
 
 // DiskConfig stores a mapping between StorageClass Name and disks that the storageclass
 // will use on each matached node.
-type DiskConfig map[string]*Disks
+type DiskConfig struct {
+	Disks           map[string]*Disks `json:"disks,omitempty"`
+	OwnerName       string            `json:"ownerName,omitempty"`
+	OwnerNamespace  string            `json:"ownerNamespace,omitempty"`
+	OwnerKind       string            `json:"ownerKind,omitempty"`
+	OwnerUID        string            `json:"ownerUID,omitempty"`
+	OwnerAPIVersion string            `json:ownerAPIVersion,omitempty`
+}
 
 // ToYAML returns yaml representation of diskconfig
 func (d *DiskConfig) ToYAML() (string, error) {

--- a/pkg/diskmaker/diskmaker_test.go
+++ b/pkg/diskmaker/diskmaker_test.go
@@ -1,11 +1,30 @@
 package diskmaker
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
 )
 
+type fakeApiUpdater struct {
+	events []*event
+}
+
+var _ apiUpdater = &fakeApiUpdater{}
+
+func (f *fakeApiUpdater) recordEvent(lv *localv1.LocalVolume, e *event) {
+	f.events = append(f.events, e)
+}
+
+func (f *fakeApiUpdater) getLocalVolume(lv *localv1.LocalVolume) (*localv1.LocalVolume, error) {
+	return lv, nil
+}
+
 func TestFindMatchingDisk(t *testing.T) {
-	d := NewDiskMaker("/tmp/foo", "/mnt/local-storage")
+	d := getFakeDiskMaker("/tmp/foo", "/mnt/local-storage")
 	deviceSet, err := d.findNewDisks(getData())
 	if err != nil {
 		t.Fatalf("error getting data %v", err)
@@ -13,9 +32,11 @@ func TestFindMatchingDisk(t *testing.T) {
 	if len(deviceSet) != 7 {
 		t.Errorf("expected 7 devices got %d", len(deviceSet))
 	}
-	diskConfig := map[string]*Disks{
-		"foo": &Disks{
-			DevicePaths: []string{"xyz"},
+	diskConfig := &DiskConfig{
+		Disks: map[string]*Disks{
+			"foo": &Disks{
+				DevicePaths: []string{"xyz"},
+			},
 		},
 	}
 	allDiskIds := getDeiveIDs()
@@ -26,6 +47,59 @@ func TestFindMatchingDisk(t *testing.T) {
 	if len(deviceMap) != 0 {
 		t.Errorf("expected 0 elements in map got %d", len(deviceMap))
 	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "diskmaker")
+	if err != nil {
+		t.Fatalf("error creating temp directory : %v", err)
+	}
+
+	defer os.RemoveAll(tempDir)
+	diskConfig := &DiskConfig{
+		Disks: map[string]*Disks{
+			"foo": &Disks{
+				DevicePaths: []string{"xyz"},
+			},
+		},
+		OwnerName:       "foobar",
+		OwnerNamespace:  "default",
+		OwnerKind:       localv1.LocalVolumeKind,
+		OwnerUID:        "foobar",
+		OwnerAPIVersion: localv1.SchemeGroupVersion.String(),
+	}
+	yaml, err := diskConfig.ToYAML()
+	if err != nil {
+		t.Fatalf("error marshalling yaml : %v", err)
+	}
+	filename := filepath.Join(tempDir, "config")
+	err = ioutil.WriteFile(filename, []byte(yaml), 0755)
+	if err != nil {
+		t.Fatalf("error writing yaml to disk : %v", err)
+	}
+
+	d := getFakeDiskMaker(filename, "/mnt/local-storage")
+	diskConfigFromDisk, err := d.loadConfig()
+	if err != nil {
+		t.Fatalf("error loading diskconfig from disk : %v", err)
+	}
+	if diskConfigFromDisk == nil {
+		t.Fatalf("expected a diskconfig got nil")
+	}
+	if d.localVolume == nil {
+		t.Fatalf("expected localvolume got nil")
+	}
+
+	if d.localVolume.Name != diskConfig.OwnerName {
+		t.Fatalf("expected owner name to be %s got %s", diskConfig.OwnerName, d.localVolume.Name)
+	}
+}
+
+func getFakeDiskMaker(configLocation, symlinkLocation string) *DiskMaker {
+	d := &DiskMaker{configLocation: configLocation, symlinkLocation: symlinkLocation}
+	d.apiClient = &fakeApiUpdater{}
+	d.er = newEventReporter(d.apiClient)
+	return d
 }
 
 func getData() string {

--- a/pkg/diskmaker/diskmaker_test.go
+++ b/pkg/diskmaker/diskmaker_test.go
@@ -98,7 +98,7 @@ func TestLoadConfig(t *testing.T) {
 func getFakeDiskMaker(configLocation, symlinkLocation string) *DiskMaker {
 	d := &DiskMaker{configLocation: configLocation, symlinkLocation: symlinkLocation}
 	d.apiClient = &fakeApiUpdater{}
-	d.er = newEventReporter(d.apiClient)
+	d.eventSync = newEventReporter(d.apiClient)
 	return d
 }
 

--- a/pkg/diskmaker/event_reporter.go
+++ b/pkg/diskmaker/event_reporter.go
@@ -1,0 +1,56 @@
+package diskmaker
+
+import (
+	"fmt"
+
+	localv1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	ErrorRunningBlockList    = "ErrorRunningBlockList"
+	ErrorReadingBlockList    = "ErrorReadingBlockList"
+	ErrorListingDeviceID     = "ErrorListingDeviceID"
+	ErrorFindingMatchingDisk = "ErrorFindingMatchingDisk"
+	ErrorCreatingSymLink     = "ErrorCreatingSymLink"
+
+	FoundMatchingDisk = "FoundMatchingDisk"
+)
+
+type event struct {
+	eventType   string
+	eventReason string
+	disk        string
+	message     string
+}
+
+func newEvent(eventReason, message, disk string) *event {
+	return &event{eventReason: eventReason, disk: disk, message: message, eventType: corev1.EventTypeWarning}
+}
+
+func newSuccessEvent(eventReason, message, disk string) *event {
+	return &event{eventReason: eventReason, disk: disk, message: message, eventType: corev1.EventTypeNormal}
+}
+
+type eventReporter struct {
+	apiClient      apiUpdater
+	reportedEvents sets.String
+}
+
+func newEventReporter(apiClient apiUpdater) *eventReporter {
+	er := &eventReporter{apiClient: apiClient}
+	er.reportedEvents = sets.NewString()
+	return er
+}
+
+// report function is not thread safe
+func (reporter *eventReporter) report(e *event, lv *localv1.LocalVolume) {
+	eventKey := fmt.Sprintf("%s:%s:%s", e.eventReason, e.eventType, e.disk)
+	if reporter.reportedEvents.Has(eventKey) {
+		return
+	}
+
+	reporter.apiClient.recordEvent(lv, e)
+	reporter.reportedEvents.Insert(eventKey)
+}


### PR DESCRIPTION
This PR includes all the changes from - https://github.com/openshift/local-storage-operator/pull/33

and adds:

1. Add a finalizer to `LocalVolume` object. 
2. Add more e2e test to verify `LocalVolume` state and finalizers.
3. Enable `LocalVolume.Status` status as a subresource. 