### PR TITLE
Corrects the WORKDIR of the must-gather image

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
-WORKDIR /go/src/github.com/openshift/local-storage-operator/must-gather
+WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 
 FROM registry.ci.openshift.org/ocp/4.8:must-gather

--- a/Dockerfile.mustgather.rhel7
+++ b/Dockerfile.mustgather.rhel7
@@ -1,5 +1,5 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.8 AS builder
-WORKDIR /go/src/github.com/openshift/local-storage-operator/must-gather
+WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 
 FROM registry.ci.openshift.org/ocp/4.8:must-gather


### PR DESCRIPTION
I've removed the trailing `/must-gather` in the WORKDIR for the must-gather image.

@yselkowitz ,

Would you mind reviewing this? I'm a little confused, as this doesn't seem to affect my local builds and testing. I can see the `gather` binary included and executable with and without this change whenever I build it locally.