### PR TITLE
Bug 2028685: LSO repeatedly reports errors while diskmaker-discovery pod is starting

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -6,6 +6,37 @@
 
 2. Create images as documented below
 
+## Running the operator locally
+
+1. Install LSO via OLM/OperatorHub in GUI
+
+2. Build the operator
+```
+make build-operator
+```
+
+3. Export env variables required by LSO [deployment](https://github.com/openshift/local-storage-operator/blob/8fc42cc8b990907c88a6da551dc85b55c2dc4417/config/manifests/4.10/local-storage-operator.clusterserviceversion.yaml#L363)
+```
+export DISKMAKER_IMAGE=quay.io/openshift/origin-local-storage-diskmaker:latest
+export KUBE_RBAC_PROXY_IMAGE=quay.io/openshift/origin-kube-rbac-proxy:latest
+export PRIORITY_CLASS_NAME=openshift-user-critical
+```
+
+4. Define LSO namespace as env variable
+```
+export WATCH_NAMESPACE=openshift-local-storage
+```
+
+5. Scale down the operator (on remote cluster)
+```
+oc scale --replicas=0 deployment.apps/local-storage-operator -n openshift-local-storage
+```
+
+6. Run the operator locally
+```
+~> ./_output/bin/local-storage-operator -kubeconfig=$KUBECONFIG
+```
+
 ## Automatic creation of operator, bundle and index images
 
 All the images including operator, diskmaker, bundle and index images can be created in one shot using following command:

--- a/controllers/localvolumediscovery/localvolumediscovery_controller.go
+++ b/controllers/localvolumediscovery/localvolumediscovery_controller.go
@@ -131,7 +131,8 @@ func (r *LocalVolumeDiscoveryReconciler) Reconcile(ctx context.Context, request 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return waitForRequeueIfDaemonsNotReady, fmt.Errorf(message)
+		discoveryLogger.Info(message)
+		return waitForRequeueIfDaemonsNotReady, nil
 	}
 
 	message := fmt.Sprintf("successfully running %d out of %d discovery daemons", desiredDaemons, readyDaemons)


### PR DESCRIPTION
PR contains two commits, one for documenting how to run LSO locally which can be useful for verification of some bug fixes (like this one) and second with an actual fix.