### PR TITLE
Bug 1756096: Included must-gather script and image

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,0 +1,10 @@
+FROM quay.io/openshift/origin-must-gather:4.5.0 as builder
+
+FROM registry.access.redhat.com/ubi8-minimal:latest
+
+RUN microdnf -y install rsync
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+COPY must-gather/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather

--- a/Dockerfile.mustgather.rhel7
+++ b/Dockerfile.mustgather.rhel7
@@ -1,0 +1,10 @@
+FROM quay.io/openshift/origin-must-gather:4.5.0 as builder
+
+FROM registry.access.redhat.com/ubi8-minimal:latest
+
+RUN microdnf -y install rsync
+
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+COPY must-gather/* /usr/bin/
+
+ENTRYPOINT /usr/bin/gather

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ Operator for local storage
 
 ## Deploying with OLM
 Instructions to deploy on OCP >= 4.2 using OLM can be found [here](docs/deploy-with-olm.md)
+
+## Using the must-gather image with the local storage operator
+Instructions for using the local storage's must-gather image can be found [here](docs/must-gather.md)

--- a/docs/must-gather.md
+++ b/docs/must-gather.md
@@ -1,0 +1,22 @@
+# Using the must-gather local-storage image
+
+The `must-gather` image provided by the local-storage operator is a supplement to the [must-gather](https://github.com/openshift/must-gather) image provided by OpenShift. This image
+is used to gather the local-storage specific resources.
+
+## Usage
+```sh
+oc adm must-gather --image=quay.io/openshift/local-must-gather:latest
+```
+
+This command creates a directory that contains:
+- All local.storage.openshift.io resources across the cluster
+
+## Building the image locally
+The `Dockerfile.mustgather` can be used to build a local local-storage must-gather image. This file is referenced in the `Makefile`, and can be built using the following command:
+
+```sh
+make must-gather REGISTRY=my-repo/
+```
+
+The arguments for `make` are as follows:
+- `REGISTRY`: Defines a custom registry for creating the must-gather image. If undefined, defaults to `quay.io/openshift/`.

--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+resources=()
+
+for I in $(/usr/bin/oc get crd | grep local.storage.openshift.io | awk '{print $1}'); do
+  resources+=($I)
+done
+
+for resource in ${resources[@]}; do
+  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
+  while read ocresource; do
+    ocobject=$(echo $ocresource | awk '{print $1}')
+    ocns=$(echo $ocresource | awk '{print $2}')
+    if [ -z "${ocns}" ]|[ "${ocns}" == "<none>" ]; then
+      object_collection_path=must-gather/cluster-scoped-resources/${resource}
+      mkdir -p ${object_collection_path}
+      /usr/bin/oc get ${resource} -o yaml ${ocobject} > ${object_collection_path}/${ocobject}.yaml
+    else
+      object_collection_path=must-gather/namespaces/${ocns}/crs/${resource}
+      mkdir -p ${object_collection_path}
+      /usr/bin/oc get ${resource} -n ${ocns} -o yaml ${ocobject} > ${object_collection_path}/${ocobject}.yaml
+    fi
+  done
+done
+
+exit 0


### PR DESCRIPTION
This PR adds a script and corresponding image to work with `oc adm must-gather`. This will cycle through all of the CRDs and output any resources for them.