### PR TITLE
Move static resources into yaml assets

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,10 +1,5 @@
 # Notes for hacking on local-storage-operator
 
-## For developing on plain k8s
-
-Developing on plain k8s is pretty simple. Just write your code and use Makefile to build your own images
-and then update `deploy/operator.yaml` to point to your images and follow rest of the instructions in `deploy/README.md`.
-
 ## For developing on OpenShift and OLM
 
 1. Download and install `opm` tool via - https://github.com/operator-framework/operator-registry

--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -40,6 +40,8 @@ spec:
         name: diskmaker-discovery
         securityContext:
           privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /mnt/local-storage
           mountPropagation: HostToContainer
@@ -50,6 +52,25 @@ spec:
         - mountPath: /run/udev
           mountPropagation: HostToContainer
           name: run-udev
+      - args:
+        - --logtostderr=true
+        - --secure-listen-address=0.0.0.0:9393
+        - --upstream=http://127.0.0.1:8383/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9393
+          name: metrics
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
       hostPID: true
       priorityClassName: ${PRIORITY_CLASS_NAME}
       serviceAccountName: local-storage-admin
@@ -66,6 +87,10 @@ spec:
           path: /run/udev
           type: ""
         name: run-udev
+      - name: metrics-serving-cert
+        secret:
+          defaultMode: 420
+          secretName: diskmaker-metric-serving-cert
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/assets/templates/diskmaker-manager-daemonset.yaml
+++ b/assets/templates/diskmaker-manager-daemonset.yaml
@@ -40,6 +40,8 @@ spec:
         name: diskmaker-manager
         securityContext:
           privileged: true
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /mnt/local-storage
           mountPropagation: HostToContainer
@@ -53,8 +55,25 @@ spec:
         - mountPath: /run/udev
           mountPropagation: HostToContainer
           name: run-udev
+      - args:
+        - --logtostderr=true
+        - --secure-listen-address=0.0.0.0:9393
+        - --upstream=http://127.0.0.1:8383/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9393
+          name: metrics
+          protocol: TCP
+        resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: metrics-serving-cert
       hostPID: true
       priorityClassName: ${PRIORITY_CLASS_NAME}
       serviceAccountName: local-storage-admin
@@ -75,6 +94,10 @@ spec:
           path: /run/udev
           type: ""
         name: run-udev
+      - name: metrics-serving-cert
+        secret:
+          defaultMode: 420
+          secretName: diskmaker-metric-serving-cert
   updateStrategy:
     rollingUpdate:
       maxSurge: 0

--- a/common/daemonsets_utils.go
+++ b/common/daemonsets_utils.go
@@ -18,34 +18,3 @@ func NodeSelectorMatchesNodeLabels(node *corev1.Node, nodeSelector *corev1.NodeS
 	matches, err := v1helper.MatchNodeSelectorTerms(node, nodeSelector)
 	return matches, err
 }
-
-func KubeProxySideCar() corev1.Container {
-	return corev1.Container{
-		Name:            "kube-rbac-proxy",
-		Image:           GetKubeRBACProxyImage(),
-		ImagePullPolicy: "IfNotPresent",
-		Ports: []corev1.ContainerPort{
-			{
-				ContainerPort: int32(9393),
-				Name:          "metrics",
-				Protocol:      corev1.ProtocolTCP,
-			},
-		},
-		Args: []string{
-			"--logtostderr=true",
-			"--secure-listen-address=0.0.0.0:9393",
-			"--upstream=http://127.0.0.1:8383/",
-			"--tls-cert-file=/etc/tls/private/tls.crt",
-			"--tls-private-key-file=/etc/tls/private/tls.key",
-		},
-		TerminationMessagePath:   "/dev/termination-log",
-		TerminationMessagePolicy: "File",
-		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      metricsServingCert,
-				MountPath: "/etc/tls/private",
-			},
-		},
-	}
-
-}

--- a/common/volume_definitions.go
+++ b/common/volume_definitions.go
@@ -14,15 +14,11 @@ const (
 
 	udevVolName = "run-udev"
 	udevPath    = "/run/udev"
-
-	metricsServingCert = "metrics-serving-cert"
 )
 
 var (
 	hostContainerPropagation = corev1.MountPropagationHostToContainer
 	directoryHostPath        = corev1.HostPathDirectory
-
-	defaultMode420 int32 = 420
 
 	// SymlinkHostDirVolume is the corev1.Volume definition for the lso symlink host directory.
 	// "/mnt/local-storage" is the default, but it can be controlled by env vars.
@@ -96,27 +92,5 @@ var (
 		Name:             udevVolName,
 		MountPath:        udevPath,
 		MountPropagation: &hostContainerPropagation,
-	}
-
-	// DiscoveryMetricsCertVolume is the corev1.Volume definition for serving cert secret for discovery service
-	DiscoveryMetricsCertVolume = corev1.Volume{
-		Name: metricsServingCert,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  DiscoveryMetricsServingCert,
-				DefaultMode: &defaultMode420,
-			},
-		},
-	}
-
-	// DiskmakerMetricsCertVolume is the corev1.Volume definition for serving cert secret for diskmaker service
-	DiskmakerMetricsCertVolume = corev1.Volume{
-		Name: metricsServingCert,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName:  DiskMakerMetricsServingCert,
-				DefaultMode: &defaultMode420,
-			},
-		},
 	}
 )

--- a/controllers/localvolumediscovery/localvolumediscovery_controller.go
+++ b/controllers/localvolumediscovery/localvolumediscovery_controller.go
@@ -181,10 +181,6 @@ func getDiskMakerDiscoveryDSMutateFn(request reconcile.Request,
 
 		ds.Spec.Template.Spec.Containers[0].Env = append(ds.Spec.Template.Spec.Containers[0].Env, envVars...)
 
-		//Add kube-rbac-proxy sidecar container to provide https proxy for http-based lso metrics.
-		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, common.KubeProxySideCar())
-		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, common.DiscoveryMetricsCertVolume)
-
 		return nil
 	}
 }

--- a/controllers/nodedaemon/daemonsets.go
+++ b/controllers/nodedaemon/daemonsets.go
@@ -93,10 +93,6 @@ func getDiskMakerDSMutateFn(
 		initMapIfNil(&ds.ObjectMeta.Annotations)
 		ds.ObjectMeta.Annotations[dataHashAnnotationKey] = dataHash
 
-		//Add kube-rbac-proxy sidecar container to provide https proxy for http-based lso metrics.
-		ds.Spec.Template.Spec.Containers = append(ds.Spec.Template.Spec.Containers, common.KubeProxySideCar())
-		ds.Spec.Template.Spec.Volumes = append(ds.Spec.Template.Spec.Volumes, common.DiskmakerMetricsCertVolume)
-
 		return nil
 	}
 }


### PR DESCRIPTION
This is a follow-up to the discussion in this PR:
https://github.com/openshift/local-storage-operator/pull/249#discussion_r673317023
I spent some time testing https://github.com/openshift/local-storage-operator/pull/263 (rebased on latest master branch) on vanilla k8s, but ultimately LSO support for vanilla k8s seems like a losing battle. It's a bit too much of a time sink without much benefit, and it will easily be broken again if we don't test upstream regularly. We may as well lean into the openshift dependency, and move our static resources into yaml to simplify the code as Hemant suggested.
CodeReady Containers (https://developers.redhat.com/products/codeready-containers/overview) are useful for testing LSO changes locally, along with the OpenShift instructions in HACKING.md.
/cc @gnufied @sp98 @rohantmp @derek-pryor 