### PR TITLE
Add label for ARM to display local storage operator

### DIFF
--- a/config/manifests/4.11/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.11/local-storage-operator.clusterserviceversion.yaml
@@ -108,6 +108,7 @@ metadata:
   labels:
     operator-metering: "true"
     "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.arm64": supported
     "operatorframework.io/arch.ppc64le": supported
     "operatorframework.io/arch.s390x": supported
 spec:


### PR DESCRIPTION
in the OperatorHub.

Signed-off-by: Saravanakumar Arumugam <sarumuga@redhat.com>