### PR TITLE
Bug 1770183: Allow operator to be upgraded automatically

### DIFF
--- a/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
@@ -34,6 +34,7 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes in kubernetes and Openshift
+    olm.skipRange: '>=4.3.0 <4.4.0'
   labels:
     operator-metering: "true"
 spec:

--- a/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
@@ -34,6 +34,7 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes in kubernetes and Openshift
+    olm.skipRange: '>=4.4.0 <4.5.0'
   labels:
     operator-metering: "true"
 spec:


### PR DESCRIPTION
Allow operator to be updated automatically across minor versions.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1770183
