### PR TITLE
Bug 1897050: localVolumeSet: keep default MinSize to 1Gi and ignore devices with `boot` substring in the partLabel

### DIFF
--- a/manifests/4.7/local-volume-sets.crd.yaml
+++ b/manifests/4.7/local-volume-sets.crd.yaml
@@ -61,7 +61,7 @@ spec:
                       type: string
                     minSize:
                       description: MinSize is the minimum size of the device which needs
-                        to be included
+                        to be included. Defaults to `1Gi` if empty.
                       type: string
                     models:
                       description: Models is a list of device models. If not empty, the

--- a/opm-bundle/manifests/local-volume-sets.crd.yaml
+++ b/opm-bundle/manifests/local-volume-sets.crd.yaml
@@ -61,7 +61,7 @@ spec:
                       type: string
                     minSize:
                       description: MinSize is the minimum size of the device which needs
-                        to be included
+                        to be included. Defaults to `1Gi` if empty.
                       type: string
                     models:
                       description: Models is a list of device models. If not empty, the

--- a/pkg/apis/local/v1alpha1/localvolumediscovery_types.go
+++ b/pkg/apis/local/v1alpha1/localvolumediscovery_types.go
@@ -23,7 +23,7 @@ type DiscoveredDeviceType string
 const (
 	// DiskType represents a device-type of block disk
 	DiskType DiscoveredDeviceType = "disk"
-	// PartType represents a device-type of partion
+	// PartType represents a device-type of partition
 	PartType DiscoveredDeviceType = "part"
 	// LVMType is an LVM type
 	LVMType DiscoveredDeviceType = "lvm"

--- a/pkg/apis/local/v1alpha1/localvolumeset_types.go
+++ b/pkg/apis/local/v1alpha1/localvolumeset_types.go
@@ -25,7 +25,7 @@ type DeviceType string
 const (
 	// RawDisk represents a device-type of block disk
 	RawDisk DeviceType = "disk"
-	// Partition represents a device-type of partion
+	// Partition represents a device-type of partition
 	Partition DeviceType = "part"
 	// Loop type device
 	Loop DeviceType = "loop"
@@ -42,7 +42,7 @@ type DeviceInclusionSpec struct {
 	// by default, it selects both
 	// +optional
 	DeviceMechanicalProperties []DeviceMechanicalProperty `json:"deviceMechanicalProperties,omitempty"`
-	// MinSize is the minimum size of the device which needs to be included
+	// MinSize is the minimum size of the device which needs to be included. Defaults to `1Gi` if empty
 	// +optional
 	MinSize *resource.Quantity `json:"minSize,omitempty"`
 	// MaxSize is the maximum size of the device which needs to be included

--- a/pkg/diskmaker/controllers/lvset/matcher_test.go
+++ b/pkg/diskmaker/controllers/lvset/matcher_test.go
@@ -140,9 +140,9 @@ func TestNotSuspended(t *testing.T) {
 	}
 	assertAll(t, results)
 }
-func TestnoBiosInPartLabel(t *testing.T) {
+func TestnoBiosBootInPartLabel(t *testing.T) {
 	matcherMap := FilterMap
-	matcher := noBiosInPartLabel
+	matcher := noBiosBootInPartLabel
 	results := []knownMatcherResult{
 		// true
 		{
@@ -168,12 +168,12 @@ func TestnoBiosInPartLabel(t *testing.T) {
 		},
 		{
 			matcherMap: matcherMap, matcher: matcher,
-			dev:         internal.BlockDevice{PartLabel: "bios boot partion"},
+			dev:         internal.BlockDevice{PartLabel: "bios boot partition"},
 			expectMatch: false,
 		},
 		{
 			matcherMap: matcherMap, matcher: matcher,
-			dev:         internal.BlockDevice{PartLabel: "this is a BIOS BOOT partion"},
+			dev:         internal.BlockDevice{PartLabel: "this is a BIOS BOOT partition"},
 			expectMatch: false,
 		},
 		{
@@ -184,6 +184,16 @@ func TestnoBiosInPartLabel(t *testing.T) {
 		{
 			matcherMap: matcherMap, matcher: matcher,
 			dev:         internal.BlockDevice{PartLabel: "BIOS"},
+			expectMatch: false,
+		},
+		{
+			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{PartLabel: "boot"},
+			expectMatch: false,
+		},
+		{
+			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{PartLabel: "BOOT"},
 			expectMatch: false,
 		},
 	}
@@ -271,12 +281,6 @@ func TestInSizeRange(t *testing.T) {
 			spec:        &localv1alpha1.DeviceInclusionSpec{},
 			expectMatch: true, expectErr: false,
 		},
-		{
-			matcherMap: matcherMap, matcher: matcher,
-			dev:         internal.BlockDevice{Size: fmt.Sprintf("%v", 10000*Ki)},
-			spec:        &localv1alpha1.DeviceInclusionSpec{},
-			expectMatch: true, expectErr: false,
-		},
 		// violate min
 		// barely
 		{
@@ -311,6 +315,25 @@ func TestInSizeRange(t *testing.T) {
 			dev:         internal.BlockDevice{Size: "foo"},
 			spec:        &localv1alpha1.DeviceInclusionSpec{MinSize: &tenGi, MaxSize: &fiftyGi},
 			expectMatch: false, expectErr: true,
+		},
+		// default minSize
+		{
+			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{Size: fmt.Sprintf("%v", .9*Gi)},
+			spec:        &localv1alpha1.DeviceInclusionSpec{},
+			expectMatch: false, expectErr: false,
+		},
+		{
+			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{Size: fmt.Sprintf("%v", 1.1*Gi)},
+			spec:        &localv1alpha1.DeviceInclusionSpec{},
+			expectMatch: true, expectErr: false,
+		},
+		{
+			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{Size: fmt.Sprintf("%v", .9*Gi)},
+			spec:        &localv1alpha1.DeviceInclusionSpec{MaxSize: &fiftyGi},
+			expectMatch: false, expectErr: false,
 		},
 	}
 	assertAll(t, results)

--- a/pkg/diskmaker/discovery/discovery.go
+++ b/pkg/diskmaker/discovery/discovery.go
@@ -229,12 +229,12 @@ func getDeviceStatus(dev internal.BlockDevice) v1alpha1.DeviceStatus {
 		return status
 	}
 
-	noBiosInPartLabel, err := lvset.FilterMap["noBiosInPartLabel"](dev, nil)
+	noBiosBootInPartLabel, err := lvset.FilterMap["noBiosBootInPartLabel"](dev, nil)
 	if err != nil {
 		status.State = v1alpha1.Unknown
 		return status
 	}
-	if !noBiosInPartLabel {
+	if !noBiosBootInPartLabel {
 		klog.Infof("device %q with part label %q is not available", dev.Name, dev.PartLabel)
 		status.State = v1alpha1.NotAvailable
 		return status


### PR DESCRIPTION
LocalVolumeSet doesn't cover all the possible cases to ignore boot devices and hence create
PVs on them. This PR keeps default minSize to 1Gi so that boot devices can be ignored. User can override the minSize value from the CR. Also ignore device where partlabel contains substring "boot"

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1897050

Signed-off-by: Santosh Pillai <sapillai@redhat.com>