### PR TITLE
Bug 1917315: delete localvolumeset-local-provisoner daemonset and fix PV name hashing

### DIFF
--- a/pkg/controller/nodedaemon/reconcile.go
+++ b/pkg/controller/nodedaemon/reconcile.go
@@ -1,8 +1,17 @@
 package nodedaemon
 
 import (
+	"context"
+	"fmt"
+	"time"
+
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,9 +37,10 @@ var _ reconcile.Reconciler = &DaemonReconciler{}
 type DaemonReconciler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client    client.Client
-	scheme    *runtime.Scheme
-	reqLogger logr.Logger
+	client                   client.Client
+	scheme                   *runtime.Scheme
+	reqLogger                logr.Logger
+	deletedStaticProvisioner bool
 }
 
 // Reconcile reads that state of the cluster for a LocalVolumeSet object and makes changes based on the state read
@@ -40,6 +50,12 @@ type DaemonReconciler struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *DaemonReconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	r.reqLogger = logf.Log.WithName(controllerName).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	// do a one-time delete of the old static-provisioner daemonset
+	err := r.cleanupOldDaemonsets(request.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	lvSets, tolerations, ownerRefs, nodeSelector, err := r.aggregateDeamonInfo(request)
 	if err != nil {
@@ -67,5 +83,51 @@ func (r *DaemonReconciler) Reconcile(request reconcile.Request) (reconcile.Resul
 		r.reqLogger.Info("daemonset changed", "daemonset.Name", ds.GetName(), "op.Result", opResult)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, err
+}
+
+// do a one-time delete of the old static-provisioner daemonset
+func (r *DaemonReconciler) cleanupOldDaemonsets(namespace string) error {
+	if r.deletedStaticProvisioner {
+		return nil
+	}
+	provisioner := &appsv1.DaemonSet{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: ProvisionerName, Namespace: namespace}, provisioner)
+	if err == nil { // provisioner daemonset found
+		r.reqLogger.Info(fmt.Sprintf("old daemonset %q found, cleaning up", ProvisionerName))
+		err = r.client.Delete(context.TODO(), provisioner)
+		if err != nil && !errors.IsGone(err) {
+			r.reqLogger.Error(err, fmt.Sprintf("could not delete daemonset %q", ProvisionerName))
+			return err
+		}
+	} else if !errors.IsNotFound(err) { // unknown error
+		r.reqLogger.Error(err, fmt.Sprintf("could not fetch daemonset %q to clean it up", ProvisionerName))
+		return err
+	}
+
+	// wait for pods to die
+	err = wait.ExponentialBackoff(wait.Backoff{
+		Cap:      time.Minute * 2,
+		Duration: time.Second,
+		Factor:   1.7,
+		Jitter:   1,
+		Steps:    20,
+	}, func() (done bool, err error) {
+		podList := &corev1.PodList{}
+		allGone := false
+		err = r.client.List(context.TODO(), podList, client.MatchingLabels{"app": ProvisionerName})
+		if err != nil && !errors.IsNotFound(err) {
+			return false, err
+		} else if len(podList.Items) == 0 {
+			allGone = true
+		}
+		r.reqLogger.Info(fmt.Sprintf("waiting for 0 pods with label app : %q", ProvisionerName), "numberFound", len(podList.Items))
+		return allGone, nil
+	})
+	if err != nil {
+		r.reqLogger.Error(err, "could not determine that old provisioner pods were deleted")
+		return err
+	}
+	r.deletedStaticProvisioner = true
+	return nil
 }

--- a/pkg/diskmaker/controllers/lvset/create_pv.go
+++ b/pkg/diskmaker/controllers/lvset/create_pv.go
@@ -33,7 +33,7 @@ func (r *ReconcileLocalVolumeSet) createPV(
 		return fmt.Errorf("could node find label %q for node %q", corev1.LabelHostname, r.runtimeConfig.Node.GetName())
 	}
 
-	pvName := generatePVName(symLinkPath, r.runtimeConfig.Node.GetName(), storageClass.GetName())
+	pvName := generatePVName(filepath.Base(symLinkPath), r.runtimeConfig.Node.Name, storageClass.Name)
 
 	pvLogger := devLogger.WithValues("pv.Name", pvName)
 

--- a/pkg/diskmaker/controllers/lvset/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lvset/create_pv_test.go
@@ -3,6 +3,7 @@ package lvset
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -238,7 +239,7 @@ func TestCreatePV(t *testing.T) {
 			return
 		}
 		pv := &corev1.PersistentVolume{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{Name: generatePVName(tc.symlinkpath, tc.node.GetName(), tc.sc.GetName())}, pv)
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: generatePVName(filepath.Base(tc.symlinkpath), tc.node.GetName(), tc.sc.GetName())}, pv)
 
 		// capacity accurate
 		pvCapacity, found := pv.Spec.Capacity["storage"]
@@ -248,7 +249,7 @@ func TestCreatePV(t *testing.T) {
 		assert.Truef(t, pvCapacity.Equal(expectedCapacity), "actual: %s,expected: %s", pvCapacity, expectedCapacity)
 
 		// pvName accurate
-		assert.Equal(t, generatePVName(tc.symlinkpath, tc.node.Name, tc.sc.Name), pv.Name)
+		assert.Equal(t, generatePVName(filepath.Base(tc.symlinkpath), tc.node.Name, tc.sc.Name), pv.Name)
 
 		// symlinkPath accurate
 		assert.NotNil(t, pv.Spec.Local)


### PR DESCRIPTION
- Fix: PV hashing had a slight difference causing duplicate PVs (full path was being hashed as opposed to only file name in 4.6)
- Perform a one-time cleanup of the old daemonset if it exists.