### PR TITLE
BUG 1874695: fix alm-examples in 4.6 csv file

### DIFF
--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
           },
           "spec": {
             "deviceInclusionSpec": {
-              "deviceMechanicalProperty": [
+              "deviceMechanicalProperties": [
                 "Rotational",
                 "NonRotational"
               ],


### PR DESCRIPTION
alm-example for LocalVolumeSet should use `deviceMechanicalProperties` instead of `deviceMechanicalProperty`

Signed-off-by: Santosh Pillai <sapillai@redhat.com>