### PR TITLE
Add opm resources and fix 4.7 build

### DIFF
--- a/manifests/4.7/image-references
+++ b/manifests/4.7/image-references
@@ -1,0 +1,17 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: local-storage-operator
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-operator:latest
+  - name: local-storage-static-provisioner
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-static-provisioner:latest
+  - name: local-storage-diskmaker
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-diskmaker:latest

--- a/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
@@ -1,0 +1,451 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: local-storage-operator.v4.7.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "local.storage.openshift.io/v1",
+          "kind": "LocalVolume",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "storageClassDevices": [
+              {
+                "devicePaths": [
+                  "/dev/vde",
+                  "/dev/vdf"
+                ],
+                "fsType": "ext4",
+                "storageClassName": "foobar",
+                "volumeMode": "Filesystem"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "local.storage.openshift.io/v1alpha1",
+          "kind": "LocalVolumeSet",
+          "metadata": {
+            "name": "example-localvolumeset"
+          },
+          "spec": {
+            "deviceInclusionSpec": {
+              "deviceMechanicalProperties": [
+                "Rotational",
+                "NonRotational"
+              ],
+              "deviceTypes": [
+                "RawDisk"
+              ],
+              "maxSize": "100G",
+              "minSize": "10G"
+            },
+            "maxDeviceCount": 10,
+            "nodeSelector": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/hostname",
+                      "operator": "In",
+                      "values": [
+                        "worker-0",
+                        "worker-1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "storageClassName": "example-storageclass",
+            "volumeMode": "Block"
+          }
+        },
+        {
+          "apiVersion": "local.storage.openshift.io/v1alpha1",
+          "kind": "LocalVolumeDiscovery",
+          "metadata": {
+            "name": "auto-discover-devices"
+          },
+          "spec": {
+            "nodeSelector": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/hostname",
+                      "operator": "In",
+                      "values": [
+                        "worker-0",
+                        "worker-1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    categories: Storage
+    "operatorframework.io/suggested-namespace": openshift-local-storage
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/origin-local-storage-operator:latest
+    support: Red Hat
+    repository: https://github.com/openshift/local-storage-operator
+    createdAt: "2019-08-14T00:00:00Z"
+    description: >
+      Configure and use local storage volumes in kubernetes and OpenShift.
+      OpenShift 4.2 and above is only supported OpenShift versions.
+    olm.skipRange: ">=4.3.0 <4.7.0"
+  labels:
+    operator-metering: "true"
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
+spec:
+  displayName: Local Storage
+  description: Local Storage Operator
+  keywords:
+    - storage
+    - local storage
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/local-storage-operator/tree/master/docs
+    - name: Source Repository
+      url: https://github.com/openshift/local-storage-operator
+  version: 4.7.0
+  maturity: stable
+  maintainers:
+    - email: aos-storage-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.14.0
+  provider:
+    name: Red Hat
+  labels:
+    alm-owner-metering: local-storage-operator
+    alm-status-descriptors: local-storage-operator.v4.7.0
+  selector:
+    matchLabels:
+      alm-owner-metering: local-storage-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - rules:
+          - apiGroups:
+            - local.storage.openshift.io
+            resources:
+            - "*"
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - services
+            - services/finalizers
+            - endpoints
+            - persistentvolumeclaims
+            - events
+            - configmaps
+            - secrets
+            verbs:
+            - "*"
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            - statefulsets
+            verbs:
+            - "*"
+          - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+          - apiGroups:
+            - apps
+            resourceNames:
+            - local-storage-operator
+            resources:
+            - deployments/finalizers
+            verbs:
+            - update
+          serviceAccountName: local-storage-operator
+        - rules:
+          - apiGroups:
+            - local.storage.openshift.io
+            resources:
+            - "*"
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+          serviceAccountName: local-storage-admin
+      clusterPermissions:
+        - rules:
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - storageclasses
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumeclaims
+            - events
+            verbs:
+              - "*"
+          - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumes
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+          serviceAccountName: local-storage-operator
+        - rules:
+          - apiGroups:
+            - security.openshift.io
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - use
+            resourceNames:
+            - privileged
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - list
+            - get
+            - watch
+          - apiGroups:
+            - ""
+            - storage.k8s.io
+            resources:
+            - configmaps
+            - storageclasses
+            - persistentvolumeclaims
+            - persistentvolumes
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - patch
+            - update
+          serviceAccountName: local-storage-admin
+      deployments:
+        - name: local-storage-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: local-storage-operator
+            template:
+              metadata:
+                labels:
+                  name: local-storage-operator
+              spec:
+                serviceAccountName: local-storage-operator
+                containers:
+                  - name: local-storage-operator
+                    image: quay.io/openshift/origin-local-storage-operator:latest
+                    ports:
+                    - containerPort: 60000
+                      name: metrics
+                    command:
+                    - local-storage-operator
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: "local-storage-operator"
+                      - name: PROVISIONER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-static-provisioner:latest
+                      - name: DISKMAKER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-diskmaker:latest
+  customresourcedefinitions:
+    owned:
+      - displayName: Local Volume
+        group: local.storage.openshift.io
+        kind: LocalVolume
+        name: localvolumes.local.storage.openshift.io
+        description: Manage local storage volumes for OpenShift
+        version: v1
+        specDescriptors:
+          - description: User requested management state of this object
+            displayName: Requested management state
+            path: managementState
+          - description: Log level of local volume diskmaker and provisioner for this object
+            displayName: LogLevel
+            path: logLevel
+          - description: Selected nodes for local storage
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: StorageClass devices configured by this object
+            displayName: StorageClassDevices
+            path: storageClassDevices
+        statusDescriptors:
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Current management state of this object
+            displayName: Operator management state
+            path: managementState
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Set
+        group: local.storage.openshift.io
+        kind: LocalVolumeSet
+        name: localvolumesets.local.storage.openshift.io
+        description: A Local Volume set allows you to filter a set of storage volumes, group them and create a dedicated storage class to consume storage from the set of volumes.
+        version: v1alpha1
+        specDescriptors:
+          - description: Selected nodes for local storage
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: StorageClassName to use for set of matched devices
+            displayName: StorageClassName
+            path: storageClassName
+          - description: VolumeMode determines whether the PV created is Block or Filesystem. By default it will be block
+            displayName:  VolumeMode
+            path: volumeMode
+          - description: FSType type to create when volumeMode is Filesystem
+            displayName: FSType
+            path: fsType
+          - description: List of tolerations to pass to the discovery daemons
+            displayName: Tolerations
+            path: tolerations
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Tolerations
+          - description: Filters for including a device in the device discovery
+            displayName: deviceInclusionSpec
+            path: deviceInclusionSpec
+        statusDescriptors:
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Total devices over which the PVs has been provisioned
+            displayName: TotalProvisionedDeviceCount
+            path: totalProvisionedDeviceCount
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Discovery
+        group: local.storage.openshift.io
+        kind: LocalVolumeDiscovery
+        name: localvolumediscoveries.local.storage.openshift.io
+        description: Discover list of potentially usable disks on the chosen set of nodes
+        version: v1alpha1
+        specDescriptors:
+          - description: Selected nodes for discovery
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: List of tolerations to pass to the discovery daemons
+            displayName: Tolerations
+            path: tolerations
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Tolerations
+        statusDescriptors:
+          - description: Current phase of the discovery
+            displayName: Phase
+            path: phase
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Discovery Result
+        group: local.storage.openshift.io
+        kind: LocalVolumeDiscoveryResult
+        name: localvolumediscoveryresults.local.storage.openshift.io
+        description: Disc inventory of available disks from selected nodes
+        version: v1alpha1
+        specDescriptors:
+          - description: Node on which the devices are discovered
+            displayName: NodeName
+            path: nodeName
+        statusDescriptors:
+          - description: DiscoveredTimeStamp is the last timestamp when the list of discovered devices was updated
+            displayName: DiscoveredTimeStamp
+            path: discoveredTimeStamp
+          - description: DiscoveredDevices contains the list of devices discovered on the node
+            displayName: DiscoveredDevices
+            path: discoveredDevices

--- a/manifests/4.7/local-volume-discoveries.crd.yaml
+++ b/manifests/4.7/local-volume-discoveries.crd.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumediscoveries.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeDiscovery
+    listKind: LocalVolumeDiscoveryList
+    plural: localvolumediscoveries
+    singular: localvolumediscovery
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              # Force "auto-discover-devices" as CR name.
+              enum:
+               - auto-discover-devices
+        spec:
+          description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
+          properties:
+            nodeSelector:
+              description: Nodes on which the automatic detection policies must run.
+              properties:
+                nodeSelectorTerms:
+                  description: Required. A list of node selector terms. The terms
+                    are ORed.
+                  items:
+                    description: A null or empty node selector term matches no objects.
+                      The requirements of them are ANDed. The TopologySelectorTerm
+                      type implements a subset of the NodeSelectorTerm.
+                    properties:
+                      matchExpressions:
+                        description: A list of node selector requirements by node's
+                          labels.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchFields:
+                        description: A list of node selector requirements by node's
+                          fields.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - nodeSelectorTerms
+              type: object
+            tolerations:
+              description: If specified tolerations is the list of toleration that
+                is passed to the LocalVolumeDiscovery Daemon
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
+          properties:
+            conditions:
+              description: Conditions are the list of conditions and their status.
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change the operator
+                has dealt with
+              format: int64
+              type: integer
+            phase:
+              description: Phase represents the current phase of discovery process
+                This is used by the OLM UI to provide status information to the user
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/4.7/local-volume-discovery-results.crd.yaml
+++ b/manifests/4.7/local-volume-discovery-results.crd.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumediscoveryresults.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeDiscoveryResult
+    listKind: LocalVolumeDiscoveryResultList
+    plural: localvolumediscoveryresults
+    singular: localvolumediscoveryresult
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LocalVolumeDiscoveryResultSpec defines the desired state of
+            LocalVolumeDiscoveryResult
+          properties:
+            nodeName:
+              description: Node on which the devices are discovered
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          description: LocalVolumeDiscoveryResultStatus defines the observed state
+            of LocalVolumeDiscoveryResult
+          properties:
+            discoveredDevices:
+              description: DiscoveredDevices contains the list of devices on which
+                LSO is capable of creating LocalPVs The devices in this list qualify
+                these following conditions. - it should be a non-removable device.
+                - it should not be a read-only device. - it should not be mounted
+                anywhere - it should not be a boot device - it should not have child
+                partitions
+              items:
+                description: DiscoveredDevice shows the list of discovered devices
+                  with their properties
+                properties:
+                  deviceID:
+                    description: DeviceID represents the persistent name of the device.
+                      For eg, /dev/disk/by-id/...
+                    type: string
+                  fstype:
+                    description: FSType represents the filesystem available on the
+                      device
+                    type: string
+                  model:
+                    description: Model of the discovered device
+                    type: string
+                  path:
+                    description: Path represents the device path. For eg, /dev/sdb
+                    type: string
+                  property:
+                    description: Property represents whether the device type is rotational
+                      or not
+                    type: string
+                  serial:
+                    description: Serial number of the disk
+                    type: string
+                  size:
+                    description: Size of the discovered device
+                    format: int64
+                    type: integer
+                  status:
+                    description: Status defines whether the device is available for
+                      use or not
+                    properties:
+                      state:
+                        description: State shows the availability of the device
+                        type: string
+                    required:
+                    - state
+                    type: object
+                  type:
+                    description: Type of the discovered device
+                    type: string
+                  vendor:
+                    description: Vendor of the discovered device
+                    type: string
+                required:
+                - deviceID
+                - fstype
+                - model
+                - path
+                - property
+                - serial
+                - size
+                - status
+                - type
+                - vendor
+                type: object
+              type: array
+            discoveredTimeStamp:
+              description: DiscoveredTimeStamp is the last timestamp when the list
+                of discovered devices was updated
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/4.7/local-volume-sets.crd.yaml
+++ b/manifests/4.7/local-volume-sets.crd.yaml
@@ -1,0 +1,272 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumesets.local.storage.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: StorageClass
+    type: string
+  - JSONPath: .status.totalProvisionedDeviceCount
+    description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
+    name: Provisioned
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeSet
+    listKind: LocalVolumeSetList
+    plural: localvolumesets
+    singular: localvolumeset
+    shortNames:
+    - lvset
+    - lvsets
+  scope: Namespaced
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      required:
+          - spec
+      type: object
+      description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
+        criteria.
+      properties:
+        spec:
+          description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
+          properties:
+            deviceInclusionSpec:
+              description: DeviceInclusionSpec is the filtration rule for including
+                a device in the device discovery
+              properties:
+                deviceMechanicalProperties:
+                  description: DeviceMechanicalProperty denotes whether Rotational
+                    or NonRotational disks should be used. by default, it selects
+                    both
+                  items:
+                    description: DeviceMechanicalProperty holds the device's mechanical
+                      spec. It can be rotational or nonRotational
+                    type: string
+                  type: array
+                deviceTypes:
+                  description: 'Devices is the list of devices that should be used
+                    for automatic detection. This would be one of the types supported
+                    by the local-storage operator. Currently, the supported types
+                    are: disk, part. If the list is empty no devices will be selected.'
+                  items:
+                    description: DeviceType is the types that will be supported by
+                      the LSO.
+                    type: string
+                    enum:
+                      - disk
+                      - part
+                  type: array
+                maxSize:
+                  description: MaxSize is the maximum size of the device which needs
+                    to be included
+                  type: string
+                minSize:
+                  description: MinSize is the minimum size of the device which needs
+                    to be included
+                  type: string
+                models:
+                  description: Models is a list of device models. If not empty, the
+                    device's model as outputted by lsblk needs to contain at least
+                    one of these strings.
+                  items:
+                    type: string
+                  type: array
+                vendors:
+                  description: Vendors is a list of device vendors. If not empty,
+                    the device's model as outputted by lsblk needs to contain at least
+                    one of these strings.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            maxDeviceCount:
+              description: Maximum number of Devices that needs to be detected per
+                node. If omitted, there will be no maximum.
+              format: int32
+              type: integer
+            fsType:
+              description: FSType type to create when volumeMode is Filesystem
+              type: string
+            nodeSelector:
+              description: Nodes on which the automatic detection policies must run.
+              properties:
+                nodeSelectorTerms:
+                  description: Required. A list of node selector terms. The terms
+                    are ORed.
+                  items:
+                    description: A null or empty node selector term matches no objects.
+                      The requirements of them are ANDed. The TopologySelectorTerm
+                      type implements a subset of the NodeSelectorTerm.
+                    properties:
+                      matchExpressions:
+                        description: A list of node selector requirements by node's
+                          labels.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchFields:
+                        description: A list of node selector requirements by node's
+                          fields.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - nodeSelectorTerms
+              type: object
+            storageClassName:
+              description: StorageClassName to use for set of matched devices
+              type: string
+            tolerations:
+              description: If specified, a list of tolerations to pass to the discovery
+                daemons.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            volumeMode:
+              description: VolumeMode determines whether the PV created is Block or
+                Filesystem. It will default to Filesystem
+              type: string
+              enum:
+                - Block
+                - Filesystem
+          required:
+          - storageClassName
+          type: object
+        status:
+          description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
+          properties:
+            conditions:
+              description: Conditions is a list of conditions and their status.
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change the operator
+                has dealt with
+              format: int64
+              type: integer
+            totalProvisionedDeviceCount:
+              description: TotalProvisionedDeviceCount is the count of the total devices
+                over which the PVs has been provisioned
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/4.7/local-volumes.crd.yaml
+++ b/manifests/4.7/local-volumes.crd.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumes.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolume
+    listKind: LocalVolumeList
+    plural: localvolumes
+    singular: localvolume
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: LocalVolume is a local storage configuration used by the operator
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'spec is the specification of the desired state of selected local devices'
+          properties:
+            nodeSelector:
+              description: Nodes on which the provisioner must run
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            managementState:
+              description: Indicates whether and how the operator should manage the component
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            logLevel:
+              description: logLevel configures log level for the diskmaker and provisioner for this object
+              type: string
+              enum: ["Normal", "Debug", "Trace", "TraceAll"]
+            storageClassDevices:
+              description: List of storage class and devices they can match
+              items:
+                properties:
+                  storageClassName:
+                    description: StorageClass name to use for set of matched devices
+                    type: string
+                  volumeMode:
+                    description: Volume mode. Block or Filesystem
+                    enum:
+                      - Block
+                      - Filesystem
+                    type: string
+                  fsType:
+                    description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
+                    type: string
+                  devicePaths:
+                    description: 'A list of devices which would be chosen for local storage.
+                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - storageClassName
+                  - devicePaths
+                type: object
+              type: array
+            tolerations:
+              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+              items:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              type: array
+          required:
+            - storageClassDevices
+          type: object
+        status:
+          description: 'status is the most recently observed status selected local devices'
+          properties:
+            generations:
+              description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
+              items:
+                description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
+                properties:
+                  group:
+                    type: string
+                  resource:
+                    type: string
+                  lastGeneration:
+                    format: int64
+                    type: integer
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - resource
+                - namespace
+                - name
+                - lastGeneration
+                type: object
+              type: array
+            conditions:
+              description: 'conditions is a list of conditions and their status'
+              type: array
+              items:
+                description: 'OperatorCondition is just the standard condition fields'
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                    enum: ["True", "False", "Unknown"]
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  reason:
+                    type: string
+                  message:
+                    type: string
+                required:
+                - type
+                - status
+            observedGeneration:
+              format: int64
+              type: integer
+            managementState:
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            readyReplicas:
+              type: integer
+              format: int32
+          type: object
+          required:
+          - conditions
+          - generations
+      required:
+        - spec

--- a/manifests/local-storage-operator.package.yaml
+++ b/manifests/local-storage-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: local-storage-operator
 channels:
-- name: "4.6"
-  currentCSV: local-storage-operator.v4.6.0
+- name: "4.7"
+  currentCSV: local-storage-operator.v4.7.0

--- a/opm-bundle/bundle.Dockerfile
+++ b/opm-bundle/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=local-storage-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=preview
+LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
+
+COPY manifests /manifests/
+COPY metadata/annotations.yaml /metadata/annotations.yaml

--- a/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
+++ b/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
@@ -1,0 +1,451 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: local-storage-operator.v4.6.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "local.storage.openshift.io/v1",
+          "kind": "LocalVolume",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "storageClassDevices": [
+              {
+                "devicePaths": [
+                  "/dev/vde",
+                  "/dev/vdf"
+                ],
+                "fsType": "ext4",
+                "storageClassName": "foobar",
+                "volumeMode": "Filesystem"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "local.storage.openshift.io/v1alpha1",
+          "kind": "LocalVolumeSet",
+          "metadata": {
+            "name": "example-localvolumeset"
+          },
+          "spec": {
+            "deviceInclusionSpec": {
+              "deviceMechanicalProperties": [
+                "Rotational",
+                "NonRotational"
+              ],
+              "deviceTypes": [
+                "RawDisk"
+              ],
+              "maxSize": "100G",
+              "minSize": "10G"
+            },
+            "maxDeviceCount": 10,
+            "nodeSelector": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/hostname",
+                      "operator": "In",
+                      "values": [
+                        "worker-0",
+                        "worker-1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "storageClassName": "example-storageclass",
+            "volumeMode": "Block"
+          }
+        },
+        {
+          "apiVersion": "local.storage.openshift.io/v1alpha1",
+          "kind": "LocalVolumeDiscovery",
+          "metadata": {
+            "name": "auto-discover-devices"
+          },
+          "spec": {
+            "nodeSelector": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/hostname",
+                      "operator": "In",
+                      "values": [
+                        "worker-0",
+                        "worker-1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    categories: Storage
+    "operatorframework.io/suggested-namespace": openshift-local-storage
+    capabilities: Full Lifecycle
+    containerImage: quay.io/openshift/origin-local-storage-operator:latest
+    support: Red Hat
+    repository: https://github.com/openshift/local-storage-operator
+    createdAt: "2019-08-14T00:00:00Z"
+    description: >
+      Configure and use local storage volumes in kubernetes and OpenShift.
+      OpenShift 4.2 and above is only supported OpenShift versions.
+    olm.skipRange: ">=4.3.0 <4.6.0"
+  labels:
+    operator-metering: "true"
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
+spec:
+  displayName: Local Storage
+  description: Local Storage Operator
+  keywords:
+    - storage
+    - local storage
+  links:
+    - name: Documentation
+      url: https://github.com/openshift/local-storage-operator/tree/master/docs
+    - name: Source Repository
+      url: https://github.com/openshift/local-storage-operator
+  version: 4.6.0
+  maturity: stable
+  maintainers:
+    - email: aos-storage-staff@redhat.com
+      name: Red Hat
+  minKubeVersion: 1.14.0
+  provider:
+    name: Red Hat
+  labels:
+    alm-owner-metering: local-storage-operator
+    alm-status-descriptors: local-storage-operator.v4.6.0
+  selector:
+    matchLabels:
+      alm-owner-metering: local-storage-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: false
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - rules:
+          - apiGroups:
+            - local.storage.openshift.io
+            resources:
+            - "*"
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - services
+            - services/finalizers
+            - endpoints
+            - persistentvolumeclaims
+            - events
+            - configmaps
+            - secrets
+            verbs:
+            - "*"
+          - apiGroups:
+            - apps
+            resources:
+            - deployments
+            - daemonsets
+            - replicasets
+            - statefulsets
+            verbs:
+            - "*"
+          - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+          - apiGroups:
+            - apps
+            resourceNames:
+            - local-storage-operator
+            resources:
+            - deployments/finalizers
+            verbs:
+            - update
+          serviceAccountName: local-storage-operator
+        - rules:
+          - apiGroups:
+            - local.storage.openshift.io
+            resources:
+            - "*"
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - update
+          serviceAccountName: local-storage-admin
+      clusterPermissions:
+        - rules:
+          - apiGroups:
+            - storage.k8s.io
+            resources:
+            - storageclasses
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumeclaims
+            - events
+            verbs:
+              - "*"
+          - apiGroups:
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - persistentvolumes
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - delete
+          serviceAccountName: local-storage-operator
+        - rules:
+          - apiGroups:
+            - security.openshift.io
+            resources:
+            - securitycontextconstraints
+            verbs:
+            - use
+            resourceNames:
+            - privileged
+          - apiGroups:
+            - ""
+            resources:
+            - nodes
+            verbs:
+            - list
+            - get
+            - watch
+          - apiGroups:
+            - ""
+            - storage.k8s.io
+            resources:
+            - configmaps
+            - storageclasses
+            - persistentvolumeclaims
+            - persistentvolumes
+            verbs:
+            - "*"
+          - apiGroups:
+            - ""
+            - events.k8s.io
+            resources:
+            - events
+            verbs:
+            - get
+            - list
+            - watch
+            - create
+            - patch
+            - update
+          serviceAccountName: local-storage-admin
+      deployments:
+        - name: local-storage-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: local-storage-operator
+            template:
+              metadata:
+                labels:
+                  name: local-storage-operator
+              spec:
+                serviceAccountName: local-storage-operator
+                containers:
+                  - name: local-storage-operator
+                    image: quay.io/openshift/origin-local-storage-operator:latest
+                    ports:
+                    - containerPort: 60000
+                      name: metrics
+                    command:
+                    - local-storage-operator
+                    imagePullPolicy: Always
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: "local-storage-operator"
+                      - name: PROVISIONER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-static-provisioner:latest
+                      - name: DISKMAKER_IMAGE
+                        value: quay.io/openshift/origin-local-storage-diskmaker:latest
+  customresourcedefinitions:
+    owned:
+      - displayName: Local Volume
+        group: local.storage.openshift.io
+        kind: LocalVolume
+        name: localvolumes.local.storage.openshift.io
+        description: Manage local storage volumes for OpenShift
+        version: v1
+        specDescriptors:
+          - description: User requested management state of this object
+            displayName: Requested management state
+            path: managementState
+          - description: Log level of local volume diskmaker and provisioner for this object
+            displayName: LogLevel
+            path: logLevel
+          - description: Selected nodes for local storage
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: StorageClass devices configured by this object
+            displayName: StorageClassDevices
+            path: storageClassDevices
+        statusDescriptors:
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Current management state of this object
+            displayName: Operator management state
+            path: managementState
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Set
+        group: local.storage.openshift.io
+        kind: LocalVolumeSet
+        name: localvolumesets.local.storage.openshift.io
+        description: A Local Volume set allows you to filter a set of storage volumes, group them and create a dedicated storage class to consume storage from the set of volumes.
+        version: v1alpha1
+        specDescriptors:
+          - description: Selected nodes for local storage
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: StorageClassName to use for set of matched devices
+            displayName: StorageClassName
+            path: storageClassName
+          - description: VolumeMode determines whether the PV created is Block or Filesystem. By default it will be block
+            displayName:  VolumeMode
+            path: volumeMode
+          - description: FSType type to create when volumeMode is Filesystem
+            displayName: FSType
+            path: fsType
+          - description: List of tolerations to pass to the discovery daemons
+            displayName: Tolerations
+            path: tolerations
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Tolerations
+          - description: Filters for including a device in the device discovery
+            displayName: deviceInclusionSpec
+            path: deviceInclusionSpec
+        statusDescriptors:
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Total devices over which the PVs has been provisioned
+            displayName: TotalProvisionedDeviceCount
+            path: totalProvisionedDeviceCount
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Discovery
+        group: local.storage.openshift.io
+        kind: LocalVolumeDiscovery
+        name: localvolumediscoveries.local.storage.openshift.io
+        description: Discover list of potentially usable disks on the chosen set of nodes
+        version: v1alpha1
+        specDescriptors:
+          - description: Selected nodes for discovery
+            displayName: NodeSelector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector'
+          - description: List of tolerations to pass to the discovery daemons
+            displayName: Tolerations
+            path: tolerations
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Tolerations
+        statusDescriptors:
+          - description: Current phase of the discovery
+            displayName: Phase
+            path: phase
+          - description: Last generation of this object
+            displayName: ObservedGeneration
+            path: observedGeneration
+          - description: Last known condition of this object
+            displayName: Conditions
+            path: conditions
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - displayName: Local Volume Discovery Result
+        group: local.storage.openshift.io
+        kind: LocalVolumeDiscoveryResult
+        name: localvolumediscoveryresults.local.storage.openshift.io
+        description: Disc inventory of available disks from selected nodes
+        version: v1alpha1
+        specDescriptors:
+          - description: Node on which the devices are discovered
+            displayName: NodeName
+            path: nodeName
+        statusDescriptors:
+          - description: DiscoveredTimeStamp is the last timestamp when the list of discovered devices was updated
+            displayName: DiscoveredTimeStamp
+            path: discoveredTimeStamp
+          - description: DiscoveredDevices contains the list of devices discovered on the node
+            displayName: DiscoveredDevices
+            path: discoveredDevices

--- a/opm-bundle/manifests/local-volume-discoveries.crd.yaml
+++ b/opm-bundle/manifests/local-volume-discoveries.crd.yaml
@@ -1,0 +1,202 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumediscoveries.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeDiscovery
+    listKind: LocalVolumeDiscoveryList
+    plural: localvolumediscoveries
+    singular: localvolumediscovery
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              # Force "auto-discover-devices" as CR name.
+              enum:
+               - auto-discover-devices
+        spec:
+          description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
+          properties:
+            nodeSelector:
+              description: Nodes on which the automatic detection policies must run.
+              properties:
+                nodeSelectorTerms:
+                  description: Required. A list of node selector terms. The terms
+                    are ORed.
+                  items:
+                    description: A null or empty node selector term matches no objects.
+                      The requirements of them are ANDed. The TopologySelectorTerm
+                      type implements a subset of the NodeSelectorTerm.
+                    properties:
+                      matchExpressions:
+                        description: A list of node selector requirements by node's
+                          labels.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchFields:
+                        description: A list of node selector requirements by node's
+                          fields.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - nodeSelectorTerms
+              type: object
+            tolerations:
+              description: If specified tolerations is the list of toleration that
+                is passed to the LocalVolumeDiscovery Daemon
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
+          properties:
+            conditions:
+              description: Conditions are the list of conditions and their status.
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change the operator
+                has dealt with
+              format: int64
+              type: integer
+            phase:
+              description: Phase represents the current phase of discovery process
+                This is used by the OLM UI to provide status information to the user
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/opm-bundle/manifests/local-volume-discovery-results.crd.yaml
+++ b/opm-bundle/manifests/local-volume-discovery-results.crd.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumediscoveryresults.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeDiscoveryResult
+    listKind: LocalVolumeDiscoveryResultList
+    plural: localvolumediscoveryresults
+    singular: localvolumediscoveryresult
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: LocalVolumeDiscoveryResultSpec defines the desired state of
+            LocalVolumeDiscoveryResult
+          properties:
+            nodeName:
+              description: Node on which the devices are discovered
+              type: string
+          required:
+          - nodeName
+          type: object
+        status:
+          description: LocalVolumeDiscoveryResultStatus defines the observed state
+            of LocalVolumeDiscoveryResult
+          properties:
+            discoveredDevices:
+              description: DiscoveredDevices contains the list of devices on which
+                LSO is capable of creating LocalPVs The devices in this list qualify
+                these following conditions. - it should be a non-removable device.
+                - it should not be a read-only device. - it should not be mounted
+                anywhere - it should not be a boot device - it should not have child
+                partitions
+              items:
+                description: DiscoveredDevice shows the list of discovered devices
+                  with their properties
+                properties:
+                  deviceID:
+                    description: DeviceID represents the persistent name of the device.
+                      For eg, /dev/disk/by-id/...
+                    type: string
+                  fstype:
+                    description: FSType represents the filesystem available on the
+                      device
+                    type: string
+                  model:
+                    description: Model of the discovered device
+                    type: string
+                  path:
+                    description: Path represents the device path. For eg, /dev/sdb
+                    type: string
+                  property:
+                    description: Property represents whether the device type is rotational
+                      or not
+                    type: string
+                  serial:
+                    description: Serial number of the disk
+                    type: string
+                  size:
+                    description: Size of the discovered device
+                    format: int64
+                    type: integer
+                  status:
+                    description: Status defines whether the device is available for
+                      use or not
+                    properties:
+                      state:
+                        description: State shows the availability of the device
+                        type: string
+                    required:
+                    - state
+                    type: object
+                  type:
+                    description: Type of the discovered device
+                    type: string
+                  vendor:
+                    description: Vendor of the discovered device
+                    type: string
+                required:
+                - deviceID
+                - fstype
+                - model
+                - path
+                - property
+                - serial
+                - size
+                - status
+                - type
+                - vendor
+                type: object
+              type: array
+            discoveredTimeStamp:
+              description: DiscoveredTimeStamp is the last timestamp when the list
+                of discovered devices was updated
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/opm-bundle/manifests/local-volume-sets.crd.yaml
+++ b/opm-bundle/manifests/local-volume-sets.crd.yaml
@@ -1,0 +1,272 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumesets.local.storage.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: StorageClass
+    type: string
+  - JSONPath: .status.totalProvisionedDeviceCount
+    description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
+    name: Provisioned
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolumeSet
+    listKind: LocalVolumeSetList
+    plural: localvolumesets
+    singular: localvolumeset
+    shortNames:
+    - lvset
+    - lvsets
+  scope: Namespaced
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      required:
+          - spec
+      type: object
+      description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
+        criteria.
+      properties:
+        spec:
+          description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
+          properties:
+            deviceInclusionSpec:
+              description: DeviceInclusionSpec is the filtration rule for including
+                a device in the device discovery
+              properties:
+                deviceMechanicalProperties:
+                  description: DeviceMechanicalProperty denotes whether Rotational
+                    or NonRotational disks should be used. by default, it selects
+                    both
+                  items:
+                    description: DeviceMechanicalProperty holds the device's mechanical
+                      spec. It can be rotational or nonRotational
+                    type: string
+                  type: array
+                deviceTypes:
+                  description: 'Devices is the list of devices that should be used
+                    for automatic detection. This would be one of the types supported
+                    by the local-storage operator. Currently, the supported types
+                    are: disk, part. If the list is empty no devices will be selected.'
+                  items:
+                    description: DeviceType is the types that will be supported by
+                      the LSO.
+                    type: string
+                    enum:
+                      - disk
+                      - part
+                  type: array
+                maxSize:
+                  description: MaxSize is the maximum size of the device which needs
+                    to be included
+                  type: string
+                minSize:
+                  description: MinSize is the minimum size of the device which needs
+                    to be included
+                  type: string
+                models:
+                  description: Models is a list of device models. If not empty, the
+                    device's model as outputted by lsblk needs to contain at least
+                    one of these strings.
+                  items:
+                    type: string
+                  type: array
+                vendors:
+                  description: Vendors is a list of device vendors. If not empty,
+                    the device's model as outputted by lsblk needs to contain at least
+                    one of these strings.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            maxDeviceCount:
+              description: Maximum number of Devices that needs to be detected per
+                node. If omitted, there will be no maximum.
+              format: int32
+              type: integer
+            fsType:
+              description: FSType type to create when volumeMode is Filesystem
+              type: string
+            nodeSelector:
+              description: Nodes on which the automatic detection policies must run.
+              properties:
+                nodeSelectorTerms:
+                  description: Required. A list of node selector terms. The terms
+                    are ORed.
+                  items:
+                    description: A null or empty node selector term matches no objects.
+                      The requirements of them are ANDed. The TopologySelectorTerm
+                      type implements a subset of the NodeSelectorTerm.
+                    properties:
+                      matchExpressions:
+                        description: A list of node selector requirements by node's
+                          labels.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchFields:
+                        description: A list of node selector requirements by node's
+                          fields.
+                        items:
+                          description: A node selector requirement is a selector that
+                            contains values, a key, and an operator that relates the
+                            key and values.
+                          properties:
+                            key:
+                              description: The label key that the selector applies
+                                to.
+                              type: string
+                            operator:
+                              description: Represents a key's relationship to a set
+                                of values. Valid operators are In, NotIn, Exists,
+                                DoesNotExist. Gt, and Lt.
+                              type: string
+                            values:
+                              description: An array of string values. If the operator
+                                is In or NotIn, the values array must be non-empty.
+                                If the operator is Exists or DoesNotExist, the values
+                                array must be empty. If the operator is Gt or Lt,
+                                the values array must have a single element, which
+                                will be interpreted as an integer. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              required:
+              - nodeSelectorTerms
+              type: object
+            storageClassName:
+              description: StorageClassName to use for set of matched devices
+              type: string
+            tolerations:
+              description: If specified, a list of tolerations to pass to the discovery
+                daemons.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+            volumeMode:
+              description: VolumeMode determines whether the PV created is Block or
+                Filesystem. It will default to Filesystem
+              type: string
+              enum:
+                - Block
+                - Filesystem
+          required:
+          - storageClassName
+          type: object
+        status:
+          description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
+          properties:
+            conditions:
+              description: Conditions is a list of conditions and their status.
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+            observedGeneration:
+              description: observedGeneration is the last generation change the operator
+                has dealt with
+              format: int64
+              type: integer
+            totalProvisionedDeviceCount:
+              description: TotalProvisionedDeviceCount is the count of the total devices
+                over which the PVs has been provisioned
+              format: int32
+              type: integer
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/opm-bundle/manifests/local-volumes.crd.yaml
+++ b/opm-bundle/manifests/local-volumes.crd.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: localvolumes.local.storage.openshift.io
+spec:
+  group: local.storage.openshift.io
+  names:
+    kind: LocalVolume
+    listKind: LocalVolumeList
+    plural: localvolumes
+    singular: localvolume
+  scope: Namespaced
+  version: v1
+  preserveUnknownFields: false
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: LocalVolume is a local storage configuration used by the operator
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: 'spec is the specification of the desired state of selected local devices'
+          properties:
+            nodeSelector:
+              description: Nodes on which the provisioner must run
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            managementState:
+              description: Indicates whether and how the operator should manage the component
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            logLevel:
+              description: logLevel configures log level for the diskmaker and provisioner for this object
+              type: string
+              enum: ["Normal", "Debug", "Trace", "TraceAll"]
+            storageClassDevices:
+              description: List of storage class and devices they can match
+              items:
+                properties:
+                  storageClassName:
+                    description: StorageClass name to use for set of matched devices
+                    type: string
+                  volumeMode:
+                    description: Volume mode. Block or Filesystem
+                    enum:
+                      - Block
+                      - Filesystem
+                    type: string
+                  fsType:
+                    description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
+                    type: string
+                  devicePaths:
+                    description: 'A list of devices which would be chosen for local storage.
+                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - storageClassName
+                  - devicePaths
+                type: object
+              type: array
+            tolerations:
+              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+              items:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              type: array
+          required:
+            - storageClassDevices
+          type: object
+        status:
+          description: 'status is the most recently observed status selected local devices'
+          properties:
+            generations:
+              description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
+              items:
+                description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
+                properties:
+                  group:
+                    type: string
+                  resource:
+                    type: string
+                  lastGeneration:
+                    format: int64
+                    type: integer
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - resource
+                - namespace
+                - name
+                - lastGeneration
+                type: object
+              type: array
+            conditions:
+              description: 'conditions is a list of conditions and their status'
+              type: array
+              items:
+                description: 'OperatorCondition is just the standard condition fields'
+                type: object
+                properties:
+                  type:
+                    type: string
+                  status:
+                    type: string
+                    enum: ["True", "False", "Unknown"]
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  reason:
+                    type: string
+                  message:
+                    type: string
+                required:
+                - type
+                - status
+            observedGeneration:
+              format: int64
+              type: integer
+            managementState:
+              type: string
+              enum: ["Managed", "Unmanaged", "Removed", "Force"]
+            readyReplicas:
+              type: integer
+              format: int32
+          type: object
+          required:
+          - conditions
+          - generations
+      required:
+        - spec

--- a/opm-bundle/metadata/annotations.yaml
+++ b/opm-bundle/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: preview
+  operators.operatorframework.io.bundle.channels.v1: preview
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: local-storage-operator


### PR DESCRIPTION
This PR adds resources for using operator-registry to build index images using new format.

It also fixes build failures for 4.7

