### PR TITLE
Bug 1783857: Use Local Volume consistently for the CRD.

### DIFF
--- a/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
@@ -227,17 +227,17 @@ spec:
                         value: quay.io/openshift/origin-local-storage-diskmaker:latest
   customresourcedefinitions:
     owned:
-      - displayName: Local Volume operator
+      - displayName: Local Volume
         group: local.storage.openshift.io
         kind: LocalVolume
         name: localvolumes.local.storage.openshift.io
         description: Manage local storage volumes for OpenShift
         version: v1
         specDescriptors:
-          - description: User requested management state of operator
+          - description: User requested management state of this object
             displayName: Requested management state
             path: managementState
-          - description: Log level of operator
+          - description: Log level of local volume diskmaker and provisioner for this object
             displayName: LogLevel
             path: logLevel
           - description: Selected nodes for local storage
@@ -245,17 +245,17 @@ spec:
             path: nodeSelector
             x-descriptors:
               - 'urn:alm:descriptor:com.tectonic.ui:selector'
-          - description: StorageClass devices configured by the operator
+          - description: StorageClass devices configured by this object
             displayName: StorageClassDevices
             path: storageClassDevices
         statusDescriptors:
           - description: Last generation of this object
             displayName: ObservedGeneration
             path: observedGeneration
-          - description: Current management state of operator
+          - description: Current management state of this object
             displayName: Operator management state
             path: managementState
-          - description: Last known condition of the operator
+          - description: Last known condition of this object
             displayName: Conditions
             path: conditions
             x-descriptors:

--- a/manifests/4.4/local-volumes.crd.yaml
+++ b/manifests/4.4/local-volumes.crd.yaml
@@ -38,7 +38,7 @@ spec:
               type: string
               enum: ["Managed", "Unmanaged", "Removed", "Force"]
             logLevel:
-              description: logLevel configures log level for the operator
+              description: logLevel configures log level for the diskmaker and provisioner for this object
               type: string
               enum: ["Normal", "Debug", "Trace", "TraceAll"]
             storageClassDevices:


### PR DESCRIPTION
The operator is called "Local Storage Operator", however, it's CRD is "Local Volume", not "Local Volume operator".

And consistently mention that fields of the object affect only the object itself (and its provisioner and diskmaker), not the operator itself.

/assign @gnufied @huffmanca 