### PR TITLE
Bug 1887750: Bug 1887751: Don't preserve unknown fields in CRs

### DIFF
--- a/manifests/4.6/local-volume-discoveries.crd.yaml
+++ b/manifests/4.6/local-volume-discoveries.crd.yaml
@@ -13,8 +13,12 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
+      required:
+          - spec
       description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
         API
       properties:

--- a/manifests/4.6/local-volume-discovery-results.crd.yaml
+++ b/manifests/4.6/local-volume-discovery-results.crd.yaml
@@ -13,8 +13,10 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  preserveUnknownFields: false
   validation:
     openAPIV3Schema:
+      type: object
       description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
         API
       properties:


### PR DESCRIPTION
1. They can be potentialy dangerous - an unknown field in an old version
may have a value that won't be valid once the field is introduced.
2. It makes the schema "structural schema" that's understood by `kubectl
explain`.

Also, make `LocalVolumeDiscovery.Spec` mandatory and set `type: object`.
Neither of them have any special effect on `oc explain`, but keep the
objects nice and tidy.