### PR TITLE
Bug 1985082: remove hard coded namespace from prometheus rbac rules

### DIFF
--- a/config/manifests/4.9/prometheus-role-binding.yaml
+++ b/config/manifests/4.9/prometheus-role-binding.yaml
@@ -2,7 +2,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
-  namespace: openshift-local-storage
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/manifests/4.9/prometheus-role.yaml
+++ b/config/manifests/4.9/prometheus-role.yaml
@@ -2,7 +2,6 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: local-storage-metrics
-  namespace: openshift-local-storage
 rules:
  - apiGroups:
    - ""


### PR DESCRIPTION
using `openshift-local-storage` namespace in prometheus rbac manifests fails to emit lso metrics in other namespaces.
This PR removes the namespace field from the prometheus-role-binding.yaml and prometheus-role.yaml. This enables
creating these resources in the same namespace as csv.

Signed-off-by: Santosh Pillai <sapillai@redhat.com>