### PR TITLE
make LSO work on non-openshift clusters

### DIFF
--- a/assets/templates/localmetrics/service-monitor.yaml
+++ b/assets/templates/localmetrics/service-monitor.yaml
@@ -16,8 +16,3 @@ spec:
   - port: metrics
     path: /metrics
     interval: 1m
-    scheme: https
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: lso-metrics-exporter.openshift-local-storage.svc

--- a/assets/templates/localmetrics/service.yaml
+++ b/assets/templates/localmetrics/service.yaml
@@ -1,8 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: lso-metrics-serving-cert
   name: lso-metrics-exporter
   namespace: openshift-local-storage
   labels:
@@ -13,6 +11,6 @@ spec:
   - name: metrics
     port: 8383
     protocol: TCP
-    targetPort: metrics
+    targetPort: 8383
   selector:
     app: lso-metrics-exporter

--- a/common/daemonsets_utils.go
+++ b/common/daemonsets_utils.go
@@ -26,7 +26,7 @@ func KubeProxySideCar() corev1.Container {
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: int32(9393),
-				Name:          "metrics",
+				Name:          KubeRBACProxyPortName,
 				Protocol:      corev1.ProtocolTCP,
 			},
 		},

--- a/common/names.go
+++ b/common/names.go
@@ -53,6 +53,10 @@ const (
 	// LocalVolumeProtectionFinalizer is set to ensure the provisioner daemonset and owning object stick around long
 	// enough to handle the PV reclaim policy.
 	LocalVolumeProtectionFinalizer = "storage.openshift.com/local-volume-protection"
+
+	KubeRBACProxyPortName = "metrics"
+
+	OpenshiftServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 // GetDiskMakerImage returns the image to be used for diskmaker daemonset

--- a/config/manifests/4.9/local-storage-operator.v4.9.0.clusterserviceversion.yaml
+++ b/config/manifests/4.9/local-storage-operator.v4.9.0.clusterserviceversion.yaml
@@ -366,6 +366,8 @@ spec:
                         value: quay.io/openshift/origin-kube-rbac-proxy:latest
                       - name: PRIORITY_CLASS_NAME
                         value: openshift-user-critical
+                      - name: SECURE_METRICS_ENDPOINT
+                        value: "true"
   customresourcedefinitions:
     owned:
       - displayName: Local Volume

--- a/controllers/nodedaemon/daemonsets.go
+++ b/controllers/nodedaemon/daemonsets.go
@@ -63,6 +63,7 @@ func getDiskMakerDSMutateFn(
 	ownerRefs []metav1.OwnerReference,
 	nodeSelector *corev1.NodeSelector,
 	dataHash string,
+	secureMetricsEndpoint bool,
 ) func(*appsv1.DaemonSet) error {
 
 	return func(ds *appsv1.DaemonSet) error {
@@ -93,9 +94,11 @@ func getDiskMakerDSMutateFn(
 		initMapIfNil(&ds.ObjectMeta.Annotations)
 		ds.ObjectMeta.Annotations[dataHashAnnotationKey] = dataHash
 
-		//Add kube-rbac-proxy sidecar container to provide https proxy for http-based lso metrics.
-		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, common.KubeProxySideCar())
-		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, common.DiskmakerMetricsCertVolume)
+		if secureMetricsEndpoint {
+			//Add kube-rbac-proxy sidecar container to provide https proxy for http-based lso metrics.
+			ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, common.KubeProxySideCar())
+			ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, common.DiskmakerMetricsCertVolume)
+		}
 
 		return nil
 	}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -103,6 +104,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	secureMetricsEndpoint := false
+	if os.Getenv("SECURE_METRICS_ENDPOINT") == "true" {
+		secureMetricsEndpoint = true
+	}
+
 	if err = (&lvcontroller.LocalVolumeReconciler{
 		Client: mgr.GetClient(),
 		//	Log:    ctrl.Log.WithName("controllers").WithName("LocalVolume"),
@@ -116,7 +122,8 @@ func main() {
 		Client:    mgr.GetClient(),
 		ReqLogger: logf.Log.WithName("controllers").WithName("LocalVolumeDiscovery"),
 		//	Log:    ctrl.Log.WithName("controllers").WithName("LocalVolumeDiscovery"),
-		Scheme: mgr.GetScheme(),
+		Scheme:                mgr.GetScheme(),
+		SecureMetricsEndpoint: secureMetricsEndpoint,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LocalVolumeDiscovery")
 		os.Exit(1)
@@ -136,7 +143,8 @@ func main() {
 		Client:    mgr.GetClient(),
 		ReqLogger: logf.Log.WithName("controllers").WithName("NodeDaemon"),
 		//	Log:    ctrl.Log.WithName("controllers").WithName("LocalVolumeSet"),
-		Scheme: mgr.GetScheme(),
+		Scheme:                mgr.GetScheme(),
+		SecureMetricsEndpoint: secureMetricsEndpoint,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LocalVolumeSet")
 		os.Exit(1)


### PR DESCRIPTION
Following changes don't LSO to be deployed on vanila K8s.
1. Use of `kube-proxy-sidcar` to secure custom metrics endpoint
2. Use of service monitor. 

This PR 
- adds `service.beta.openshift.io/serving-cert-secret-name` annotation to daemonset service if `SECURE_METRICS_ENDPOINT` env is true
- adds kube-rbac-proxy sidecar container to lso daemonsets if `SECURE_METRICS_ENDPOINT` is true


This should help users to deploy LSO in non openshift environments as well. But they would still need Prometheus to create servicemonitors. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>