### PR TITLE
Bug 1961120: added permissions to service monitoring

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -59,6 +59,9 @@ rules:
   - list
   - watch
   - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apps
   resourceNames:

--- a/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
@@ -189,6 +189,9 @@ spec:
             - list
             - watch
             - create
+            - update
+            - patch
+            - delete
           - apiGroups:
             - apps
             resourceNames:


### PR DESCRIPTION
This PR added permissions to operators service monitoring, allowing cluster version upgrade.

Currently the operators has `create` permission. When upgrading the cluster, it needs permission to `update` the service role.