### PR TITLE
BUG 1872079: change device status to NotAvailable if block mode pv is provisioned on it.

### DIFF
--- a/pkg/controller/localvolumediscovery/localvolumediscovery_controller.go
+++ b/pkg/controller/localvolumediscovery/localvolumediscovery_controller.go
@@ -192,6 +192,7 @@ func getDiskMakerDiscoveryDSMutateFn(request reconcile.Request,
 		ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env, envVars...)
 		ds.Spec.Template.Spec.Containers[0].Image = common.GetDiskMakerImage()
 		ds.Spec.Template.Spec.Containers[0].Args = []string{"discover"}
+		ds.Spec.Template.Spec.HostPID = true
 
 		return nil
 	}


### PR DESCRIPTION
Continuous discovery changes the device status to NotAvailable when pv is provisioned on it.
In case of filesystem mode pv, the discovery checks the filesystem on the device and makes it NotAvailable.
For block mode pv, the discovery checks the bind mount of the device in /var/lib/kubelet/plugins/kubernetes.io~local-volume/volumeDevices/<pv-name>/<pod-uuid>
and makes the device as NotAvailable if a bind mount is present.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>