### PR TITLE
Bug 1884285: Do not link with -extldflags "-static"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ all build: build-diskmaker build-operator
 .PHONY: all build
 
 build-diskmaker:
-	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -mod=vendor -a -i -ldflags '-X main.version=$(REV) -extldflags "-static"' -o $(TARGET_DIR)/diskmaker $(CURPATH)/cmd/diskmaker
+	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -mod=vendor -a -i -ldflags '-X main.version=$(REV)' -o $(TARGET_DIR)/diskmaker $(CURPATH)/cmd/diskmaker
 
 build-operator:
-	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -mod=vendor -a -i -ldflags '-X main.version=$(REV) -extldflags "-static"' -o $(TARGET_DIR)/local-storage-operator $(CURPATH)/cmd/manager
+	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -mod=vendor -a -i -ldflags '-X main.version=$(REV)' -o $(TARGET_DIR)/local-storage-operator $(CURPATH)/cmd/manager
 
 images: diskmaker-container operator-container must-gather
 


### PR DESCRIPTION
This breaks the build on ppc64le, which depends on the external linker
and therefore behaves differently than other architectures.