### PR TITLE
Bug 1961942: use /disk/by-id name as symlink name

### DIFF
--- a/pkg/diskmaker/event_reporter.go
+++ b/pkg/diskmaker/event_reporter.go
@@ -16,6 +16,7 @@ const (
 	ErrorListingDeviceID     = "ErrorListingDeviceID"
 	ErrorFindingMatchingDisk = "ErrorFindingMatchingDisk"
 	ErrorCreatingSymLink     = "ErrorCreatingSymLink"
+	SymLinkedOnDeviceName    = "SymlinkedOnDeivceName"
 
 	FoundMatchingDisk   = "FoundMatchingDisk"
 	DeviceSymlinkExists = "DeviceSymlinkExists"


### PR DESCRIPTION
If the device provided in the `devicePaths` list in the localVolume CR has `/dev/disk/by-id`, then use the `id` name to create symlink in `/mnt/local-storage/<storageClassName>` directory. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>
(cherry picked from commit 7b64dc238138a1fe54f864df211fdf5eca96ed14)

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1955862


Tests:

1. Localvolume CR 

```
  storageClassDevices:
    - storageClassName: "test"
      volumeMode: Filesystem
      fsType: ext4
      devicePaths:
        - /dev/sdb
        - /dev/sdc
        - /dev/sdd
```

2. `/dev/sdd` has no diskID, where as , `/dev/sdb` and `/dev/sdc` have diskID in `/dev/disk/by-id`

```
$ ls -lR /dev/disk

/dev/disk/by-id:
total 0
lrwxrwxrwx 1 root root  9 May 17 06:54 ata-VBOX_CD-ROM_VB0-1a2b3c4d__ -> ../../sr0
lrwxrwxrwx 1 root root  9 May 17 06:55 ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93 -> ../../sdb
lrwxrwxrwx 1 root root  9 May 17 06:54 ata-VBOX_HARDDISK_____VBc80535a7-0f341983 -> ../../sda
lrwxrwxrwx 1 root root 10 May 17 06:54 ata-VBOX_HARDDISK_____VBc80535a7-0f341983-part1 -> ../../sda1
lrwxrwxrwx 1 root root  9 May 17 06:59 ata-VBOX_HARDDISK_____VBd77b4088-cdd82838 -> ../../sd
```

3. Observe that `/dev/sdb` and `/dev/sdc` symlinks are created via their `/dev/disk/by-id` and with the same name. 
Where as `/dev/sdd` symlink is created with name `sdd`

```
$ ls /mnt/local-storage/test/
ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93  ata-VBOX_HARDDISK_____VBd77b4088-cdd82838  sdd
$ 
```

```
$ ls -lR /mnt/local-storage/test/
/mnt/local-storage/test/:
total 0
lrwxrwxrwx 1 root root 57 May 17 07:03 ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93 -> /dev/disk/by-id/ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93
lrwxrwxrwx 1 root root 57 May 17 07:03 ata-VBOX_HARDDISK_____VBd77b4088-cdd82838 -> /dev/disk/by-id/ata-VBOX_HARDDISK_____VBd77b4088-cdd82838
lrwxrwxrwx 1 root root  8 May 17 07:03 sdd -> /dev/sdd
$ 

```


**Upgrade Tests**

1. Before upgrade:

- have following disks
/sdb -- has disk/id -- ata-VBOX_HARDDISK_____VB3ec86ebf-ed3a5a93 
/sdc -- no dev disk by id

- localvolume CR:
```
  storageClassDevices:
    - storageClassName: "test"
      volumeMode: Filesystem
      fsType: ext4
      devicePaths:
        - /dev/sdb
        - /dev/sdc
        #- /dev/sdd
```

- Symlinks created:
```
$ cd /mnt/local-storage/test/
$ ls
sdb  sdc
```

- PVs created:
```
Every 2.0s: oc get pv                                                  localhost.localdomain: Wed May 19 11:01:48 2021

NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
local-pv-a36f27f9   8Gi        RWO            Delete           Available           test                    11m
local-pv-d00d358a   10Gi       RWO            Delete           Available           test                    11m

```

2. After upgrading:

- added a new disk(sdd) with /dev/disk/by-id

- added the disk in the local volume CR and applied it.
 
```
    storageClassDevices:
    - storageClassName: "test"
      volumeMode: Filesystem
      fsType: ext4
      devicePaths:
        - /dev/sdb
        - /dev/sdc
        - /dev/sdd
```

- Only one new symlink was created for /dev/sdd. This symlink was based on ID.  New symlinks were not created for /sda and /sdc
```
$ ls /mnt/local-storage/test/
ata-VBOX_HARDDISK_____VB6c3ba355-dac989e6  sdb	sdc
$ 
```

- One new PV was created: 

```
Every 2.0s: oc get pv                                                  localhost.localdomain: Wed May 19 11:05:23 2021

NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
local-pv-a36f27f9   8Gi        RWO            Delete           Available           test                    15m
local-pv-d00d358a   10Gi       RWO            Delete           Available           test                    15m
local-pv-dad1b103   10Gi       RWO            Delete           Available           test                    2m1s
```
