### PR TITLE
Bug 1774090: Backport fix for OCP 4.3 installation

### DIFF
--- a/manifests/4.2/local-storage-operator.v4.2.0.clusterserviceversion.yaml
+++ b/manifests/4.2/local-storage-operator.v4.2.0.clusterserviceversion.yaml
@@ -156,6 +156,12 @@ spec:
             verbs:
               - "*"
           - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
             - ""
             resources:
             - nodes


### PR DESCRIPTION
This will allow 4.2 manifests to work on OCP-4.3

