### PR TITLE
BUG 1875060:  show correct local-storage-operator version

### DIFF
--- a/cmd/diskmaker/diskmaker.go
+++ b/cmd/diskmaker/diskmaker.go
@@ -30,6 +30,7 @@ func printVersion() {
 }
 
 func startDiskMaker(cmd *cobra.Command, args []string) error {
+	printVersion()
 	diskMaker, err := diskmaker.NewDiskMaker(configLocation, symlinkLocation)
 	if err != nil {
 		log.Error(err, "Failed to create DiskMaker")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/openshift/local-storage-operator/pkg/apis"
 	"github.com/openshift/local-storage-operator/pkg/controller"
-	"github.com/openshift/local-storage-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -38,14 +37,15 @@ var (
 	metricsHost               = "0.0.0.0"
 	metricsPort         int32 = 8383
 	operatorMetricsPort int32 = 8686
+	version                   = "unknown"
 )
 var log = logf.Log.WithName("cmd")
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("local-storage-operator Version: %s", version))
 }
 
 func main() {


### PR DESCRIPTION
Operator-sdk changes broke the local-storage-operator version reporting. This PR fixes that and shows correct local-storage-operator version

Signed-off-by: Santosh Pillai <sapillai@redhat.com>