### PR TITLE
Bug 2006698: increase the polling interval to 1m for lv diskmaker

### DIFF
--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -33,7 +33,7 @@ import (
 // It also ensures that only stable device names are used.
 
 var (
-	checkDuration = 5 * time.Second
+	checkDuration = 60 * time.Second
 	diskByIDPath  = "/dev/disk/by-id/*"
 )
 


### PR DESCRIPTION
This is a backport of #275 to 4.8