### PR TITLE
diskmaker: discovery: fix typo in warning message

### DIFF
--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -169,7 +169,7 @@ func getDiscoverdDevices(blockDevices []internal.BlockDevice) []v1alpha1.Discove
 	for _, blockDevice := range blockDevices {
 		deviceID, err := blockDevice.GetPathByID()
 		if err != nil {
-			klog.Warningf("failed to get persisent ID for the device %q. Error %v", blockDevice.Name, err)
+			klog.Warningf("failed to get persistent ID for the device %q. Error %v", blockDevice.Name, err)
 			deviceID = ""
 		}
 


### PR DESCRIPTION
s/persisent/persistent

Signed-off-by: Julian Wiedmann <jwi@linux.ibm.com>