### PR TITLE
Bug 2027008: diskmaker-discovery pods don't start because of missing …

### DIFF
--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -90,7 +90,7 @@ spec:
       - name: metrics-serving-cert
         secret:
           defaultMode: 420
-          secretName: diskmaker-metric-serving-cert
+          secretName: discovery-metric-serving-cert
   updateStrategy:
     rollingUpdate:
       maxSurge: 0


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2027008
/cc @openshift/storage 