### PR TITLE
Bug 1840319: Change namespace of local-storage operator

### DIFF
--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -17,7 +17,7 @@ Github repo.  Grab the [latest release](https://github.com/operator-framework/op
 
 ### Create and Subscribe to the local-storage Catalog
 
-By default the local-storage-operator assumes the `local-storage` namespace for its resources and it is automatically created while installing
+By default the local-storage-operator assumes the `openshift-local-storage` namespace for its resources and it is automatically created while installing
 the operator using this method.
 
 
@@ -48,7 +48,7 @@ apiVersion: "local.storage.openshift.io/v1"
 kind: "LocalVolume"
 metadata:
   name: "local-disks"
-  namespace: "local-storage"
+  namespace: "openshift-local-storage"
 spec:
   nodeSelector:
     nodeSelectorTerms:
@@ -74,7 +74,7 @@ apiVersion: "local.storage.openshift.io/v1"
 kind: "LocalVolume"
 metadata:
   name: "local-disks"
-  namespace: "local-storage"
+  namespace: "openshift-local-storage"
 spec:
   nodeSelector:
     nodeSelectorTerms:
@@ -125,7 +125,7 @@ apiVersion: "local.storage.openshift.io/v1"
 kind: "LocalVolume"
 metadata:
   name: "local-disks"
-  namespace: "local-storage"
+  namespace: "openshift-local-storage"
 spec:
   tolerations:
     - key: localstorage
@@ -144,7 +144,7 @@ The defined tolerations will be passed to the resulting DaemonSets, allowing the
 ### Verify your deployment
 
 ```bash
-oc get all -n local-storage
+oc get all -n openshift-local-storage
 NAME                                          READY   STATUS    RESTARTS   AGE
 pod/local-disks-local-provisioner-h97hj       1/1     Running   0          46m
 pod/local-disks-local-provisioner-j4mnn       1/1     Running   0          46m

--- a/examples/olm/catalog-create-subscribe.yaml
+++ b/examples/olm/catalog-create-subscribe.yaml
@@ -1,16 +1,16 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: local-storage
+  name: openshift-local-storage
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: local-operator-group
-  namespace: local-storage
+  namespace: openshift-local-storage
 spec:
   targetNamespaces:
-    - local-storage
+    - openshift-local-storage
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
@@ -28,7 +28,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: local-storage-operator
-  namespace: local-storage
+  namespace: openshift-local-storage
 spec:
   channel: "4.4"
   installPlanApproval: Automatic

--- a/examples/olm/redhat-src-catalog.yaml
+++ b/examples/olm/redhat-src-catalog.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: local-storage
+  name: openshift-local-storage
 ---
 apiVersion: operators.coreos.com/v1alpha2
 kind: OperatorGroup
 metadata:
   name: local-operator-group
-  namespace: local-storage
+  namespace: openshift-local-storage
 spec:
   targetNamespaces:
-    - local-storage
+    - openshift-local-storage
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: local-storage-operator
-  namespace: local-storage
+  namespace: openshift-local-storage
 spec:
   channel: "4.2"
   installPlanApproval: Automatic

--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -28,6 +28,7 @@ metadata:
         }
       ]
     categories: Storage
+    "operatorframework.io/suggested-namespace": openshift-local-storage
     capabilities: Full Lifecycle
     containerImage: quay.io/openshift/origin-local-storage-operator:latest
     support: Red Hat


### PR DESCRIPTION
This will change namespace of local-storage-operator from `local-storage` to `openshift-local-storage`. In general this should fine. The clusters which are using LSO in `local-storage` namespace will keep working in that namespace even after upgrade, we make no attempt to move the operator back into `openshift-local-storage` namespace. 

With OLM the operator's namespace is anyways an suggestion and not something we can enforce. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1840319
