### PR TITLE
Bug 1906519: update crds in 4.7 to use apiextensions.k8s.io/v1

### DIFF
--- a/deploy/localvolume_crd.yaml
+++ b/deploy/localvolume_crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.5/local-volumes.crd.yaml
+../manifests/4.7/local-volumes.crd.yaml

--- a/deploy/localvolumediscovery_crd.yaml
+++ b/deploy/localvolumediscovery_crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.6/local-volume-discoveries.crd.yaml
+../manifests/4.7/local-volume-discoveries.crd.yaml

--- a/deploy/localvolumediscoveryresult_crd.yaml
+++ b/deploy/localvolumediscoveryresult_crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.6/local-volume-discovery-results.crd.yaml
+../manifests/4.7/local-volume-discovery-results.crd.yaml

--- a/deploy/localvolumeset_crd.yaml
+++ b/deploy/localvolumeset_crd.yaml
@@ -1,1 +1,1 @@
-../manifests/4.6/local-volume-sets.crd.yaml
+../manifests/4.7/local-volume-sets.crd.yaml

--- a/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/local-storage-operator.v4.7.0.clusterserviceversion.yaml
@@ -102,7 +102,7 @@ metadata:
       Configure and use local storage volumes in kubernetes and OpenShift.
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.7.0"
-    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]' 
+    operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/manifests/4.7/local-volume-discoveries.crd.yaml
+++ b/manifests/4.7/local-volume-discoveries.crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumediscoveries.local.storage.openshift.io
@@ -11,195 +11,193 @@ spec:
     plural: localvolumediscoveries
     singular: localvolumediscovery
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      required:
-          - spec
-      description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          required:
+              - spec
+          description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
+            API
           properties:
-            name:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-              # Force "auto-discover-devices" as CR name.
-              enum:
-               - auto-discover-devices
-        spec:
-          description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
-          properties:
-            nodeSelector:
-              description: Nodes on which the automatic detection policies must run.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
               properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms. The terms
-                    are ORed.
+                name:
+                  type: string
+                  # Force "auto-discover-devices" as CR name.
+                  enum:
+                  - auto-discover-devices
+            spec:
+              description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
+              properties:
+                nodeSelector:
+                  description: Nodes on which the automatic detection policies must run.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms. The terms
+                        are ORed.
+                      items:
+                        description: A null or empty node selector term matches no objects.
+                          The requirements of them are ANDed. The TopologySelectorTerm
+                          type implements a subset of the NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements by node's
+                              labels.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements by node's
+                              fields.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+                tolerations:
+                  description: If specified tolerations is the list of toleration that
+                    is passed to the LocalVolumeDiscovery Daemon
                   items:
-                    description: A null or empty node selector term matches no objects.
-                      The requirements of them are ANDed. The TopologySelectorTerm
-                      type implements a subset of the NodeSelectorTerm.
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
                     properties:
-                      matchExpressions:
-                        description: A list of node selector requirements by node's
-                          labels.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements by node's
-                          fields.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty, operator
+                          must be Exists; this combination means to match all values and
+                          all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal. Exists
+                          is equivalent to wildcard for value, so that a pod can tolerate
+                          all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time the
+                          toleration (which must be of effect NoExecute, otherwise this
+                          field is ignored) tolerates the taint. By default, it is not
+                          set, which means tolerate the taint forever (do not evict).
+                          Zero and negative values will be treated as 0 (evict immediately)
+                          by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise
+                          just a regular string.
+                        type: string
                     type: object
                   type: array
-              required:
-              - nodeSelectorTerms
               type: object
-            tolerations:
-              description: If specified tolerations is the list of toleration that
-                is passed to the LocalVolumeDiscovery Daemon
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
+            status:
+              description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
+              properties:
+                conditions:
+                  description: Conditions are the list of conditions and their status.
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: observedGeneration is the last generation change the operator
+                    has dealt with
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase of discovery process
+                    This is used by the OLM UI to provide status information to the user
+                  type: string
+              type: object
           type: object
-        status:
-          description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
-          properties:
-            conditions:
-              description: Conditions are the list of conditions and their status.
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change the operator
-                has dealt with
-              format: int64
-              type: integer
-            phase:
-              description: Phase represents the current phase of discovery process
-                This is used by the OLM UI to provide status information to the user
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+      subresources:
+        status: {}

--- a/manifests/4.7/local-volume-discovery-results.crd.yaml
+++ b/manifests/4.7/local-volume-discovery-results.crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumediscoveryresults.local.storage.openshift.io
@@ -11,113 +11,111 @@ spec:
     plural: localvolumediscoveryresults
     singular: localvolumediscoveryresult
   scope: Namespaced
-  subresources:
-    status: {}
-  preserveUnknownFields: false
-  validation:
-    openAPIV3Schema:
-      description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: LocalVolumeDiscoveryResultSpec defines the desired state of
-            LocalVolumeDiscoveryResult
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
+            API
           properties:
-            nodeName:
-              description: Node on which the devices are discovered
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-          required:
-          - nodeName
-          type: object
-        status:
-          description: LocalVolumeDiscoveryResultStatus defines the observed state
-            of LocalVolumeDiscoveryResult
-          properties:
-            discoveredDevices:
-              description: DiscoveredDevices contains the list of devices on which
-                LSO is capable of creating LocalPVs The devices in this list qualify
-                these following conditions. - it should be a non-removable device.
-                - it should not be a read-only device. - it should not be mounted
-                anywhere - it should not be a boot device - it should not have child
-                partitions
-              items:
-                description: DiscoveredDevice shows the list of discovered devices
-                  with their properties
-                properties:
-                  deviceID:
-                    description: DeviceID represents the persistent name of the device.
-                      For eg, /dev/disk/by-id/...
-                    type: string
-                  fstype:
-                    description: FSType represents the filesystem available on the
-                      device
-                    type: string
-                  model:
-                    description: Model of the discovered device
-                    type: string
-                  path:
-                    description: Path represents the device path. For eg, /dev/sdb
-                    type: string
-                  property:
-                    description: Property represents whether the device type is rotational
-                      or not
-                    type: string
-                  serial:
-                    description: Serial number of the disk
-                    type: string
-                  size:
-                    description: Size of the discovered device
-                    format: int64
-                    type: integer
-                  status:
-                    description: Status defines whether the device is available for
-                      use or not
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LocalVolumeDiscoveryResultSpec defines the desired state of
+                LocalVolumeDiscoveryResult
+              properties:
+                nodeName:
+                  description: Node on which the devices are discovered
+                  type: string
+              required:
+              - nodeName
+              type: object
+            status:
+              description: LocalVolumeDiscoveryResultStatus defines the observed state
+                of LocalVolumeDiscoveryResult
+              properties:
+                discoveredDevices:
+                  description: DiscoveredDevices contains the list of devices on which
+                    LSO is capable of creating LocalPVs The devices in this list qualify
+                    these following conditions. - it should be a non-removable device.
+                    - it should not be a read-only device. - it should not be mounted
+                    anywhere - it should not be a boot device - it should not have child
+                    partitions
+                  items:
+                    description: DiscoveredDevice shows the list of discovered devices
+                      with their properties
                     properties:
-                      state:
-                        description: State shows the availability of the device
+                      deviceID:
+                        description: DeviceID represents the persistent name of the device.
+                          For eg, /dev/disk/by-id/...
+                        type: string
+                      fstype:
+                        description: FSType represents the filesystem available on the
+                          device
+                        type: string
+                      model:
+                        description: Model of the discovered device
+                        type: string
+                      path:
+                        description: Path represents the device path. For eg, /dev/sdb
+                        type: string
+                      property:
+                        description: Property represents whether the device type is rotational
+                          or not
+                        type: string
+                      serial:
+                        description: Serial number of the disk
+                        type: string
+                      size:
+                        description: Size of the discovered device
+                        format: int64
+                        type: integer
+                      status:
+                        description: Status defines whether the device is available for
+                          use or not
+                        properties:
+                          state:
+                            description: State shows the availability of the device
+                            type: string
+                        required:
+                        - state
+                        type: object
+                      type:
+                        description: Type of the discovered device
+                        type: string
+                      vendor:
+                        description: Vendor of the discovered device
                         type: string
                     required:
-                    - state
+                    - deviceID
+                    - fstype
+                    - model
+                    - path
+                    - property
+                    - serial
+                    - size
+                    - status
+                    - type
+                    - vendor
                     type: object
-                  type:
-                    description: Type of the discovered device
-                    type: string
-                  vendor:
-                    description: Vendor of the discovered device
-                    type: string
-                required:
-                - deviceID
-                - fstype
-                - model
-                - path
-                - property
-                - serial
-                - size
-                - status
-                - type
-                - vendor
-                type: object
-              type: array
-            discoveredTimeStamp:
-              description: DiscoveredTimeStamp is the last timestamp when the list
-                of discovered devices was updated
-              type: string
+                  type: array
+                discoveredTimeStamp:
+                  description: DiscoveredTimeStamp is the last timestamp when the list
+                    of discovered devices was updated
+                  type: string
+              type: object
           type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+      subresources:
+        status: {}

--- a/manifests/4.7/local-volume-sets.crd.yaml
+++ b/manifests/4.7/local-volume-sets.crd.yaml
@@ -1,21 +1,9 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumesets.local.storage.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.storageClassName
-    description: StorageClass
-    name: StorageClass
-    type: string
-  - JSONPath: .status.totalProvisionedDeviceCount
-    description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
-    name: Provisioned
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: local.storage.openshift.io
   names:
     kind: LocalVolumeSet
@@ -26,247 +14,257 @@ spec:
     - lvset
     - lvsets
   scope: Namespaced
-  preserveUnknownFields: false
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      required:
-          - spec
-      type: object
-      description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
-        criteria.
-      properties:
-        spec:
-          description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          required:
+              - spec
+          type: object
+          description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
+            criteria.
           properties:
-            deviceInclusionSpec:
-              description: DeviceInclusionSpec is the filtration rule for including
-                a device in the device discovery
+            spec:
+              description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
               properties:
-                deviceMechanicalProperties:
-                  description: DeviceMechanicalProperty denotes whether Rotational
-                    or NonRotational disks should be used. by default, it selects
-                    both
-                  items:
-                    description: DeviceMechanicalProperty holds the device's mechanical
-                      spec. It can be rotational or nonRotational
-                    type: string
-                  type: array
-                deviceTypes:
-                  description: 'Devices is the list of devices that should be used
-                    for automatic detection. This would be one of the types supported
-                    by the local-storage operator. Currently, the supported types
-                    are: disk, part. If the list is empty no devices will be selected.'
-                  items:
-                    description: DeviceType is the types that will be supported by
-                      the LSO.
-                    type: string
-                    enum:
-                      - disk
-                      - part
-                  type: array
-                maxSize:
-                  description: MaxSize is the maximum size of the device which needs
-                    to be included
+                deviceInclusionSpec:
+                  description: DeviceInclusionSpec is the filtration rule for including
+                    a device in the device discovery
+                  properties:
+                    deviceMechanicalProperties:
+                      description: DeviceMechanicalProperty denotes whether Rotational
+                        or NonRotational disks should be used. by default, it selects
+                        both
+                      items:
+                        description: DeviceMechanicalProperty holds the device's mechanical
+                          spec. It can be rotational or nonRotational
+                        type: string
+                      type: array
+                    deviceTypes:
+                      description: 'Devices is the list of devices that should be used
+                        for automatic detection. This would be one of the types supported
+                        by the local-storage operator. Currently, the supported types
+                        are: disk, part. If the list is empty no devices will be selected.'
+                      items:
+                        description: DeviceType is the types that will be supported by
+                          the LSO.
+                        type: string
+                        enum:
+                          - disk
+                          - part
+                      type: array
+                    maxSize:
+                      description: MaxSize is the maximum size of the device which needs
+                        to be included
+                      type: string
+                    minSize:
+                      description: MinSize is the minimum size of the device which needs
+                        to be included
+                      type: string
+                    models:
+                      description: Models is a list of device models. If not empty, the
+                        device's model as outputted by lsblk needs to contain at least
+                        one of these strings.
+                      items:
+                        type: string
+                      type: array
+                    vendors:
+                      description: Vendors is a list of device vendors. If not empty,
+                        the device's model as outputted by lsblk needs to contain at least
+                        one of these strings.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                maxDeviceCount:
+                  description: Maximum number of Devices that needs to be detected per
+                    node. If omitted, there will be no maximum.
+                  format: int32
+                  type: integer
+                fsType:
+                  description: FSType type to create when volumeMode is Filesystem
                   type: string
-                minSize:
-                  description: MinSize is the minimum size of the device which needs
-                    to be included
+                nodeSelector:
+                  description: Nodes on which the automatic detection policies must run.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms. The terms
+                        are ORed.
+                      items:
+                        description: A null or empty node selector term matches no objects.
+                          The requirements of them are ANDed. The TopologySelectorTerm
+                          type implements a subset of the NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements by node's
+                              labels.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements by node's
+                              fields.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+                storageClassName:
+                  description: StorageClassName to use for set of matched devices
                   type: string
-                models:
-                  description: Models is a list of device models. If not empty, the
-                    device's model as outputted by lsblk needs to contain at least
-                    one of these strings.
+                tolerations:
+                  description: If specified, a list of tolerations to pass to the discovery
+                    daemons.
                   items:
-                    type: string
-                  type: array
-                vendors:
-                  description: Vendors is a list of device vendors. If not empty,
-                    the device's model as outputted by lsblk needs to contain at least
-                    one of these strings.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            maxDeviceCount:
-              description: Maximum number of Devices that needs to be detected per
-                node. If omitted, there will be no maximum.
-              format: int32
-              type: integer
-            fsType:
-              description: FSType type to create when volumeMode is Filesystem
-              type: string
-            nodeSelector:
-              description: Nodes on which the automatic detection policies must run.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms. The terms
-                    are ORed.
-                  items:
-                    description: A null or empty node selector term matches no objects.
-                      The requirements of them are ANDed. The TopologySelectorTerm
-                      type implements a subset of the NodeSelectorTerm.
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
                     properties:
-                      matchExpressions:
-                        description: A list of node selector requirements by node's
-                          labels.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements by node's
-                          fields.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty, operator
+                          must be Exists; this combination means to match all values and
+                          all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal. Exists
+                          is equivalent to wildcard for value, so that a pod can tolerate
+                          all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time the
+                          toleration (which must be of effect NoExecute, otherwise this
+                          field is ignored) tolerates the taint. By default, it is not
+                          set, which means tolerate the taint forever (do not evict).
+                          Zero and negative values will be treated as 0 (evict immediately)
+                          by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise
+                          just a regular string.
+                        type: string
                     type: object
                   type: array
+                volumeMode:
+                  description: VolumeMode determines whether the PV created is Block or
+                    Filesystem. It will default to Filesystem
+                  type: string
+                  enum:
+                    - Block
+                    - Filesystem
               required:
-              - nodeSelectorTerms
+              - storageClassName
               type: object
-            storageClassName:
-              description: StorageClassName to use for set of matched devices
-              type: string
-            tolerations:
-              description: If specified, a list of tolerations to pass to the discovery
-                daemons.
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-            volumeMode:
-              description: VolumeMode determines whether the PV created is Block or
-                Filesystem. It will default to Filesystem
-              type: string
-              enum:
-                - Block
-                - Filesystem
-          required:
-          - storageClassName
-          type: object
-        status:
-          description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
-          properties:
-            conditions:
-              description: Conditions is a list of conditions and their status.
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change the operator
-                has dealt with
-              format: int64
-              type: integer
-            totalProvisionedDeviceCount:
-              description: TotalProvisionedDeviceCount is the count of the total devices
-                over which the PVs has been provisioned
-              format: int32
-              type: integer
-          type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+            status:
+              description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
+              properties:
+                conditions:
+                  description: Conditions is a list of conditions and their status.
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: observedGeneration is the last generation change the operator
+                    has dealt with
+                  format: int64
+                  type: integer
+                totalProvisionedDeviceCount:
+                  description: TotalProvisionedDeviceCount is the count of the total devices
+                    over which the PVs has been provisioned
+                  format: int32
+                  type: integer
+              type: object
+      additionalPrinterColumns:
+      - jsonPath: .spec.storageClassName
+        description: StorageClass
+        name: StorageClass
+        type: string
+      - jsonPath: .status.totalProvisionedDeviceCount
+        description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
+        name: Provisioned
+        type: integer
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      subresources:
+        status: {}

--- a/manifests/4.7/local-volumes.crd.yaml
+++ b/manifests/4.7/local-volumes.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumes.local.storage.openshift.io
@@ -10,139 +10,141 @@ spec:
     plural: localvolumes
     singular: localvolume
   scope: Namespaced
-  version: v1
-  preserveUnknownFields: false
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      description: LocalVolume is a local storage configuration used by the operator
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           type: object
-        spec:
-          description: 'spec is the specification of the desired state of selected local devices'
+          description: LocalVolume is a local storage configuration used by the operator
           properties:
-            nodeSelector:
-              description: Nodes on which the provisioner must run
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              x-kubernetes-preserve-unknown-fields: true
-            managementState:
-              description: Indicates whether and how the operator should manage the component
-              type: string
-              enum: ["Managed", "Unmanaged", "Removed", "Force"]
-            logLevel:
-              description: logLevel configures log level for the diskmaker and provisioner for this object
-              type: string
-              enum: ["Normal", "Debug", "Trace", "TraceAll"]
-            storageClassDevices:
-              description: List of storage class and devices they can match
-              items:
-                properties:
-                  storageClassName:
-                    description: StorageClass name to use for set of matched devices
-                    type: string
-                  volumeMode:
-                    description: Volume mode. Block or Filesystem
-                    enum:
-                      - Block
-                      - Filesystem
-                    type: string
-                  fsType:
-                    description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
-                    type: string
-                  devicePaths:
-                    description: 'A list of devices which would be chosen for local storage.
-                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
-                    items:
-                      type: string
-                    type: array
-                required:
-                  - storageClassName
-                  - devicePaths
-                type: object
-              type: array
-            tolerations:
-              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
-              items:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
+            spec:
+              description: 'spec is the specification of the desired state of selected local devices'
+              properties:
+                nodeSelector:
+                  description: Nodes on which the provisioner must run
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                managementState:
+                  description: Indicates whether and how the operator should manage the component
+                  type: string
+                  enum: ["Managed", "Unmanaged", "Removed", "Force"]
+                logLevel:
+                  description: logLevel configures log level for the diskmaker and provisioner for this object
+                  type: string
+                  enum: ["Normal", "Debug", "Trace", "TraceAll"]
+                storageClassDevices:
+                  description: List of storage class and devices they can match
+                  items:
+                    properties:
+                      storageClassName:
+                        description: StorageClass name to use for set of matched devices
+                        type: string
+                      volumeMode:
+                        description: Volume mode. Block or Filesystem
+                        enum:
+                          - Block
+                          - Filesystem
+                        type: string
+                      fsType:
+                        description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
+                        type: string
+                      devicePaths:
+                        description: 'A list of devices which would be chosen for local storage.
+                        For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - storageClassName
+                      - devicePaths
+                    type: object
+                  type: array
+                tolerations:
+                  description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+              required:
+                - storageClassDevices
+              type: object
+            status:
+              description: 'status is the most recently observed status selected local devices'
+              properties:
+                generations:
+                  description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
+                  items:
+                    description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
+                    properties:
+                      group:
+                        type: string
+                      resource:
+                        type: string
+                      lastGeneration:
+                        format: int64
+                        type: integer
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - group
+                    - resource
+                    - namespace
+                    - name
+                    - lastGeneration
+                    type: object
+                  type: array
+                conditions:
+                  description: 'conditions is a list of conditions and their status'
+                  type: array
+                  items:
+                    description: 'OperatorCondition is just the standard condition fields'
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                    required:
+                    - type
+                    - status
+                observedGeneration:
+                  format: int64
+                  type: integer
+                managementState:
+                  type: string
+                  enum: ["Managed", "Unmanaged", "Removed", "Force"]
+                readyReplicas:
+                  type: integer
+                  format: int32
+              type: object
+              required:
+              - conditions
+              - generations
           required:
-            - storageClassDevices
-          type: object
-        status:
-          description: 'status is the most recently observed status selected local devices'
-          properties:
-            generations:
-              description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
-              items:
-                description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
-                properties:
-                  group:
-                    type: string
-                  resource:
-                    type: string
-                  lastGeneration:
-                    format: int64
-                    type: integer
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - group
-                - resource
-                - namespace
-                - name
-                - lastGeneration
-                type: object
-              type: array
-            conditions:
-              description: 'conditions is a list of conditions and their status'
-              type: array
-              items:
-                description: 'OperatorCondition is just the standard condition fields'
-                type: object
-                properties:
-                  type:
-                    type: string
-                  status:
-                    type: string
-                    enum: ["True", "False", "Unknown"]
-                  lastTransitionTime:
-                    type: string
-                    format: date-time
-                  reason:
-                    type: string
-                  message:
-                    type: string
-                required:
-                - type
-                - status
-            observedGeneration:
-              format: int64
-              type: integer
-            managementState:
-              type: string
-              enum: ["Managed", "Unmanaged", "Removed", "Force"]
-            readyReplicas:
-              type: integer
-              format: int32
-          type: object
-          required:
-          - conditions
-          - generations
-      required:
-        - spec
+            - spec
+      subresources:
+        status: {}

--- a/opm-bundle/manifests/local-volume-discoveries.crd.yaml
+++ b/opm-bundle/manifests/local-volume-discoveries.crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumediscoveries.local.storage.openshift.io
@@ -11,192 +11,193 @@ spec:
     plural: localvolumediscoveries
     singular: localvolumediscovery
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          required:
+              - spec
+          description: LocalVolumeDiscovery is the Schema for the localvolumediscoveries
+            API
           properties:
-            name:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-              # Force "auto-discover-devices" as CR name.
-              enum:
-               - auto-discover-devices
-        spec:
-          description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
-          properties:
-            nodeSelector:
-              description: Nodes on which the automatic detection policies must run.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
               properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms. The terms
-                    are ORed.
+                name:
+                  type: string
+                  # Force "auto-discover-devices" as CR name.
+                  enum:
+                  - auto-discover-devices
+            spec:
+              description: LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery
+              properties:
+                nodeSelector:
+                  description: Nodes on which the automatic detection policies must run.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms. The terms
+                        are ORed.
+                      items:
+                        description: A null or empty node selector term matches no objects.
+                          The requirements of them are ANDed. The TopologySelectorTerm
+                          type implements a subset of the NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements by node's
+                              labels.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements by node's
+                              fields.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+                tolerations:
+                  description: If specified tolerations is the list of toleration that
+                    is passed to the LocalVolumeDiscovery Daemon
                   items:
-                    description: A null or empty node selector term matches no objects.
-                      The requirements of them are ANDed. The TopologySelectorTerm
-                      type implements a subset of the NodeSelectorTerm.
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
                     properties:
-                      matchExpressions:
-                        description: A list of node selector requirements by node's
-                          labels.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements by node's
-                          fields.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty, operator
+                          must be Exists; this combination means to match all values and
+                          all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal. Exists
+                          is equivalent to wildcard for value, so that a pod can tolerate
+                          all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time the
+                          toleration (which must be of effect NoExecute, otherwise this
+                          field is ignored) tolerates the taint. By default, it is not
+                          set, which means tolerate the taint forever (do not evict).
+                          Zero and negative values will be treated as 0 (evict immediately)
+                          by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise
+                          just a regular string.
+                        type: string
                     type: object
                   type: array
-              required:
-              - nodeSelectorTerms
               type: object
-            tolerations:
-              description: If specified tolerations is the list of toleration that
-                is passed to the LocalVolumeDiscovery Daemon
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
+            status:
+              description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
+              properties:
+                conditions:
+                  description: Conditions are the list of conditions and their status.
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: observedGeneration is the last generation change the operator
+                    has dealt with
+                  format: int64
+                  type: integer
+                phase:
+                  description: Phase represents the current phase of discovery process
+                    This is used by the OLM UI to provide status information to the user
+                  type: string
+              type: object
           type: object
-        status:
-          description: LocalVolumeDiscoveryStatus defines the observed state of LocalVolumeDiscovery
-          properties:
-            conditions:
-              description: Conditions are the list of conditions and their status.
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change the operator
-                has dealt with
-              format: int64
-              type: integer
-            phase:
-              description: Phase represents the current phase of discovery process
-                This is used by the OLM UI to provide status information to the user
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+      subresources:
+        status: {}

--- a/opm-bundle/manifests/local-volume-discovery-results.crd.yaml
+++ b/opm-bundle/manifests/local-volume-discovery-results.crd.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumediscoveryresults.local.storage.openshift.io
@@ -11,112 +11,111 @@ spec:
     plural: localvolumediscoveryresults
     singular: localvolumediscoveryresult
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: LocalVolumeDiscoveryResultSpec defines the desired state of
-            LocalVolumeDiscoveryResult
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: LocalVolumeDiscoveryResult is the Schema for the localvolumediscoveryresults
+            API
           properties:
-            nodeName:
-              description: Node on which the devices are discovered
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-          required:
-          - nodeName
-          type: object
-        status:
-          description: LocalVolumeDiscoveryResultStatus defines the observed state
-            of LocalVolumeDiscoveryResult
-          properties:
-            discoveredDevices:
-              description: DiscoveredDevices contains the list of devices on which
-                LSO is capable of creating LocalPVs The devices in this list qualify
-                these following conditions. - it should be a non-removable device.
-                - it should not be a read-only device. - it should not be mounted
-                anywhere - it should not be a boot device - it should not have child
-                partitions
-              items:
-                description: DiscoveredDevice shows the list of discovered devices
-                  with their properties
-                properties:
-                  deviceID:
-                    description: DeviceID represents the persistent name of the device.
-                      For eg, /dev/disk/by-id/...
-                    type: string
-                  fstype:
-                    description: FSType represents the filesystem available on the
-                      device
-                    type: string
-                  model:
-                    description: Model of the discovered device
-                    type: string
-                  path:
-                    description: Path represents the device path. For eg, /dev/sdb
-                    type: string
-                  property:
-                    description: Property represents whether the device type is rotational
-                      or not
-                    type: string
-                  serial:
-                    description: Serial number of the disk
-                    type: string
-                  size:
-                    description: Size of the discovered device
-                    format: int64
-                    type: integer
-                  status:
-                    description: Status defines whether the device is available for
-                      use or not
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: LocalVolumeDiscoveryResultSpec defines the desired state of
+                LocalVolumeDiscoveryResult
+              properties:
+                nodeName:
+                  description: Node on which the devices are discovered
+                  type: string
+              required:
+              - nodeName
+              type: object
+            status:
+              description: LocalVolumeDiscoveryResultStatus defines the observed state
+                of LocalVolumeDiscoveryResult
+              properties:
+                discoveredDevices:
+                  description: DiscoveredDevices contains the list of devices on which
+                    LSO is capable of creating LocalPVs The devices in this list qualify
+                    these following conditions. - it should be a non-removable device.
+                    - it should not be a read-only device. - it should not be mounted
+                    anywhere - it should not be a boot device - it should not have child
+                    partitions
+                  items:
+                    description: DiscoveredDevice shows the list of discovered devices
+                      with their properties
                     properties:
-                      state:
-                        description: State shows the availability of the device
+                      deviceID:
+                        description: DeviceID represents the persistent name of the device.
+                          For eg, /dev/disk/by-id/...
+                        type: string
+                      fstype:
+                        description: FSType represents the filesystem available on the
+                          device
+                        type: string
+                      model:
+                        description: Model of the discovered device
+                        type: string
+                      path:
+                        description: Path represents the device path. For eg, /dev/sdb
+                        type: string
+                      property:
+                        description: Property represents whether the device type is rotational
+                          or not
+                        type: string
+                      serial:
+                        description: Serial number of the disk
+                        type: string
+                      size:
+                        description: Size of the discovered device
+                        format: int64
+                        type: integer
+                      status:
+                        description: Status defines whether the device is available for
+                          use or not
+                        properties:
+                          state:
+                            description: State shows the availability of the device
+                            type: string
+                        required:
+                        - state
+                        type: object
+                      type:
+                        description: Type of the discovered device
+                        type: string
+                      vendor:
+                        description: Vendor of the discovered device
                         type: string
                     required:
-                    - state
+                    - deviceID
+                    - fstype
+                    - model
+                    - path
+                    - property
+                    - serial
+                    - size
+                    - status
+                    - type
+                    - vendor
                     type: object
-                  type:
-                    description: Type of the discovered device
-                    type: string
-                  vendor:
-                    description: Vendor of the discovered device
-                    type: string
-                required:
-                - deviceID
-                - fstype
-                - model
-                - path
-                - property
-                - serial
-                - size
-                - status
-                - type
-                - vendor
-                type: object
-              type: array
-            discoveredTimeStamp:
-              description: DiscoveredTimeStamp is the last timestamp when the list
-                of discovered devices was updated
-              type: string
+                  type: array
+                discoveredTimeStamp:
+                  description: DiscoveredTimeStamp is the last timestamp when the list
+                    of discovered devices was updated
+                  type: string
+              type: object
           type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+      subresources:
+        status: {}

--- a/opm-bundle/manifests/local-volume-sets.crd.yaml
+++ b/opm-bundle/manifests/local-volume-sets.crd.yaml
@@ -1,21 +1,9 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumesets.local.storage.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.storageClassName
-    description: StorageClass
-    name: StorageClass
-    type: string
-  - JSONPath: .status.totalProvisionedDeviceCount
-    description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
-    name: Provisioned
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: local.storage.openshift.io
   names:
     kind: LocalVolumeSet
@@ -26,247 +14,257 @@ spec:
     - lvset
     - lvsets
   scope: Namespaced
-  preserveUnknownFields: false
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      required:
-          - spec
-      type: object
-      description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
-        criteria.
-      properties:
-        spec:
-          description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          required:
+              - spec
+          type: object
+          description: LocalVolumeSet enables automatic provisioning of local PersistentVolumes based on specified
+            criteria.
           properties:
-            deviceInclusionSpec:
-              description: DeviceInclusionSpec is the filtration rule for including
-                a device in the device discovery
+            spec:
+              description: LocalVolumeSetSpec defines the desired state of LocalVolumeSet
               properties:
-                deviceMechanicalProperties:
-                  description: DeviceMechanicalProperty denotes whether Rotational
-                    or NonRotational disks should be used. by default, it selects
-                    both
-                  items:
-                    description: DeviceMechanicalProperty holds the device's mechanical
-                      spec. It can be rotational or nonRotational
-                    type: string
-                  type: array
-                deviceTypes:
-                  description: 'Devices is the list of devices that should be used
-                    for automatic detection. This would be one of the types supported
-                    by the local-storage operator. Currently, the supported types
-                    are: disk, part. If the list is empty no devices will be selected.'
-                  items:
-                    description: DeviceType is the types that will be supported by
-                      the LSO.
-                    type: string
-                    enum:
-                      - disk
-                      - part
-                  type: array
-                maxSize:
-                  description: MaxSize is the maximum size of the device which needs
-                    to be included
+                deviceInclusionSpec:
+                  description: DeviceInclusionSpec is the filtration rule for including
+                    a device in the device discovery
+                  properties:
+                    deviceMechanicalProperties:
+                      description: DeviceMechanicalProperty denotes whether Rotational
+                        or NonRotational disks should be used. by default, it selects
+                        both
+                      items:
+                        description: DeviceMechanicalProperty holds the device's mechanical
+                          spec. It can be rotational or nonRotational
+                        type: string
+                      type: array
+                    deviceTypes:
+                      description: 'Devices is the list of devices that should be used
+                        for automatic detection. This would be one of the types supported
+                        by the local-storage operator. Currently, the supported types
+                        are: disk, part. If the list is empty no devices will be selected.'
+                      items:
+                        description: DeviceType is the types that will be supported by
+                          the LSO.
+                        type: string
+                        enum:
+                          - disk
+                          - part
+                      type: array
+                    maxSize:
+                      description: MaxSize is the maximum size of the device which needs
+                        to be included
+                      type: string
+                    minSize:
+                      description: MinSize is the minimum size of the device which needs
+                        to be included
+                      type: string
+                    models:
+                      description: Models is a list of device models. If not empty, the
+                        device's model as outputted by lsblk needs to contain at least
+                        one of these strings.
+                      items:
+                        type: string
+                      type: array
+                    vendors:
+                      description: Vendors is a list of device vendors. If not empty,
+                        the device's model as outputted by lsblk needs to contain at least
+                        one of these strings.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                maxDeviceCount:
+                  description: Maximum number of Devices that needs to be detected per
+                    node. If omitted, there will be no maximum.
+                  format: int32
+                  type: integer
+                fsType:
+                  description: FSType type to create when volumeMode is Filesystem
                   type: string
-                minSize:
-                  description: MinSize is the minimum size of the device which needs
-                    to be included
+                nodeSelector:
+                  description: Nodes on which the automatic detection policies must run.
+                  properties:
+                    nodeSelectorTerms:
+                      description: Required. A list of node selector terms. The terms
+                        are ORed.
+                      items:
+                        description: A null or empty node selector term matches no objects.
+                          The requirements of them are ANDed. The TopologySelectorTerm
+                          type implements a subset of the NodeSelectorTerm.
+                        properties:
+                          matchExpressions:
+                            description: A list of node selector requirements by node's
+                              labels.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchFields:
+                            description: A list of node selector requirements by node's
+                              fields.
+                            items:
+                              description: A node selector requirement is a selector that
+                                contains values, a key, and an operator that relates the
+                                key and values.
+                              properties:
+                                key:
+                                  description: The label key that the selector applies
+                                    to.
+                                  type: string
+                                operator:
+                                  description: Represents a key's relationship to a set
+                                    of values. Valid operators are In, NotIn, Exists,
+                                    DoesNotExist. Gt, and Lt.
+                                  type: string
+                                values:
+                                  description: An array of string values. If the operator
+                                    is In or NotIn, the values array must be non-empty.
+                                    If the operator is Exists or DoesNotExist, the values
+                                    array must be empty. If the operator is Gt or Lt,
+                                    the values array must have a single element, which
+                                    will be interpreted as an integer. This array is replaced
+                                    during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - nodeSelectorTerms
+                  type: object
+                storageClassName:
+                  description: StorageClassName to use for set of matched devices
                   type: string
-                models:
-                  description: Models is a list of device models. If not empty, the
-                    device's model as outputted by lsblk needs to contain at least
-                    one of these strings.
+                tolerations:
+                  description: If specified, a list of tolerations to pass to the discovery
+                    daemons.
                   items:
-                    type: string
-                  type: array
-                vendors:
-                  description: Vendors is a list of device vendors. If not empty,
-                    the device's model as outputted by lsblk needs to contain at least
-                    one of these strings.
-                  items:
-                    type: string
-                  type: array
-              type: object
-            maxDeviceCount:
-              description: Maximum number of Devices that needs to be detected per
-                node. If omitted, there will be no maximum.
-              format: int32
-              type: integer
-            fsType:
-              description: FSType type to create when volumeMode is Filesystem
-              type: string
-            nodeSelector:
-              description: Nodes on which the automatic detection policies must run.
-              properties:
-                nodeSelectorTerms:
-                  description: Required. A list of node selector terms. The terms
-                    are ORed.
-                  items:
-                    description: A null or empty node selector term matches no objects.
-                      The requirements of them are ANDed. The TopologySelectorTerm
-                      type implements a subset of the NodeSelectorTerm.
+                    description: The pod this Toleration is attached to tolerates any
+                      taint that matches the triple <key,value,effect> using the matching
+                      operator <operator>.
                     properties:
-                      matchExpressions:
-                        description: A list of node selector requirements by node's
-                          labels.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchFields:
-                        description: A list of node selector requirements by node's
-                          fields.
-                        items:
-                          description: A node selector requirement is a selector that
-                            contains values, a key, and an operator that relates the
-                            key and values.
-                          properties:
-                            key:
-                              description: The label key that the selector applies
-                                to.
-                              type: string
-                            operator:
-                              description: Represents a key's relationship to a set
-                                of values. Valid operators are In, NotIn, Exists,
-                                DoesNotExist. Gt, and Lt.
-                              type: string
-                            values:
-                              description: An array of string values. If the operator
-                                is In or NotIn, the values array must be non-empty.
-                                If the operator is Exists or DoesNotExist, the values
-                                array must be empty. If the operator is Gt or Lt,
-                                the values array must have a single element, which
-                                will be interpreted as an integer. This array is replaced
-                                during a strategic merge patch.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty, operator
+                          must be Exists; this combination means to match all values and
+                          all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal. Exists
+                          is equivalent to wildcard for value, so that a pod can tolerate
+                          all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time the
+                          toleration (which must be of effect NoExecute, otherwise this
+                          field is ignored) tolerates the taint. By default, it is not
+                          set, which means tolerate the taint forever (do not evict).
+                          Zero and negative values will be treated as 0 (evict immediately)
+                          by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise
+                          just a regular string.
+                        type: string
                     type: object
                   type: array
+                volumeMode:
+                  description: VolumeMode determines whether the PV created is Block or
+                    Filesystem. It will default to Filesystem
+                  type: string
+                  enum:
+                    - Block
+                    - Filesystem
               required:
-              - nodeSelectorTerms
+              - storageClassName
               type: object
-            storageClassName:
-              description: StorageClassName to use for set of matched devices
-              type: string
-            tolerations:
-              description: If specified, a list of tolerations to pass to the discovery
-                daemons.
-              items:
-                description: The pod this Toleration is attached to tolerates any
-                  taint that matches the triple <key,value,effect> using the matching
-                  operator <operator>.
-                properties:
-                  effect:
-                    description: Effect indicates the taint effect to match. Empty
-                      means match all taint effects. When specified, allowed values
-                      are NoSchedule, PreferNoSchedule and NoExecute.
-                    type: string
-                  key:
-                    description: Key is the taint key that the toleration applies
-                      to. Empty means match all taint keys. If the key is empty, operator
-                      must be Exists; this combination means to match all values and
-                      all keys.
-                    type: string
-                  operator:
-                    description: Operator represents a key's relationship to the value.
-                      Valid operators are Exists and Equal. Defaults to Equal. Exists
-                      is equivalent to wildcard for value, so that a pod can tolerate
-                      all taints of a particular category.
-                    type: string
-                  tolerationSeconds:
-                    description: TolerationSeconds represents the period of time the
-                      toleration (which must be of effect NoExecute, otherwise this
-                      field is ignored) tolerates the taint. By default, it is not
-                      set, which means tolerate the taint forever (do not evict).
-                      Zero and negative values will be treated as 0 (evict immediately)
-                      by the system.
-                    format: int64
-                    type: integer
-                  value:
-                    description: Value is the taint value the toleration matches to.
-                      If the operator is Exists, the value should be empty, otherwise
-                      just a regular string.
-                    type: string
-                type: object
-              type: array
-            volumeMode:
-              description: VolumeMode determines whether the PV created is Block or
-                Filesystem. It will default to Filesystem
-              type: string
-              enum:
-                - Block
-                - Filesystem
-          required:
-          - storageClassName
-          type: object
-        status:
-          description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
-          properties:
-            conditions:
-              description: Conditions is a list of conditions and their status.
-              items:
-                description: OperatorCondition is just the standard condition fields.
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: observedGeneration is the last generation change the operator
-                has dealt with
-              format: int64
-              type: integer
-            totalProvisionedDeviceCount:
-              description: TotalProvisionedDeviceCount is the count of the total devices
-                over which the PVs has been provisioned
-              format: int32
-              type: integer
-          type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+            status:
+              description: LocalVolumeSetStatus defines the observed state of LocalVolumeSet
+              properties:
+                conditions:
+                  description: Conditions is a list of conditions and their status.
+                  items:
+                    description: OperatorCondition is just the standard condition fields.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    type: object
+                  type: array
+                observedGeneration:
+                  description: observedGeneration is the last generation change the operator
+                    has dealt with
+                  format: int64
+                  type: integer
+                totalProvisionedDeviceCount:
+                  description: TotalProvisionedDeviceCount is the count of the total devices
+                    over which the PVs has been provisioned
+                  format: int32
+                  type: integer
+              type: object
+      additionalPrinterColumns:
+      - jsonPath: .spec.storageClassName
+        description: StorageClass
+        name: StorageClass
+        type: string
+      - jsonPath: .status.totalProvisionedDeviceCount
+        description: The number of PVs provisioned for this LocalVolumeSet's StorageClass
+        name: Provisioned
+        type: integer
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      subresources:
+        status: {}

--- a/opm-bundle/manifests/local-volumes.crd.yaml
+++ b/opm-bundle/manifests/local-volumes.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: localvolumes.local.storage.openshift.io
@@ -10,139 +10,141 @@ spec:
     plural: localvolumes
     singular: localvolume
   scope: Namespaced
-  version: v1
-  preserveUnknownFields: false
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      description: LocalVolume is a local storage configuration used by the operator
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
           type: object
-        spec:
-          description: 'spec is the specification of the desired state of selected local devices'
+          description: LocalVolume is a local storage configuration used by the operator
           properties:
-            nodeSelector:
-              description: Nodes on which the provisioner must run
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              x-kubernetes-preserve-unknown-fields: true
-            managementState:
-              description: Indicates whether and how the operator should manage the component
-              type: string
-              enum: ["Managed", "Unmanaged", "Removed", "Force"]
-            logLevel:
-              description: logLevel configures log level for the diskmaker and provisioner for this object
-              type: string
-              enum: ["Normal", "Debug", "Trace", "TraceAll"]
-            storageClassDevices:
-              description: List of storage class and devices they can match
-              items:
-                properties:
-                  storageClassName:
-                    description: StorageClass name to use for set of matched devices
-                    type: string
-                  volumeMode:
-                    description: Volume mode. Block or Filesystem
-                    enum:
-                      - Block
-                      - Filesystem
-                    type: string
-                  fsType:
-                    description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
-                    type: string
-                  devicePaths:
-                    description: 'A list of devices which would be chosen for local storage.
-                    For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
-                    items:
-                      type: string
-                    type: array
-                required:
-                  - storageClassName
-                  - devicePaths
-                type: object
-              type: array
-            tolerations:
-              description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
-              items:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              type: array
+            spec:
+              description: 'spec is the specification of the desired state of selected local devices'
+              properties:
+                nodeSelector:
+                  description: Nodes on which the provisioner must run
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                managementState:
+                  description: Indicates whether and how the operator should manage the component
+                  type: string
+                  enum: ["Managed", "Unmanaged", "Removed", "Force"]
+                logLevel:
+                  description: logLevel configures log level for the diskmaker and provisioner for this object
+                  type: string
+                  enum: ["Normal", "Debug", "Trace", "TraceAll"]
+                storageClassDevices:
+                  description: List of storage class and devices they can match
+                  items:
+                    properties:
+                      storageClassName:
+                        description: StorageClass name to use for set of matched devices
+                        type: string
+                      volumeMode:
+                        description: Volume mode. Block or Filesystem
+                        enum:
+                          - Block
+                          - Filesystem
+                        type: string
+                      fsType:
+                        description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
+                        type: string
+                      devicePaths:
+                        description: 'A list of devices which would be chosen for local storage.
+                        For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]'
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - storageClassName
+                      - devicePaths
+                    type: object
+                  type: array
+                tolerations:
+                  description: A list of tolerations to pass to the diskmaker and provisioner DaemonSets.
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+              required:
+                - storageClassDevices
+              type: object
+            status:
+              description: 'status is the most recently observed status selected local devices'
+              properties:
+                generations:
+                  description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
+                  items:
+                    description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
+                    properties:
+                      group:
+                        type: string
+                      resource:
+                        type: string
+                      lastGeneration:
+                        format: int64
+                        type: integer
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                    - group
+                    - resource
+                    - namespace
+                    - name
+                    - lastGeneration
+                    type: object
+                  type: array
+                conditions:
+                  description: 'conditions is a list of conditions and their status'
+                  type: array
+                  items:
+                    description: 'OperatorCondition is just the standard condition fields'
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                    required:
+                    - type
+                    - status
+                observedGeneration:
+                  format: int64
+                  type: integer
+                managementState:
+                  type: string
+                  enum: ["Managed", "Unmanaged", "Removed", "Force"]
+                readyReplicas:
+                  type: integer
+                  format: int32
+              type: object
+              required:
+              - conditions
+              - generations
           required:
-            - storageClassDevices
-          type: object
-        status:
-          description: 'status is the most recently observed status selected local devices'
-          properties:
-            generations:
-              description: 'generations are used to determine when an item needs to be reconciled or has changed in a way that needs a reaction.'
-              items:
-                description: 'GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.'
-                properties:
-                  group:
-                    type: string
-                  resource:
-                    type: string
-                  lastGeneration:
-                    format: int64
-                    type: integer
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - group
-                - resource
-                - namespace
-                - name
-                - lastGeneration
-                type: object
-              type: array
-            conditions:
-              description: 'conditions is a list of conditions and their status'
-              type: array
-              items:
-                description: 'OperatorCondition is just the standard condition fields'
-                type: object
-                properties:
-                  type:
-                    type: string
-                  status:
-                    type: string
-                    enum: ["True", "False", "Unknown"]
-                  lastTransitionTime:
-                    type: string
-                    format: date-time
-                  reason:
-                    type: string
-                  message:
-                    type: string
-                required:
-                - type
-                - status
-            observedGeneration:
-              format: int64
-              type: integer
-            managementState:
-              type: string
-              enum: ["Managed", "Unmanaged", "Removed", "Force"]
-            readyReplicas:
-              type: integer
-              format: int32
-          type: object
-          required:
-          - conditions
-          - generations
-      required:
-        - spec
+            - spec
+      subresources:
+        status: {}


### PR DESCRIPTION
updated LSO crds in /manifests/4.7 directory to use `apiextensions.k8s.io/v1` instead of `apiextensions.k8s.io/v1beta1`

The `CustomResourceDefinition` API type is promoted to `apiextensions.k8s.io/v1` with the following changes:
* Use of the new `default` feature in validation schemas is limited to v1
* `spec.scope` is no longer defaulted to `Namespaced` and must be explicitly specified
* `spec.version` is removed; use `spec.versions` instead
* `spec.validation` is removed; use `spec.versions[*].schema` instead
* `spec.subresources` is removed; use `spec.versions[*].subresources` instead
* `spec.additionalPrinterColumns` is removed; use `spec.versions[*].additionalPrinterColumns` instead
*  In `additionalPrinterColumns` items, the `JSONPath` field was renamed to `jsonPath` (fixes https://github.com/kubernetes/kubernetes/issues/66531)
* `spec.conversion.webhookClientConfig` is moved to `spec.conversion.webhook.clientConfig`
* `spec.conversion.conversionReviewVersions` is moved to `spec.conversion.webhook.conversionReviewVersions`
* `spec.versions[*].schema.openAPIV3Schema` is now required when creating v1 CustomResourceDefinitions
* `spec.preserveUnknownFields: true` is disallowed when creating v1 CustomResourceDefinitions; it must be specified within schema definitions as `x-kubernetes-preserve-unknown-fields: true`
The `apiextensions.k8s.io/v1beta1` version of `CustomResourceDefinition` is deprecated and will no longer be served in v1.19.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1906519

Signed-off-by: Santosh Pillai <sapillai@redhat.com>