### PR TITLE
Warn about installation on OCP from in-tree docs

### DIFF
--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -2,7 +2,7 @@
 
 The local-storage Operator is avaialble in OLM, this makes it easy to consume local storage on your OCP cluster.
 
-**Warning: These docs are for internal development and testing. Use https://docs.openshift.com/container-platform/4.2/storage/persistent-storage/persistent-storage-local.html docs for installation on OCP**
+**Warning: These docs are for internal development and testing. Use https://docs.openshift.com/container-platform/latest/storage/persistent-storage/persistent-storage-local.html docs for installation on OCP**
 
 ## Pre Requisites
 

--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -2,6 +2,8 @@
 
 The local-storage Operator is avaialble in OLM, this makes it easy to consume local storage on your OCP cluster.
 
+**Warning: These docs are for internal development and testing. Use https://docs.openshift.com/container-platform/4.2/storage/persistent-storage/persistent-storage-local.html docs for installation on OCP**
+
 ## Pre Requisites
 
 * A running OCP cluster (>= 4.1), with unused raw disks.  This operator also works with upstream raw Kubernetes clusters


### PR DESCRIPTION
We should warn people from using docs stored in github repo, so as we do not have issues like https://github.com/openshift/local-storage-operator/issues/87
