### PR TITLE
Bug 1993973 : fix lso_lvset_provisioned_PV_count for multiple lvset

### DIFF
--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -175,6 +175,9 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 		var currentDeviceSymlinked bool
 		alreadyProvisionedCount, currentDeviceSymlinked, noMatch, err = getAlreadySymlinked(symLinkDir, blockDevice, blockDevices)
 		_ = currentDeviceSymlinked
+
+		totalProvisionedPVs = alreadyProvisionedCount
+
 		if err != nil && lvset.Spec.MaxDeviceCount != nil {
 			r.eventReporter.Report(lvset, newDiskEvent(ErrorListingExistingSymlinks, "error determining already provisioned disks", "", corev1.EventTypeWarning))
 			return ctrl.Result{}, fmt.Errorf("could not determine how many devices are already provisioned: %w", err)
@@ -200,9 +203,8 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 			r.eventReporter.Report(lvset, newDiskEvent(diskmaker.ErrorProvisioningDisk, "provisioning failed", blockDevice.KName, corev1.EventTypeWarning))
 			return ctrl.Result{}, fmt.Errorf("could not provision disk: %w", err)
 		}
-		devLogger.Info("provisioning succeeded")
 
-		totalProvisionedPVs += 1
+		devLogger.Info("provisioning succeeded")
 	}
 
 	reqLogger.Info("total devices provisioned", "count", totalProvisionedPVs, "storageClass.Name", storageClassName)


### PR DESCRIPTION
When multiple lvsets are created, lso_lvset_provisioned_PV_count metric uses the same value across all the storage classes.
This PR fixes this issue.

Tests:

- Total PVs provisioned: 
``` 
kubectl get pv
NAME               CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
local-pv-8ec5067   10Gi       RWO            Delete           Available           lvs1                    11m
```

- Updated metrics:
```
sh-4.4# curl http://0.0.0.0:8383/metrics | grep lso_lvset_provisioned_PV_count{
lso_lvset_provisioned_PV_count{nodeName="minikube",storageClass="lvs1"} 1
lso_lvset_provisioned_PV_count{nodeName="minikube",storageClass="lvs2"} 0
```

Adding more disks:

- Total Pvs provisioned:
```
Every 2.0s: kubectl get pv                                              localhost.localdomain: Thu Aug 19 11:24:38 2021

NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
local-pv-39e0831d   8Gi        RWO            Delete           Available           lvs2                    6m41s
local-pv-7ab9d76b   9Gi        RWO            Delete           Available           lvs2                    39s
local-pv-8ec5067    10Gi       RWO            Delete           Available           lvs1                    24m
```

- Updated metrics:
```
sh-4.4# curl http://0.0.0.0:8383/metrics | grep lso_lvset_provisioned_PV_count
# HELP lso_lvset_provisioned_PV_count Total persistent volumes provisioned by the Local Volume Set controller per node
# TYPE lso_lvset_provisioned_PV_count gauge
lso_lvset_provisioned_PV_count{nodeName="minikube",storageClass="lvs1"} 1
lso_lvset_provisioned_PV_count{nodeName="minikube",storageClass="lvs2"} 2
```


Signed-off-by: Santosh Pillai <sapillai@redhat.com>