### PR TITLE
Bug 1800637: Remove orphan storageclasses

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -279,6 +279,13 @@ func (h *Handler) cleanupLocalVolumeDeployment(lv *localv1.LocalVolume) error {
 		return fmt.Errorf(msg)
 	}
 
+	err = h.removeUnExpectedStorageClasses(lv, sets.NewString())
+	if err != nil {
+		msg := err.Error()
+		h.apiClient.recordEvent(lv, corev1.EventTypeWarning, deletingStorageClassFailed, msg)
+		return err
+	}
+
 	lv = removeFinalizer(lv)
 	return h.apiClient.updateLocalVolume(lv)
 }

--- a/pkg/controller/controller_events.go
+++ b/pkg/controller/controller_events.go
@@ -3,5 +3,6 @@ package controller
 const (
 	localVolumeUpdateFailed        = "LocalVolumeUpdateFailed"
 	listingPersistentVolumesFailed = "ListingPersistentVolumeFailed"
+	deletingStorageClassFailed     = "DeletingStorageClassFailed"
 	localVolumeDeletionFailed      = "LocalVolumeDeletionFailed"
 )


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/local-storage-operator/pull/85. 

Delete storageclass when localvolume object is deleted without using ownerreferences.

