### PR TITLE
use /disk/by-id name as symlink name in LocalVolume

### DIFF
--- a/pkg/diskmaker/diskmaker.go
+++ b/pkg/diskmaker/diskmaker.go
@@ -124,10 +124,22 @@ func (d *DiskMaker) Run(stop <-chan struct{}) {
 	}
 }
 
-func (d *DiskMaker) createSymLink(deviceNameLocation DiskLocation, symLinkPath string, symLinkDirPath string, baseDeviceName string) {
+func (d *DiskMaker) createSymLink(deviceNameLocation DiskLocation, symLinkDirPath string) {
+
+	var symLinkSource, symLinkTarget string
+	var isSymLinkedByDeviceName bool
+	if deviceNameLocation.diskID != "" {
+		symLinkSource = deviceNameLocation.diskID
+		symLinkTarget = getSymlinkTarget(deviceNameLocation.diskID, symLinkDirPath)
+	} else {
+		symLinkSource = deviceNameLocation.diskNamePath
+		symLinkTarget = getSymlinkTarget(deviceNameLocation.diskNamePath, symLinkDirPath)
+		isSymLinkedByDeviceName = true
+	}
+
 	// get PV creation lock which checks for existing symlinks to this device
 	pvLock, pvLocked, existingSymlinks, err := internal.GetPVCreationLock(
-		deviceNameLocation.diskNamePath,
+		symLinkSource,
 		d.symlinkLocation,
 	)
 
@@ -150,37 +162,37 @@ func (d *DiskMaker) createSymLink(deviceNameLocation DiskLocation, symLinkPath s
 	err = os.MkdirAll(symLinkDirPath, 0755)
 	if err != nil {
 		msg := fmt.Sprintf("error creating symlink dir %s: %v", symLinkDirPath, err)
-		e := NewEvent(ErrorFindingMatchingDisk, msg, symLinkPath)
+		e := NewEvent(ErrorFindingMatchingDisk, msg, symLinkTarget)
 		d.eventSync.Report(e, d.localVolume)
 		klog.Errorf(msg)
 		return
 	}
 
-	if fileExists(symLinkPath) {
-		klog.V(4).Infof("symlink %s already exists", symLinkPath)
+	if fileExists(symLinkTarget) {
+		klog.V(4).Infof("symlink %s already exists", symLinkTarget)
 		return
 	}
 
-	var symLinkErr error
-	if deviceNameLocation.diskID != "" {
-		klog.V(3).Infof("symlinking to %s to %s", deviceNameLocation.diskID, symLinkPath)
-		symLinkErr = os.Symlink(deviceNameLocation.diskID, symLinkPath)
-	} else {
-		klog.V(3).Infof("symlinking to %s to %s", deviceNameLocation.diskNamePath, symLinkPath)
-		symLinkErr = os.Symlink(deviceNameLocation.diskNamePath, symLinkPath)
-	}
-	if symLinkErr != nil {
-		msg := fmt.Sprintf("error creating symlink %s: %v", symLinkPath, symLinkErr)
-		e := NewEvent(ErrorFindingMatchingDisk, msg, deviceNameLocation.diskNamePath)
+	err = os.Symlink(symLinkSource, symLinkTarget)
+	if err != nil {
+		msg := fmt.Sprintf("error creating symlink %s: %v", symLinkTarget, err)
+		e := NewEvent(ErrorFindingMatchingDisk, msg, symLinkSource)
 		d.eventSync.Report(e, d.localVolume)
 		klog.Errorf(msg)
 		return
 	}
 
-	successMsg := fmt.Sprintf("found matching disk %s", baseDeviceName)
+	if isSymLinkedByDeviceName {
+		msg := fmt.Sprintf("created symlink on device name %s with no disk/by-id. device name might not persist on reboot", symLinkSource)
+		e := NewEvent(SymLinkedOnDeviceName, msg, symLinkSource)
+		d.eventSync.Report(e, d.localVolume)
+		klog.Warningf(msg)
+		return
+	}
+
+	successMsg := fmt.Sprintf("found matching disk %s with id %s", deviceNameLocation.diskNamePath, deviceNameLocation.diskID)
 	e := NewSuccessEvent(FoundMatchingDisk, successMsg, deviceNameLocation.diskNamePath)
 	d.eventSync.Report(e, d.localVolume)
-
 }
 
 func (d *DiskMaker) symLinkDisks(diskConfig *DiskConfig) {
@@ -251,12 +263,8 @@ func (d *DiskMaker) symLinkDisks(diskConfig *DiskConfig) {
 
 	for storageClass, deviceArray := range deviceMap {
 		for _, deviceNameLocation := range deviceArray {
-
 			symLinkDirPath := path.Join(d.symlinkLocation, storageClass)
-			baseDeviceName := filepath.Base(deviceNameLocation.diskNamePath)
-			symLinkPath := path.Join(symLinkDirPath, baseDeviceName)
-
-			d.createSymLink(deviceNameLocation, symLinkPath, symLinkDirPath, baseDeviceName)
+			d.createSymLink(deviceNameLocation, symLinkDirPath)
 		}
 	}
 
@@ -388,4 +396,9 @@ func fileExists(filename string) bool {
 		return false
 	}
 	return true
+}
+
+func getSymlinkTarget(device, symLinkDirPath string) string {
+	baseDeviceName := filepath.Base(device)
+	return path.Join(symLinkDirPath, baseDeviceName)
 }

--- a/pkg/diskmaker/event_reporter.go
+++ b/pkg/diskmaker/event_reporter.go
@@ -16,6 +16,7 @@ const (
 	ErrorListingDeviceID     = "ErrorListingDeviceID"
 	ErrorFindingMatchingDisk = "ErrorFindingMatchingDisk"
 	ErrorCreatingSymLink     = "ErrorCreatingSymLink"
+	SymLinkedOnDeviceName    = "SymlinkedOnDeivceName"
 
 	FoundMatchingDisk   = "FoundMatchingDisk"
 	DeviceSymlinkExists = "DeviceSymlinkExists"


### PR DESCRIPTION
If the device provided in the `devicePaths` list in the localVolume CR has `/dev/disk/by-id`, then use the `id` name to create symlink in `/mnt/local-storage/<storageClassName>` directory. 

for example: `/mnt/local-storage/belowsixty/ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93`

Test:

1. /dev/sdb and /dev/sdc had /disk/by-id. So symlinks created by id
   /dev/sdd had no id. So Symlink got created by disk name

```
/mnt/local-storage/belowsixty
$ ls
ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93  ata-VBOX_HARDDISK_____VBddf003e5-4cfb17c1  sdd
```


2. Triggering warning events when device has no id
```
$ kubectl get event | grep  localvolume/example
16s         Normal    FoundMatchingDisk         localvolume/example                           minikube - found matching disk /dev/sdc with id /dev/disk/by-id/ata-VBOX_HARDDISK_____VB09c666fa-a3385f88
16s         Warning   SymlinkedOnDeivceName     localvolume/example                           minikube - created symlink on device name /dev/sdd with no disk/by-id. device name might not persist on reboot
16s         Normal    FoundMatchingDisk         localvolume/example                           minikube - found matching disk /dev/sdb with id /dev/disk/by-id/ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93
```

Signed-off-by: Santosh Pillai <sapillai@redhat.com>