### PR TITLE
Bug 2033750: Get kube-rbac-proxy from CSV

### DIFF
--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         - --upstream=http://127.0.0.1:8383/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        image: ${RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/assets/templates/diskmaker-manager-daemonset.yaml
+++ b/assets/templates/diskmaker-manager-daemonset.yaml
@@ -61,7 +61,7 @@ spec:
         - --upstream=http://127.0.0.1:8383/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
-        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        image: ${RBAC_PROXY_IMAGE}
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
         ports:

--- a/controllers/localvolumediscovery/localvolumediscovery_controller.go
+++ b/controllers/localvolumediscovery/localvolumediscovery_controller.go
@@ -165,6 +165,7 @@ func getDiskMakerDiscoveryDSMutateFn(request reconcile.Request,
 			[]string{
 				"${OBJECT_NAMESPACE}", request.Namespace,
 				"${CONTAINER_IMAGE}", common.GetDiskMakerImage(),
+				"${RBAC_PROXY_IMAGE}", common.GetKubeRBACProxyImage(),
 			},
 		)
 		if err != nil {

--- a/controllers/nodedaemon/daemonset_test.go
+++ b/controllers/nodedaemon/daemonset_test.go
@@ -45,6 +45,7 @@ func TestMutateAggregatedSpecTemplates(t *testing.T) {
 		[]string{
 			"${OBJECT_NAMESPACE}", "new-namespace",
 			"${CONTAINER_IMAGE}", common.GetDiskMakerImage(),
+			"${RBAC_PROXY_IMAGE}", common.GetKubeRBACProxyImage(),
 			"${PRIORITY_CLASS_NAME}", "",
 		},
 	)

--- a/controllers/nodedaemon/daemonsets.go
+++ b/controllers/nodedaemon/daemonsets.go
@@ -72,6 +72,7 @@ func getDiskMakerDSMutateFn(
 			[]string{
 				"${OBJECT_NAMESPACE}", request.Namespace,
 				"${CONTAINER_IMAGE}", common.GetDiskMakerImage(),
+				"${RBAC_PROXY_IMAGE}", common.GetKubeRBACProxyImage(),
 				"${PRIORITY_CLASS_NAME}", os.Getenv("PRIORITY_CLASS_NAME"),
 			},
 		)


### PR DESCRIPTION
This fixes a regression caused by #298, causing the origin image to be used even in productized builds regardless of the CSV.

/cc @dobsonj
/assign @gnufied
