### PR TITLE
Bug 1779545: Fix skipRange for 4.3

### DIFF
--- a/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
+++ b/manifests/4.3/local-storage-operator.v4.3.0.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes in kubernetes and Openshift
-    olm.skipRange: '>=4.3.0 <4.4.0'
+    olm.skipRange: '>=4.2.0 <4.3.0'
   labels:
     operator-metering: "true"
 spec:

--- a/manifests/art.yaml
+++ b/manifests/art.yaml
@@ -7,8 +7,8 @@ updates:
     # replace entire version line, otherwise would replace 4.3.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"
-    - search: 'olm.skipRange: ">=4.3.0 <{MAJOR}.{MINOR}.0"'
-      replace: 'olm.skipRange: ">=4.3.0 <{FULL_VER}"'
+    - search: 'olm.skipRange: ">=4.2.0 <{MAJOR}.{MINOR}.0"'
+      replace: 'olm.skipRange: ">=4.2.0 <{FULL_VER}"'
   - file: "local-storage-operator.package.yaml"
     update_list:
     - search: "currentCSV: local-storage-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
This should allow operator to be updatable automatically.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1779545

This is just a reworked cherry-pick of https://github.com/openshift/local-storage-operator/pull/99
