### PR TITLE
Modified LocalVolumeSet controller to delete unexpected StorageClasses

### DIFF
--- a/controllers/localvolumeset/finalizer.go
+++ b/controllers/localvolumeset/finalizer.go
@@ -7,42 +7,50 @@ import (
 	localv1alpha1 "github.com/openshift/local-storage-operator/api/v1alpha1"
 	"github.com/openshift/local-storage-operator/common"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *LocalVolumeSetReconciler) syncFinalizer(lvSet localv1alpha1.LocalVolumeSet) error {
+func (r *LocalVolumeSetReconciler) cleanupLocalVolumeSetDeployment(ctx context.Context, lvSet localv1alpha1.LocalVolumeSet) error {
 	lvSetExisting := &localv1alpha1.LocalVolumeSet{}
 	lvSet.DeepCopyInto(lvSetExisting)
-	// finalizer should exist and be removed only when deleting
-	setFinalizer := true
 
-	// handle deletion
-	if !lvSet.DeletionTimestamp.IsZero() {
-		r.Log.Info("deletionTimeStamp found, waiting for 0 bound PVs")
-		// if obect is deleted, finalizer should be unset only when no boundPVs are found
-		boundPVs, releasedPVs, err := common.GetBoundAndReleasedPVs(&lvSet, r.Client)
-		if err != nil {
-			return fmt.Errorf("could not list bound PVs: %w", err)
-		}
-
-		// if we add support for other reclaimPolicy's we can avoid appending releasedPVs here only bound PVs
-		pendingPVs := append(boundPVs, releasedPVs...)
-		if len(pendingPVs) == 0 {
-			setFinalizer = false
-			r.Log.Info("no bound/released PVs found, removing finalizer")
-		} else {
-			pvNames := ""
-			for i, pv := range pendingPVs {
-				pvNames += fmt.Sprintf(" %v", pv.Name)
-				// only print up to 10 PV names
-				if i >= 9 {
-					pvNames += "..."
-					break
-				}
-			}
-			r.Log.Info("bound/released PVs found, not removing finalizer", "pvNames", pvNames)
-		}
+	r.Log.Info("deletionTimeStamp found, waiting for 0 bound PVs")
+	// if obect is deleted, finalizer should be unset only when no boundPVs are found
+	boundPVs, releasedPVs, err := common.GetBoundAndReleasedPVs(&lvSet, r.Client)
+	if err != nil {
+		return fmt.Errorf("could not list bound PVs: %w", err)
 	}
+
+	// if we add support for other reclaimPolicy's we can avoid appending releasedPVs here only bound PVs
+	pendingPVs := append(boundPVs, releasedPVs...)
+	if len(pendingPVs) == 0 {
+		err := r.removeUnExpectedStorageClasses(ctx, &lvSet, sets.NewString())
+		if err != nil {
+			return err
+		}
+		r.Log.Info("no bound/released PVs found, removing finalizer")
+		err = r.syncFinalizer(ctx, lvSet, !setFinalizer)
+	} else {
+		pvNames := ""
+		for i, pv := range pendingPVs {
+			pvNames += fmt.Sprintf(" %v", pv.Name)
+			// only print up to 10 PV names
+			if i >= 9 {
+				pvNames += "..."
+				break
+			}
+		}
+		r.Log.Info("bound/released PVs found, not removing finalizer", "pvNames", pvNames)
+		err = r.syncFinalizer(ctx, lvSet, setFinalizer)
+	}
+
+	return err
+
+}
+func (r *LocalVolumeSetReconciler) syncFinalizer(ctx context.Context, lvSet localv1alpha1.LocalVolumeSet, setFinalizer bool) error {
+	lvSetExisting := &localv1alpha1.LocalVolumeSet{}
+	lvSet.DeepCopyInto(lvSetExisting)
 
 	if setFinalizer {
 		controllerutil.AddFinalizer(&lvSet, common.LocalVolumeProtectionFinalizer)
@@ -52,7 +60,7 @@ func (r *LocalVolumeSetReconciler) syncFinalizer(lvSet localv1alpha1.LocalVolume
 
 	// update finalizer in lvset and make client call only if the value changed
 	if !equality.Semantic.DeepEqual(lvSetExisting, lvSet) {
-		return r.Client.Update(context.TODO(), &lvSet)
+		return r.Client.Update(ctx, &lvSet)
 	}
 
 	return nil


### PR DESCRIPTION
While deleting LVSet, the StorageClass should also be deleted, to unify with the behaviour of LV deletion.
This PR makes sure that while deleting LVSet, StorageClass is also deleted.

Also added some e2e tests for verification.

Signed off by: Priyanka Jiandani <pjiandan@rdhat.com>