### PR TITLE
Bug 1904577: Hide the LocalVolumeDiscoveryResult CRD from the UI

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -28,14 +28,14 @@ cat ${repo_dir}/deploy/localvolumediscoveryresult_crd.yaml >> ${global_manifest}
 
 sed -i "s,quay.io/openshift/origin-local-storage-operator,${IMAGE_LOCAL_STORAGE_OPERATOR}," ${manifest}
 sed -i "s,quay.io/openshift/origin-local-storage-diskmaker,${IMAGE_LOCAL_DISKMAKER}," ${manifest}
-NAMESPACE=${NAMESPACE:-default}
-LOCAL_DISK=${LOCAL_DISK:-""}
+export TEST_NAMESPACE=${TEST_NAMESPACE:-default}
+export TEST_LOCAL_DISK=${TEST_LOCAL_DISK:-""}
 
 export \
     IMAGE_LOCAL_STORAGE_OPERATOR \
     IMAGE_LOCAL_DISKMAKER
 
-TEST_NAMESPACE=${NAMESPACE} TEST_LOCAL_DISK=${LOCAL_DISK} go test -timeout 0 ./test/e2e/... \
+go test -timeout 0 ./test/e2e/... \
   -root=$(pwd) \
   -kubeconfig=${KUBECONFIG} \
   -globalMan ${global_manifest} \

--- a/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/4.6/local-storage-operator.v4.6.0.clusterserviceversion.yaml
@@ -102,6 +102,7 @@ metadata:
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.6.0"
+    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]' 
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
This is a cherrypick of https://github.com/openshift/local-storage-operator/pull/177 for 4.6.

Adds the LocalVolumeDiscoveryResult CRD to the list of internal objects, preventing it from being displayed in the UI.