### PR TITLE
Bug 1937244: remove leading and trailing whitespaces in lsblk output

### DIFF
--- a/pkg/internal/diskutil.go
+++ b/pkg/internal/diskutil.go
@@ -236,7 +236,7 @@ func ListBlockDevices() ([]BlockDevice, []string, error) {
 			}
 			key := strings.ToLower(keyValueList[0])
 			value := strings.Replace(keyValueList[1], `"`, "", -1)
-			outputMap[key] = value
+			outputMap[key] = strings.TrimSpace(value)
 		}
 
 		// only use device if name is populated, and non-empty

--- a/pkg/internal/diskutil_test.go
+++ b/pkg/internal/diskutil_test.go
@@ -142,6 +142,19 @@ func TestListBlockDevices(t *testing.T) {
 			totalBadRows:      0,
 			expected:          []BlockDevice{},
 		},
+		{
+			label:             "Case 4: lsblk output with white space",
+			lsblkOutput:       `NAME="sda" MODEL="VBOX HARDDISK   " VENDOR="ATA   "`,
+			totalBlockDevices: 1,
+			totalBadRows:      0,
+			expected: []BlockDevice{
+				{
+					Name:   "sda",
+					Model:  "VBOX HARDDISK",
+					Vendor: "ATA",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
using strings.Trimspace() on all `lsblk` outputs to prevent showing local volume discovery with whitespaces.  For example, the `model` in the below discovery results shows whitespace.

```
 deviceID: /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol0aae98a99ce01086e
    fstype: ""
    model: 'Amazon Elastic Block Store              '
    path: /dev/nvme1n1
    property: NonRotational
    serial: vol0aae98a99ce01086e
    size: 2147483648
    status:
      state: Available
    type: disk
    vendor: ""
  discoveredTimeStamp: "2021-03-10T01:39:50Z"
```
fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1937244

Signed-off-by: Santosh Pillai <sapillai@redhat.com>