### PR TITLE
Updates must-gather Dockerfiles to be more easily built for quay mirroring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 RUN make build-operator
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM registry.ci.openshift.org/ocp/4.8:base
 COPY --from=builder /go/src/github.com/openshift/local-storage-operator/_output/bin/local-storage-operator /usr/bin/
 COPY manifests /manifests
 ENTRYPOINT ["/usr/bin/local-storage-operator"]

--- a/Dockerfile.diskmaker
+++ b/Dockerfile.diskmaker
@@ -1,15 +1,17 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
 WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 RUN make build-diskmaker
 
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 
+FROM registry.ci.openshift.org/ocp/4.8:base
 
-COPY manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/local-storage-operator/_output/bin/diskmaker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/local-storage-operator/deploy/scripts /scripts
+COPY manifests /manifests
 
- ENTRYPOINT ["/usr/bin/diskmaker"]
+RUN yum install -y e2fsprogs xfsprogs && yum clean all && rm -rf /var/cache/yum
+
+ENTRYPOINT ["/usr/bin/diskmaker"]
 LABEL io.k8s.display-name="OpenShift local storage diskmaker" \
       io.k8s.description="This is a component of OpenShift and manages local disks." \
-        maintainer="Hemant Kumar <hekumar@redhat.com>"registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+        maintainer="Hemant Kumar <hekumar@redhat.com>"

--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,10 +1,9 @@
-FROM registry.ci.openshift.org/ocp/4.8:must-gather AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
+WORKDIR /go/src/github.com/openshift/local-storage-operator/must-gather
+COPY . .
 
-FROM registry.ci.openshift.org/ocp/4.8:cli
-
-RUN microdnf -y install rsync
-
-COPY --from=builder /usr/bin/oc /usr/bin/oc
-COPY must-gather/* /usr/bin/
+FROM registry.ci.openshift.org/ocp/4.8:must-gather
+COPY --from=builder /go/src/github.com/openshift/local-storage-operator/must-gather/* /usr/bin/
+RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather

--- a/Dockerfile.mustgather.rhel7
+++ b/Dockerfile.mustgather.rhel7
@@ -1,10 +1,9 @@
-FROM quay.io/openshift/origin-must-gather:4.5.0 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
+WORKDIR /go/src/github.com/openshift/local-storage-operator/must-gather
+COPY . .
 
-FROM registry.access.redhat.com/ubi8-minimal:latest
-
-RUN microdnf -y install rsync
-
-COPY --from=builder /usr/bin/oc /usr/bin/oc
-COPY must-gather/* /usr/bin/
+FROM registry.ci.openshift.org/ocp/4.8:must-gather
+COPY --from=builder /go/src/github.com/openshift/local-storage-operator/must-gather/* /usr/bin/
+RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
Updates must-gather Dockerfiles to be more easily built for quay mirroring. There have been issues with mirroring the must-gather image to quay.io due to the current Dockerfiles. These changes allow the must-gather images to more closely mirror the OCS must-gather images, and should allow them to be mirrored to quay without issue.