### PR TITLE
DiskMaker: Adds support for using all available device paths in the nodes

### DIFF
--- a/manifests/4.4/local-volumes.crd.yaml
+++ b/manifests/4.4/local-volumes.crd.yaml
@@ -57,6 +57,21 @@ spec:
                   fsType:
                     description: File system type
                     type: string
+                  useAllDevices:
+                      description: Switch to enable selection of all available paths for storage
+                      type: boolean
+                  excludeDeviceNames:
+                    description: 'A list of regex patterns that match devices which would be excluded for local storage when useAllDevices is enabled.
+                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                    items:
+                      type: string
+                    type: array
+                  excludeDeviceTypes:
+                    description: 'A list of devices types which would be excluded for local storage when useAllDevices is enabled.
+                    For example - ["part", "lvm", "crypt"]'
+                    items:
+                      type: string
+                    type: array
                   devicePaths:
                     description: 'A list of devices which would be chosen for local storage.
                     For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
@@ -65,7 +80,6 @@ spec:
                     type: array
                 required:
                   - storageClassName
-                  - devicePaths
                 type: object
               type: array
             tolerations:

--- a/pkg/apis/local/v1/types.go
+++ b/pkg/apis/local/v1/types.go
@@ -64,7 +64,18 @@ type StorageClassDevice struct {
 	FSType string `json:"fsType,omitempty"`
 	// A list of device paths which would be chosen for local storage.
 	// For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]
+	// +optional
 	DevicePaths []string `json:"devicePaths,omitempty"`
+	// UseAllDevices enables grabbing of all available devices for localStorage
+	// Note: The DevicePaths will be ignored when this is enabled
+	UseAllDevices bool `json:"useAllDevices,omitempty"`
+	// A list of device paths which would be excluded for local storage when UseAllDevices is enabled
+	// For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]
+	// +optional
+	ExcludeDeviceNames []string `json:"excludeDeviceNames,omitempty"`
+	// ExcludeDeviceTypes is the list of deviceTypes to ignore
+	// +optional
+	ExcludeDeviceTypes []string `json:"excludeDeviceTypes,omitempty"`
 }
 
 type LocalVolumeStatus struct {

--- a/pkg/apis/local/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/local/v1/zz_generated.deepcopy.go
@@ -147,6 +147,16 @@ func (in *StorageClassDevice) DeepCopyInto(out *StorageClassDevice) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExcludeDeviceNames != nil {
+		in, out := &in.ExcludeDeviceNames, &out.ExcludeDeviceNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ExcludeDeviceTypes != nil {
+		in, out := &in.ExcludeDeviceTypes, &out.ExcludeDeviceTypes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -537,6 +537,10 @@ func (h *Handler) generateDiskMakerConfig(cr *localv1.LocalVolume) (*corev1.Conf
 		if len(storageClassDevice.DevicePaths) > 0 {
 			disks.DevicePaths = storageClassDevice.DevicePaths
 		}
+		disks.UseAllDevices = storageClassDevice.UseAllDevices
+		disks.ExcludeDeviceNames = storageClassDevice.ExcludeDeviceNames
+		disks.ExcludeDeviceTypes = storageClassDevice.ExcludeDeviceTypes
+
 		configMapData.Disks[storageClassDevice.StorageClassName] = disks
 	}
 

--- a/pkg/diskmaker/diskconfig.go
+++ b/pkg/diskmaker/diskconfig.go
@@ -10,7 +10,13 @@ import (
 
 // Disks defines disks to be used for local volumes
 type Disks struct {
-	DevicePaths []string `json:"devicePaths,omitempty"`
+	// these fields are direct copy of some in StorageClassDevice
+	// we are considering replacing this entire field with StorageClassDevice,
+	// but we are concerned it will break something, so we're only adding to it for now.
+	DevicePaths        []string `json:"devicePaths,omitempty"`
+	UseAllDevices      bool     `json:"useAllDevices,omitempty"`
+	ExcludeDeviceNames []string `json:"excludeDeviceNames,omitempty"`
+	ExcludeDeviceTypes []string `json:"excludeDeviceTypes,omitempty"`
 }
 
 // DeviceNames returns devices which are used by name.


### PR DESCRIPTION
This commit modifies API scheme of LocalVolumeCRD for supporting `useAllDevices` feature and also adds generated code for the above change. UseAllDevices feature will enable DiskMaker to automatically detect the available device paths in the nodes for provisioning PVs.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>