### PR TITLE
Bug 1781502: Updating LSO to use digest for 4.3

### DIFF
--- a/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
       ]
     categories: Storage
     capabilities: Full Lifecycle
-    containerImage: quay.io/openshift/origin-local-storage-operator:4.3.0
+    containerImage: quay.io/openshift/origin-local-storage-operator:latest
     support: Red Hat
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"

--- a/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
+++ b/manifests/4.4/local-storage-operator.v4.4.0.clusterserviceversion.yaml
@@ -29,7 +29,7 @@ metadata:
       ]
     categories: Storage
     capabilities: Full Lifecycle
-    containerImage: quay.io/openshift/origin-local-storage-operator:4.4.0
+    containerImage: quay.io/openshift/origin-local-storage-operator:latest
     support: Red Hat
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"


### PR DESCRIPTION
We currently use digests for 4.4 and 4.5; however, because we specify the versions instead of relying on the `olm.skipRange` to subscribe to the correct channel. Changing this to be `latest` should allow ART to correctly use the digest instead of the tag.