### PR TITLE
Bug 1850143: Fix quote in 4.5 version so as it can automatically update

### DIFF
--- a/manifests/4.5/local-storage-operator.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/4.5/local-storage-operator.v4.5.0.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ metadata:
     description: >
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
-    olm.skipRange: '>=4.3.0 <4.5.0'
+    olm.skipRange: ">=4.3.0 <4.5.0"
   labels:
     operator-metering: "true"
 spec:


### PR DESCRIPTION
We need to update skipVersion in 4.5 so as the operator can update itself. 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1850143

I am making this fix because https://github.com/openshift/local-storage-operator/pull/117 PR did not make it to `release-4.5` branch.

