### PR TITLE
Update csv filename in art.yaml

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -1,5 +1,5 @@
 updates:
-  - file: "{MAJOR}.{MINOR}/local-storage-operator.v{MAJOR}.{MINOR}.0.clusterserviceversion.yaml" # relative to this file
+  - file: "{MAJOR}.{MINOR}/local-storage-operator.clusterserviceversion.yaml" # relative to this file
     update_list:
     # replace metadata.name value
     - search: "local-storage-operator.v{MAJOR}.{MINOR}.0"


### PR DESCRIPTION
Recent PR https://github.com/openshift/local-storage-operator/pull/287 introduced a filename change which is breaking ART builds. This is to make that change consistent with what's in art.yaml

cc @priyanka19-98 @yselkowitz 