### PR TITLE
Rename workload annotations

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: local-storage-operator
     spec:

--- a/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
@@ -300,7 +300,7 @@ spec:
             template:
               metadata:
                 annotations:
-                  workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   name: local-storage-operator
               spec:

--- a/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
+++ b/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
@@ -300,7 +300,7 @@ spec:
             template:
               metadata:
                 annotations:
-                  workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                  target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   name: local-storage-operator
               spec:

--- a/pkg/controller/nodedaemon/daemonsets.go
+++ b/pkg/controller/nodedaemon/daemonsets.go
@@ -178,7 +178,7 @@ func MutateAggregatedSpec(
 
 	// add management workload annotations
 	initMapIfNil(&ds.Spec.Template.ObjectMeta.Annotations)
-	ds.Spec.Template.ObjectMeta.Annotations["workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
+	ds.Spec.Template.ObjectMeta.Annotations["target.workload.openshift.io/management"] = `{"effect": "PreferredDuringScheduling"}`
 
 	// ownerRefs
 	ds.ObjectMeta.OwnerReferences = ownerRefs


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please