### PR TITLE
Add BZ subcomponent to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,4 @@ approvers:
   - bertinatto
   - huffmanca
 component: "Storage"
+subcomponent: "Local Storage Operator"


### PR DESCRIPTION
Subcomponent is a mandatory field in Bugzilla, make sure whoever parses OWNERS can actually file a bug.