### PR TITLE
Bug 1868365: Remove spec.minDeviceCount from LocalVolumeSet CSV example

### DIFF
--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -45,7 +45,6 @@ metadata:
               "minSize": "10G"
             },
             "maxDeviceCount": 10,
-            "minDeviceCount": 5,
             "nodeSelector": {
               "nodeSelectorTerms": [
                 {


### PR DESCRIPTION
This was a leftover from a feature we decided to forgo.

Signed-off-by: Rohan CJ <rohantmp@redhat.com>