### PR TITLE
Fix rbac permissions when operator is installed via OperatorSource

### DIFF
--- a/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2.0/local-storage-operator.v4.2.0.clusterserviceversion.yaml
@@ -151,6 +151,13 @@ spec:
           - apiGroups:
             - ""
             resources:
+            - persistentvolumeclaims
+            - events
+            verbs:
+              - "*"
+          - apiGroups:
+            - ""
+            resources:
             - nodes
             verbs:
             - get


### PR DESCRIPTION
When installing via operator source, the pvc and events permissions
are granted only for local-storage namespace but local storage
provisioner requires permission at cluster scope.

/sig storage

cc @jsafrane @bertinatto 
