### PR TITLE
Bug 1887046: Remove unnecessary events

### DIFF
--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -279,14 +279,6 @@ func symLinkDisk(obj runtime.Object, eventReporter *eventReporter, devLogger log
 	}
 	defer unlockFunc()
 	if len(existingSymlinks) > 0 { // already claimed
-		eventReporter.Report(
-			obj,
-			newDiskEvent(
-				diskmaker.DeviceSymlinkExists,
-				"this device is already matched by another LocalVolume or LocalVolumeSet",
-				dev.KName, corev1.EventTypeNormal,
-			),
-		)
 		return nil
 	} else if err != nil || !pvLocked { // locking failed for some other reasion
 		devLogger.Error(err, "not symlinking, could not get lock")

--- a/pkg/diskmaker/diskmaker.go
+++ b/pkg/diskmaker/diskmaker.go
@@ -210,8 +210,6 @@ func (d *DiskMaker) symLinkDisks(diskConfig *DiskConfig) {
 			}
 			defer unlockFunc()
 			if len(existingSymlinks) > 0 { // already claimed, fail silently
-				e := NewEvent(DeviceSymlinkExists, "this device is already matched by another LocalVolume or LocalVolumeSet", symLinkPath)
-				d.eventSync.Report(e, d.localVolume)
 				unlockFunc()
 				continue
 			} else if err != nil || !pvLocked { // locking failed for some other reasion


### PR DESCRIPTION
QE claimed these events may cause confusion if there is only one LocalVolume or LocalVolumeSet.

https://bugzilla.redhat.com/show_bug.cgi?id=1887046