### PR TITLE
Add management workload annotations

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -10,6 +10,8 @@ spec:
       name: local-storage-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: local-storage-operator
     spec:

--- a/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
@@ -299,6 +299,8 @@ spec:
                 name: local-storage-operator
             template:
               metadata:
+                annotations:
+                  workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   name: local-storage-operator
               spec:

--- a/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
+++ b/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
@@ -299,6 +299,8 @@ spec:
                 name: local-storage-operator
             template:
               metadata:
+                annotations:
+                  workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   name: local-storage-operator
               spec:

--- a/pkg/controller/nodedaemon/daemonsets.go
+++ b/pkg/controller/nodedaemon/daemonsets.go
@@ -176,6 +176,10 @@ func MutateAggregatedSpec(
 		ds.Spec.Template.ObjectMeta.Labels[key] = value
 	}
 
+	// add management workload annotations
+	initMapIfNil(&ds.Spec.Template.ObjectMeta.Annotations)
+	ds.Spec.Template.ObjectMeta.Annotations["workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
+
 	// ownerRefs
 	ds.ObjectMeta.OwnerReferences = ownerRefs
 


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.