### PR TITLE
Bug 1862489:  LSO autoprovisioning should exclude top level disks that are part of LVM volume group

### DIFF
--- a/pkg/common/names.go
+++ b/pkg/common/names.go
@@ -21,6 +21,9 @@ const (
 	ProvisionerImageEnv = "PROVISIONER_IMAGE"
 	// LocalDiskLocationEnv is passed to the operator to override the LOCAL_DISK_LOCATION host directory
 	LocalDiskLocationEnv = "LOCAL_DISK_LOCATION"
+
+	// ProvisionerConfigMapName is the name of the local-static-provisioner configmap
+	ProvisionerConfigMapName = "local-volumeset-provisioner"
 )
 
 // GetLocalProvisionerImage return the image to be used for provisioner daemonset

--- a/pkg/common/volume_definitions.go
+++ b/pkg/common/volume_definitions.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	symlinkDirVolName = "local-disks"
+
+	devDirVolName = "device-dir"
+	devDirPath    = "/dev"
+
+	provisionerConfigVolName = "provisioner-config"
+
+	udevVolName = "run-udev"
+	udevPath    = "/run/udev"
+)
+
+var (
+	hostContainerPropagation = corev1.MountPropagationHostToContainer
+	directoryHostPath        = corev1.HostPathDirectory
+
+	// SymlinkHostDirVolume is the corev1.Volume definition for the lso symlink host directory.
+	// "/mnt/local-storage" is the default, but it can be controlled by env vars.
+	// SymlinkMount is the corresponding mount
+	SymlinkHostDirVolume = corev1.Volume{
+		Name: "local-disks",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: GetLocalDiskLocationPath(),
+			},
+		},
+	}
+	// SymlinkMount is the corresponding mount for SymlinkHostDirVolume
+	SymlinkMount = corev1.VolumeMount{
+		Name:             "local-disks",
+		MountPath:        GetLocalDiskLocationPath(),
+		MountPropagation: &hostContainerPropagation,
+	}
+
+	// DevHostDirVolume  is the corev1.Volume definition for the "/dev" bind mount used to
+	// list block devices.
+	// DevMount is the corresponding mount
+	DevHostDirVolume = corev1.Volume{
+		Name: devDirVolName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: devDirPath,
+				Type: &directoryHostPath,
+			},
+		},
+	}
+	// DevMount is the corresponding mount for DevHostDirVolume
+	DevMount = corev1.VolumeMount{
+		Name:             devDirVolName,
+		MountPath:        devDirPath,
+		MountPropagation: &hostContainerPropagation,
+	}
+
+	// ProvisionerConfigHostDirVolume is the corev1.Volume definition for the
+	// local-static-provisioner configmap
+	// ProvisionerConfigMount is the corresponding mount
+	ProvisionerConfigHostDirVolume = corev1.Volume{
+		Name: provisionerConfigVolName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: ProvisionerConfigMapName,
+				},
+			},
+		},
+	}
+
+	// ProvisionerConfigMount is the corresponding mount for ProvisionerConfigHostDirVolume
+	ProvisionerConfigMount = corev1.VolumeMount{
+		Name:      provisionerConfigVolName,
+		ReadOnly:  true,
+		MountPath: "/etc/provisioner/config",
+	}
+
+	// UDevHostDirVolume is the corev1.Volume definition for the
+	// "/run/udev" host bind-mount. This helps lsblk give more accurate output.
+	// UDevMount is the corresponding mount
+	UDevHostDirVolume = corev1.Volume{
+		Name: udevVolName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: udevPath},
+		},
+	}
+	// UDevMount is the corresponding mount for UDevHostDirVolume
+	UDevMount = corev1.VolumeMount{
+		Name:             udevVolName,
+		MountPath:        udevPath,
+		MountPropagation: &hostContainerPropagation,
+	}
+)

--- a/pkg/controller/localvolumediscovery/localvolumediscovery_controller.go
+++ b/pkg/controller/localvolumediscovery/localvolumediscovery_controller.go
@@ -34,8 +34,6 @@ var (
 )
 
 const (
-	udevPath           = "/run/udev"
-	udevVolName        = "run-udev"
 	DiskMakerDiscovery = "diskmaker-discovery"
 )
 
@@ -279,51 +277,16 @@ func (r *ReconcileLocalVolumeDiscovery) getDaemonSetStatus(namespace string) (in
 }
 
 func getVolumesAndMounts() ([]corev1.Volume, []corev1.VolumeMount) {
-	hostContainerPropagation := corev1.MountPropagationHostToContainer
-	volumeMounts := []corev1.VolumeMount{
-		{
-			Name:             "local-disks",
-			MountPath:        common.GetLocalDiskLocationPath(),
-			MountPropagation: &hostContainerPropagation,
-		},
-		{
-			Name:             "device-dir",
-			MountPath:        "/dev",
-			MountPropagation: &hostContainerPropagation,
-		},
-		{
-			Name:             udevVolName,
-			MountPath:        udevPath,
-			MountPropagation: &hostContainerPropagation,
-		},
-	}
-	directoryHostPath := corev1.HostPathDirectory
 	volumes := []corev1.Volume{
-		{
-			Name: "local-disks",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: common.GetLocalDiskLocationPath(),
-				},
-			},
-		},
-		{
-			Name: "device-dir",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/dev",
-					Type: &directoryHostPath,
-				},
-			},
-		},
-		{
-			Name: udevVolName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{Path: udevPath},
-			},
-		},
+		common.SymlinkHostDirVolume,
+		common.DevHostDirVolume,
+		common.UDevHostDirVolume,
 	}
-
+	volumeMounts := []corev1.VolumeMount{
+		common.SymlinkMount,
+		common.DevMount,
+		common.UDevMount,
+	}
 	return volumes, volumeMounts
 }
 

--- a/pkg/controller/nodedaemon/add.go
+++ b/pkg/controller/nodedaemon/add.go
@@ -56,7 +56,7 @@ func AddDaemonReconciler(mgr manager.Manager) error {
 	}
 
 	// watch provisioner configmap
-	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, enqueueOnlyNamespace, common.EnqueueOnlyLabeledSubcomponents(ProvisionerConfigMapName))
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, enqueueOnlyNamespace, common.EnqueueOnlyLabeledSubcomponents(common.ProvisionerConfigMapName))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/nodedaemon/provisioner_config.go
+++ b/pkg/controller/nodedaemon/provisioner_config.go
@@ -27,9 +27,9 @@ func (r *DaemonReconciler) reconcileProvisionerConfigMap(
 ) (*corev1.ConfigMap, controllerutil.OperationResult, error) {
 	// object meta
 	objectMeta := metav1.ObjectMeta{
-		Name:      ProvisionerConfigMapName,
+		Name:      common.ProvisionerConfigMapName,
 		Namespace: request.Namespace,
-		Labels:    map[string]string{"app": ProvisionerConfigMapName},
+		Labels:    map[string]string{"app": common.ProvisionerConfigMapName},
 	}
 	configMap := &corev1.ConfigMap{ObjectMeta: objectMeta}
 

--- a/pkg/controller/nodedaemon/reconcile.go
+++ b/pkg/controller/nodedaemon/reconcile.go
@@ -15,8 +15,6 @@ const (
 	ProvisionerName = "localvolumeset-local-provisioner"
 	// DiskMakerName is the name of the diskmaker-manager daemonset
 	DiskMakerName = "diskmaker-manager"
-	// ProvisionerConfigMapName is the name of the local-static-provisioner configmap
-	ProvisionerConfigMapName = "local-volumeset-provisioner"
 
 	dataHashAnnotationKey = "local.storage.openshift.io/configMapDataHash"
 )

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/openshift/local-storage-operator/pkg/common"
+
 	"github.com/go-logr/logr"
 	localv1alpha1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1alpha1"
-	"github.com/openshift/local-storage-operator/pkg/controller/nodedaemon"
 	"github.com/openshift/local-storage-operator/pkg/diskmaker"
 	"github.com/openshift/local-storage-operator/pkg/internal"
 	corev1 "k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func (r *ReconcileLocalVolumeSet) Reconcile(request reconcile.Request) (reconcil
 
 	// get associated provisioner config
 	cm := &corev1.ConfigMap{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: nodedaemon.ProvisionerConfigMapName, Namespace: request.Namespace}, cm)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: common.ProvisionerConfigMapName, Namespace: request.Namespace}, cm)
 	if err != nil {
 		reqLogger.Error(err, "could not get provisioner configmap")
 		return reconcile.Result{}, err


### PR DESCRIPTION
Mounting `/run/udev` to allow lsblk to detect the FSType of lvm disks as `LVM2_member`

Verification:

```
$ oc debug node/$MY_NODE_NAME  -- chroot /host lsblk -o +FSTYPE
Starting pod/ip-10-0-162-216us-east-2computeinternal-debug ...
To use host binaries, run `chroot /host`
NAME                         MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT FSTYPE
nvme0n1                      259:0    0   120G  0 disk            
|-nvme0n1p1                  259:1    0   384M  0 part /boot      ext4
|-nvme0n1p2                  259:2    0   127M  0 part /boot/efi  vfat
|-nvme0n1p3                  259:3    0     1M  0 part            
`-nvme0n1p4                  259:4    0 119.5G  0 part            crypto_LUKS
  `-coreos-luks-root-nocrypt 253:0    0 119.5G  0 dm   /sysroot   xfs
nvme1n1                      259:5    0    50G  0 disk            LVM2_member
nvme2n1                      259:6    0    10G  0 disk            
nvme3n1                      259:7    0    30G  0 disk            


$ oc logs -f diskmaker-manager-lgvpv|grep -i filesystem|grep nvme1n1
{"level":"info","ts":1601019103.9825587,"logger":"localvolumeset-symlink-controller","msg":"filter negative","Request.Namespace":"default","Request.Name":"block-3","Device.Name":"nvme1n1","filter.Name":"noFilesystemSignature"}
```