### PR TITLE
Bug 1826185: Fix status.conditions type

### DIFF
--- a/manifests/4.5/local-volumes.crd.yaml
+++ b/manifests/4.5/local-volumes.crd.yaml
@@ -103,6 +103,7 @@ spec:
             conditions:
               type: array
               items:
+                type: object
                 properties:
                   type:
                     type: string
@@ -110,7 +111,7 @@ spec:
                     type: string
                     enum: ["True", "False", "Unknown"]
                   lastTransitionTime:
-                    type: dateTime
+                    type: string
                     format: date-time
                   reason:
                     type: string


### PR DESCRIPTION
Kubernetes structural schema requires type of all fields and array items. In addition, it does not know "dateTime" type.

/assign @gnufied 