### PR TITLE
Bug 2007684: Don't block informer threads [4.9]

### DIFF
--- a/diskmaker/controllers/deleter/reconcile.go
+++ b/diskmaker/controllers/deleter/reconcile.go
@@ -220,8 +220,11 @@ func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.Persiste
 	}
 	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ownerNamespace}})
 	if isDelete {
-		time.Sleep(time.Second * 10)
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ownerNamespace}})
+		// Don't block the informer goroutine.
+		go func () {
+			time.Sleep(time.Second * 10)
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: ownerNamespace}})
+		}()
 	}
 }
 

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -562,9 +562,12 @@ func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.Persiste
 	}
 
 	if isDelete {
-		// delayed reconcile so that the cleanup tracker has time to mark the PV cleaned up
-		time.Sleep(time.Second * 10)
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ownerName, Namespace: ownerNamespace}})
+		// Delayed reconcile so that the cleanup tracker has time to mark the PV cleaned up.
+		// Don't block the informer goroutine.
+		go func () {
+			time.Sleep(time.Second * 10)
+			q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ownerName, Namespace: ownerNamespace}})
+		}()
 	} else {
 		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: ownerName, Namespace: ownerNamespace}})
 	}


### PR DESCRIPTION
Don't sleep in the informer threads. When multiple PVs are released at the
same time, one PV is processed in every 10 seconds. This further adds up
with PV updates and it may take several minutes to process all released
PVs.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2007684