### PR TITLE
Corrected version to 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Operator for local storage
 
 ## Deploying with OLM
-Instructions to deploy on OCP >= 4.1 using OLM can be found [here](docs/deploy-with-olm.md)
+Instructions to deploy on OCP >= 4.2 using OLM can be found [here](docs/deploy-with-olm.md)

--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -6,7 +6,7 @@ The local-storage Operator is avaialble in OLM, this makes it easy to consume lo
 
 ## Pre Requisites
 
-* A running OCP cluster (>= 4.1), with unused raw disks.  This operator also works with upstream raw Kubernetes clusters
+* A running OCP cluster (>= 4.2), with unused raw disks.  This operator also works with upstream raw Kubernetes clusters
   and has been tested with version 1.14.
 * OLM version >= 0.9.0.
 


### PR DESCRIPTION
This addresses [issue 77](https://github.com/openshift/local-storage-operator/issues/77), and corrects the version of OCP 4.2 reported in the README and docs.