### PR TITLE
Bug 1867066: [Auto-discovery] List BIOS-BOOT and EFI-SYSTEM devices as Unavailable

### DIFF
--- a/pkg/diskmaker/discovery/discovery.go
+++ b/pkg/diskmaker/discovery/discovery.go
@@ -26,6 +26,8 @@ const (
 	probeInterval                 = 5 * time.Minute
 	resultCRName                  = "discovery-result-%s"
 	resultCRLabel                 = "discovery-result-node"
+	biosBoot                      = "BIOS-BOOT"
+	efiSystem                     = "EFI-SYSTEM"
 )
 
 // DeviceDiscovery instance
@@ -221,6 +223,11 @@ func ignoreDevices(dev internal.BlockDevice) bool {
 func getDeviceStatus(dev internal.BlockDevice) v1alpha1.DeviceStatus {
 	status := v1alpha1.DeviceStatus{}
 	if dev.FSType != "" {
+		status.State = v1alpha1.NotAvailable
+		return status
+	}
+
+	if dev.PartLabel == biosBoot || dev.PartLabel == efiSystem {
 		status.State = v1alpha1.NotAvailable
 		return status
 	}

--- a/pkg/diskmaker/discovery/discovery_test.go
+++ b/pkg/diskmaker/discovery/discovery_test.go
@@ -14,15 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const (
-	testData1 = `NAME="sda" ROTA="1" TYPE="disk" SIZE="62914560000" MODEL="VBOX HARDDISK" VENDOR="ATA" RO="1" RM="0" STATE="running" FSTYPE="" SERIAL=""
-NAME="sda1" ROTA="1" TYPE="part" SIZE="62913494528" MODEL="" VENDOR="" RO="1" RM="0" STATE="" FSTYPE="" SERIAL=""
-`
-	testData2 = `NAME="sdc" ROTA="1" TYPE="disk" SIZE="62914560000" MODEL="VBOX HARDDISK" VENDOR="ATA" RO="0" RM="1" STATE="running" FSTYPE="ext4" SERIAL=""
-NAME="sdc3" ROTA="1" TYPE="part" SIZE="62913494528" MODEL="" VENDOR="" RO="0" RM="1" STATE="" FSTYPE="ext4" SERIAL=""
-`
-)
-
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
@@ -327,6 +318,86 @@ func TestGetDiscoveredDevices(t *testing.T) {
 					Size:     resource.MustParse("62913494528"),
 					Property: "NonRotational",
 					FSType:   "ext4",
+					Status:   v1alpha1.DeviceStatus{State: "NotAvailable"},
+				},
+			},
+			fakeGlobfunc: func(name string) ([]string, error) {
+				return []string{"/dev/disk/by-id/sda1"}, nil
+			},
+			fakeEvalSymlinkfunc: func(path string) (string, error) {
+				return "/dev/disk/by-id/sda1", nil
+			},
+		},
+		{
+			label: "Case 3",
+			blockDevices: []internal.BlockDevice{
+				{
+					Name:       "sda1",
+					KName:      "sda1",
+					FSType:     "",
+					Type:       "part",
+					Size:       "62913494528",
+					Model:      "",
+					Vendor:     "",
+					Serial:     "",
+					Rotational: "0",
+					ReadOnly:   "0",
+					Removable:  "0",
+					State:      "running",
+					PartLabel:  "BIOS-BOOT",
+				},
+			},
+			expected: []v1alpha1.DiscoveredDevice{
+				{
+					DeviceID: "/dev/disk/by-id/sda1",
+					Path:     "/dev/sda1",
+					Model:    "",
+					Type:     "part",
+					Vendor:   "",
+					Serial:   "",
+					Size:     resource.MustParse("62913494528"),
+					Property: "NonRotational",
+					FSType:   "",
+					Status:   v1alpha1.DeviceStatus{State: "NotAvailable"},
+				},
+			},
+			fakeGlobfunc: func(name string) ([]string, error) {
+				return []string{"/dev/disk/by-id/sda1"}, nil
+			},
+			fakeEvalSymlinkfunc: func(path string) (string, error) {
+				return "/dev/disk/by-id/sda1", nil
+			},
+		},
+		{
+			label: "Case 4",
+			blockDevices: []internal.BlockDevice{
+				{
+					Name:       "sda1",
+					KName:      "sda1",
+					FSType:     "",
+					Type:       "part",
+					Size:       "62913494528",
+					Model:      "",
+					Vendor:     "",
+					Serial:     "",
+					Rotational: "0",
+					ReadOnly:   "0",
+					Removable:  "0",
+					State:      "running",
+					PartLabel:  "EFI-SYSTEM",
+				},
+			},
+			expected: []v1alpha1.DiscoveredDevice{
+				{
+					DeviceID: "/dev/disk/by-id/sda1",
+					Path:     "/dev/sda1",
+					Model:    "",
+					Type:     "part",
+					Vendor:   "",
+					Serial:   "",
+					Size:     resource.MustParse("62913494528"),
+					Property: "NonRotational",
+					FSType:   "",
 					Status:   v1alpha1.DeviceStatus{State: "NotAvailable"},
 				},
 			},

--- a/pkg/internal/diskutil.go
+++ b/pkg/internal/diskutil.go
@@ -54,6 +54,7 @@ type BlockDevice struct {
 	Removable  string `json:"rm,omitempty"`
 	PathByID   string `json:"pathByID,omitempty"`
 	Serial     string `json:"serial,omitempty"`
+	PartLabel  string `json:"partLabel,omitempty"`
 }
 
 // IDPathNotFoundError indicates that a symlink to the device was not found in /dev/disk/by-id/
@@ -181,7 +182,7 @@ func ListBlockDevices() ([]BlockDevice, []string, error) {
 	// var output bytes.Buffer
 	var blockDevices []BlockDevice
 
-	columns := "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,FSTYPE,KNAME,SERIAL"
+	columns := "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,FSTYPE,KNAME,SERIAL,PARTLABEL"
 	args := []string{"--pairs", "-b", "-o", columns}
 	cmd := ExecCommand("lsblk", args...)
 	output, err := executeCmdWithCombinedOutput(cmd)

--- a/pkg/internal/diskutil_test.go
+++ b/pkg/internal/diskutil_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	lsblkOutput1 = `NAME="sda" KNAME="sda" ROTA="1" TYPE="disk" SIZE="62914560000" MODEL="VBOX HARDDISK" VENDOR="ATA" RO="0" RM="0" STATE="running" FSTYPE="" SERIAL=""
-NAME="sda1" KNAME="sda1" ROTA="1" TYPE="part" SIZE="62913494528" MODEL="" VENDOR="" RO="0" RM="0" STATE="" FSTYPE="" SERIAL=""
+	lsblkOutput1 = `NAME="sda" KNAME="sda" ROTA="1" TYPE="disk" SIZE="62914560000" MODEL="VBOX HARDDISK" VENDOR="ATA" RO="0" RM="0" STATE="running" FSTYPE="" SERIAL="" PARTLABEL=""
+NAME="sda1" KNAME="sda1" ROTA="1" TYPE="part" SIZE="62913494528" MODEL="" VENDOR="" RO="0" RM="0" STATE="" FSTYPE="" SERIAL="" PARTLABEL="BIOS-BOOT"
 `
 	lsblkOutput2 = `NAME="sdc" KNAME="sdc" ROTA="1" TYPE="disk" SIZE="62914560000" MODEL="VBOX HARDDISK" VENDOR="ATA" RO="0" RM="1" STATE="running" FSTYPE="ext4" SERIAL=""
 NAME="sdc3" KNAME="sdc3" ROTA="1" TYPE="part" SIZE="62913494528" MODEL="" VENDOR="" RO="0" RM="1" STATE="" FSTYPE="ext4" SERIAL=""
@@ -54,6 +54,7 @@ func TestListBlockDevices(t *testing.T) {
 					ReadOnly:   "0",
 					Removable:  "0",
 					State:      "running",
+					PartLabel:  "",
 				},
 				{
 
@@ -68,6 +69,7 @@ func TestListBlockDevices(t *testing.T) {
 					ReadOnly:   "0",
 					Removable:  "0",
 					State:      "running",
+					PartLabel:  "BIOS-BOOT",
 				},
 			},
 		},
@@ -89,6 +91,7 @@ func TestListBlockDevices(t *testing.T) {
 					ReadOnly:   "0",
 					Removable:  "1",
 					State:      "running",
+					PartLabel:  "",
 				},
 				{
 
@@ -103,6 +106,7 @@ func TestListBlockDevices(t *testing.T) {
 					ReadOnly:   "0",
 					Removable:  "1",
 					State:      "running",
+					PartLabel:  "",
 				},
 			},
 		},
@@ -133,6 +137,7 @@ func TestListBlockDevices(t *testing.T) {
 			assert.Equalf(t, tc.expected[i].Serial, blockDevices[i].Serial, "[%q: Device: %d]: invalid block device serial", tc.label, i+1)
 			assert.Equalf(t, tc.expected[i].Rotational, blockDevices[i].Rotational, "[%q: Device: %d]: invalid block device rotational property", tc.label, i+1)
 			assert.Equalf(t, tc.expected[i].ReadOnly, blockDevices[i].ReadOnly, "[%q: Device: %d]: invalid block device read only value", tc.label, i+1)
+			assert.Equalf(t, tc.expected[i].PartLabel, blockDevices[i].PartLabel, "[%q: Device: %d]: invalid block device PartLabel value", tc.label, i+1)
 		}
 	}
 


### PR DESCRIPTION
The PR fixes LocalVolumeDiscovery to discover devices with `PARTLABEL`  as `BIOS-BOOT` and `EFI-SYSTEM` as `Unavailable`. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>