### PR TITLE
Bug 1826185: Add root type and description

### DIFF
--- a/manifests/4.5/local-volumes.crd.yaml
+++ b/manifests/4.5/local-volumes.crd.yaml
@@ -15,6 +15,8 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
+      type: object
+      decription: LocalVolume is a local storage configuration used by the operator
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
`type` is a mandatory field. Adding `description` for completeness.

@openshift/storage 