### PR TITLE
Bug 1886973: Hide the LocalVolumeDiscoveryResult CRD from the UI

### DIFF
--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -102,6 +102,7 @@ metadata:
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.6.0"
+    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]' 
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
@@ -102,6 +102,7 @@ metadata:
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.7.0"
+    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]' 
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
+++ b/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
@@ -102,6 +102,7 @@ metadata:
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.6.0"
+    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
Adds the LocalVolumeDiscoveryResult CRD to the list of internal objects, preventing it from being displayed in the UI.