### PR TITLE
Bug 1862443: Remove permission to modify serviceaccounts

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -110,18 +110,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - serviceaccounts
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
   - get

--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -219,18 +219,6 @@ spec:
           - apiGroups:
             - ""
             resources:
-            - serviceaccounts
-            verbs:
-            - get
-            - list
-            - watch
-            - create
-            - update
-            - patch
-            - delete
-          - apiGroups:
-            - ""
-            resources:
             - persistentvolumeclaims
             - events
             verbs:


### PR DESCRIPTION
Dynamic RBAC was removed in #110, so this is no longer necessary.

Signed-off-by: Rohan CJ <rohantmp@redhat.com>