### PR TITLE
Bug 1997122: localvolume: add event/log message if device already claimed

### DIFF
--- a/diskmaker/controllers/lv/reconcile.go
+++ b/diskmaker/controllers/lv/reconcile.go
@@ -101,9 +101,14 @@ func (r *LocalVolumeReconciler) createSymlink(
 				return true
 			}
 		}
+		msg := fmt.Sprintf("not symlinking, already claimed: %v", existingSymlinks)
+		r.eventSync.Report(r.localVolume, newDiskEvent(DeviceSymlinkExists, msg, symLinkTarget, corev1.EventTypeWarning))
+		klog.Errorf(msg)
 		return false
 	} else if err != nil || !pvLocked { // locking failed for some other reasion
-		klog.Errorf("not symlinking, could not get lock: %v", err)
+		msg := fmt.Sprintf("not symlinking, locking failed: %+v", err)
+		r.eventSync.Report(r.localVolume, newDiskEvent(ErrorCreatingSymLink, msg, symLinkTarget, corev1.EventTypeWarning))
+		klog.Errorf(msg)
 		return false
 	}
 


### PR DESCRIPTION
LocalVolume device paths are explicitly specified, so if they are
already claimed, we should not fail siliently.

Signed-off-by: Rohan CJ <rohantmp@redhat.com>