### PR TITLE
Bug 1966561: add OLM bug workaround for workload partitioning

### DIFF
--- a/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
@@ -102,6 +102,10 @@ metadata:
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.8.0"
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported

--- a/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
+++ b/opm-bundle/manifests/local-storage-operator.clusterserviceversion.yaml
@@ -102,6 +102,10 @@ metadata:
       OpenShift 4.2 and above is only supported OpenShift versions.
     olm.skipRange: ">=4.3.0 <4.8.0"
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
+    # This annotation injection is a workaround for BZ-1950047, since the associated
+    # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
+    # TODO: remove the next line after BZ-1950047 is resolved.
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported


### PR DESCRIPTION
PR #230 added annotations
required for supporting the workload partitioning feature for ocp 4.8.
However, OLM has a bug in processing the annotations (BZ 1950047).
This PR provides a workaround necessary to release the workload
partitioning in OCP 4.8.