### PR TITLE
Bug 1798198: We need to keep 4.4 channels for now

### DIFF
--- a/manifests/4.4/image-references
+++ b/manifests/4.4/image-references
@@ -1,0 +1,17 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: local-storage-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-operator:latest
+  - name: local-storage-static-provisioner
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-static-provisioner:latest
+  - name: local-storage-diskmaker
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-diskmaker:latest

--- a/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
@@ -1,0 +1,262 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: local-storage-operator.v4.4.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "local.storage.openshift.io/v1",
+          "kind": "LocalVolume",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "storageClassDevices": [
+              {
+                "devicePaths": [
+                    "/dev/vde",
+                    "/dev/vdf"
+                ],
+                "fsType": "ext4",
+                "storageClassName": "foobar",
+                "volumeMode": "Filesystem"
+              }
+            ]
+          }
+        }
+      ]
+    categories: Storage
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/origin-local-storage-operator:4.4.0
+    support: Red Hat
+    repository: https://github.com/openshift/local-storage-operator
+    createdAt: "2019-08-14T00:00:00Z"
+    description: >
+      Configure and use local storage volumes in kubernetes and Openshift.
+      Openshift 4.2 and above is only supported Openshift versions.
+    olm.skipRange: '>=4.4.0 <4.5.0'
+  labels:
+    operator-metering: "true"
+spec:
+  displayName: Local Storage
+  description: Local Storage Operator
+  keywords:
+    - storage
+    - local storage
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/local-storage-operator/tree/master/docs
+    - name: Source Repository
+      url: https://github.com/openshift/local-storage-operator
+  version: 4.4.0
+  maturity: stable
+  maintainers:
+    - email: aos-storage-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.14.0
+  provider:
+    name: Red Hat
+  labels:
+    alm-owner-metering: local-storage-operator
+    alm-status-descriptors: local-storage-operator.v4.4.0
+  selector:
+    matchLabels:
+      alm-owner-metering: local-storage-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - rules:
+          - apiGroups:
+            - local.storage.openshift.io
+            resources:
+            - "*"
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - services
+            - endpoints
+            - persistentvolumeclaims
+            - events
+            - configmaps
+            - secrets
+            verbs:
+            - "*"
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - roles
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            - statefulsets
+            verbs:
+            - "*"
+          serviceAccountName: local-storage-operator
+      clusterPermissions:
+        - rules:
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - storageclasses
+            verbs:
+            - "*"
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterroles
+            - clusterrolebindings
+            - rolebindings
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - ""
+            resources:
+            - serviceaccounts
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+            - patch
+            - delete
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumeclaims
+            - events
+            verbs:
+              - "*"
+          - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumes
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+          serviceAccountName: local-storage-operator
+        - rules:
+          - apiGroups:
+            - security.openshift.io
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - use
+            resourceNames:
+            - privileged
+          serviceAccountName: local-storage-admin
+      deployments:
+        - name: local-storage-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: local-storage-operator
+            template:
+              metadata:
+                labels:
+                  name: local-storage-operator
+              spec:
+                serviceAccountName: local-storage-operator
+                containers:
+                  - name: local-storage-operator
+                    image: quay.io/openshift/origin-local-storage-operator:latest
+                    ports:
+                    - containerPort: 60000
+                      name: metrics
+                    command:
+                    - local-storage-operator
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: "local-storage-operator"
+                      - name: PROVISIONER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-static-provisioner:latest
+                      - name: DISKMAKER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-diskmaker:latest
+  customresourcedefinitions:
+    owned:
+      - displayName: Local Volume
+        group: local.storage.openshift.io
+        kind: LocalVolume
+        name: localvolumes.local.storage.openshift.io
+        description: Manage local storage volumes for OpenShift
+        version: v1
+        specDescriptors:
+          - description: User requested management state of this object
+            displayName: Requested management state
+            path: managementState
+          - description: Log level of local volume diskmaker and provisioner for this object
+            displayName: LogLevel
+            path: logLevel
+          - description: Selected nodes for local storage
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: StorageClass devices configured by this object
+            displayName: StorageClassDevices
+            path: storageClassDevices
+        statusDescriptors:
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Current management state of this object
+            displayName: Operator management state
+            path: managementState
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'

--- a/manifests/4.4/local-volumes.crd.yaml
+++ b/manifests/4.4/local-volumes.crd.yaml
@@ -1,0 +1,130 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumes.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolume
+    listKind: LocalVolumeList
+    plural: localvolumes
+    singular: localvolume
+  scope: Namespaced
+  version: v1
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            nodeSelector:
+              description: Nodes on which the provisioner must run
+              type: object
+            managementState:
+              description: Indicates whether and how the operator should manage the component
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            logLevel:
+              description: logLevel configures log level for the diskmaker and provisioner for this object
+              type: string
+              enum: ["Normal", "Debug", "Trace", "TraceAll"]
+            storageClassDevices:
+              description: List of storage class and devices they can match
+              items:
+                properties:
+                  storageClassName:
+                    description: StorageClass name to use for set of matched devices
+                    type: string
+                  volumeMode:
+                    description: Volume mode. Block or Filesystem
+                    enum:
+                      - Block
+                      - Filesystem
+                    type: string
+                  fsType:
+                    description: File system type
+                    type: string
+                  devicePaths:
+                    description: 'A list of devices which would be chosen for local storage.
+                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - storageClassName
+                  - devicePaths
+                type: object
+              type: array
+            tolerations:
+              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+              items:
+                type: object
+              type: array
+          required:
+            - storageClassDevices
+          type: object
+        status:
+          properties:
+            generations:
+              items:
+                properties:
+                  group:
+                    type: string
+                  resource:
+                    type: string
+                  lastGeneration:
+                    format: int64
+                    type: integer
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - resource
+                - namespace
+                - name
+                - lastGeneration
+                type: object
+              type: array
+            conditions:
+              type: array
+              items:
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                    enum: ["True", "False", "Unknown"]
+                  lastTransitionTime:
+                    type: dateTime
+                    format: date-time
+                  reason:
+                    type: string
+                  message:
+                    type: string
+            observedGeneration:
+              format: int64
+              type: integer
+            managementState:
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            readyReplicas:
+              type: integer
+              format: int32
+          type: object
+      required:
+        - spec

--- a/manifests/local-storage-operator.package.yaml
+++ b/manifests/local-storage-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: local-storage-operator
 channels:
-- name: "4.5"
-  currentCSV: local-storage-operator.v4.5.0
+- name: "4.4"
+  currentCSV: local-storage-operator.v4.4.0


### PR DESCRIPTION
Restore 4.4 manifests for now, because we are still syncing master changes into 4.4 release automatically.

cc @sosiouxme 
