### PR TITLE
Updating manifests to include Toleration definitions

### DIFF
--- a/manifests/4.3/local-volumes.crd.yaml
+++ b/manifests/4.3/local-volumes.crd.yaml
@@ -68,6 +68,11 @@ spec:
                   - devicePaths
                 type: object
               type: array
+            tolerations:
+              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+              items:
+                type: object
+              type: array
           required:
             - storageClassDevices
           type: object

--- a/manifests/4.4/local-volumes.crd.yaml
+++ b/manifests/4.4/local-volumes.crd.yaml
@@ -68,6 +68,11 @@ spec:
                   - devicePaths
                 type: object
               type: array
+            tolerations:
+              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+              items:
+                type: object
+              type: array
           required:
             - storageClassDevices
           type: object

--- a/pkg/apis/local/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/local/v1/zz_generated.deepcopy.go
@@ -86,6 +86,13 @@ func (in *LocalVolumeSpec) DeepCopyInto(out *LocalVolumeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
The LocalVolume CRDs were not updated as part of https://github.com/openshift/local-storage-operator/pull/59 . This PR corrects that oversight.