### PR TITLE
Bug 1971231: Fix released PVs not getting cleaned up (backport)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -984,7 +984,6 @@ k8s.io/sample-apiserver v0.0.0-20191016112829-06bb3c9d77c9/go.mod h1:sXltHZrQa4j
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191010214722-8d271d903fe4/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20191114184206-e782cd3c129f h1:GiPwtSzdP43eI1hpPCbROQCCIgCuiMMNF8YUVLF3vJo=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTUt3aVoBpi2DqRsU=
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/diskmaker/controllers/lvset/add.go
+++ b/pkg/diskmaker/controllers/lvset/add.go
@@ -2,7 +2,6 @@ package lvset
 
 import (
 	"fmt"
-	"time"
 
 	localv1alpha1 "github.com/openshift/local-storage-operator/pkg/apis/local/v1alpha1"
 	"github.com/openshift/local-storage-operator/pkg/common"
@@ -146,15 +145,11 @@ func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.Persiste
 	if !found {
 		return
 	}
-	ownerNamespace, found := pv.Labels[common.PVOwnerNameLabel]
+	ownerNamespace, found := pv.Labels[common.PVOwnerNamespaceLabel]
 	if !found {
 		return
 	}
 	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ownerName, Namespace: ownerNamespace}})
-	if isDelete {
-		time.Sleep(time.Second * 10)
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ownerName, Namespace: ownerNamespace}})
-	}
 }
 
 // blank assignment to verify that ReconcileLocalVolumeSet implements reconcile.Reconciler

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -128,6 +128,10 @@ func (r *ReconcileLocalVolumeSet) Reconcile(request reconcile.Request) (reconcil
 	}
 	symLinkDir := symLinkConfig.HostDir
 
+	// cleanup released PVs
+	// this function will be run once more after provisioning as the first run does the cleanup and the second run does the deletion
+	r.deleter.DeletePVs()
+
 	// list block devices
 	blockDevices, badRows, err := internal.ListBlockDevices()
 	if err != nil {
@@ -201,6 +205,8 @@ func (r *ReconcileLocalVolumeSet) Reconcile(request reconcile.Request) (reconcil
 		reqLogger.Info("found stale symLink Entries", "storageClass.Name", storageClassName, "paths.List", noMatch, "directory", symLinkDir)
 	}
 
+	// cleanup released PVs
+	// run once before provisioning too as the first run does the cleanup and the second run does the deletion
 	r.deleter.DeletePVs()
 
 	// shorten the requeueTime if there are delayed devices


### PR DESCRIPTION
The event handler for the queuing logic was enqueueing the name
as the namespace, so PV events were being missed. Also, the deleter
has to be called twice per cleanup.
