### PR TITLE
Bug 1995653: Update RBAC api to v1 from v1beta1

### DIFF
--- a/config/manifests/4.9/prometheus-role-binding.yaml
+++ b/config/manifests/4.9/prometheus-role-binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
   namespace: openshift-local-storage

--- a/config/manifests/4.9/prometheus-role.yaml
+++ b/config/manifests/4.9/prometheus-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
   namespace: openshift-local-storage

--- a/config/rbac/diskmaker/role_binding.yaml
+++ b/config/rbac/diskmaker/role_binding.yaml
@@ -1,6 +1,6 @@
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-admin
 subjects:

--- a/config/rbac/monitoring/prometheus_role.yaml
+++ b/config/rbac/monitoring/prometheus_role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
   namespace: openshift-local-storage

--- a/config/rbac/monitoring/prometheus_role_binding.yaml
+++ b/config/rbac/monitoring/prometheus_role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
   namespace: openshift-local-storage

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,6 +1,6 @@
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-operator
 subjects:


### PR DESCRIPTION
Some RBAC manifests use v1beta1 api, which is deprecated. This commit updates the api version to v1.

Signed off by: Priyanka Jiandani<pjiandan@redhat.com>

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1995653