### PR TITLE
Bug 2041620: bundle CSV alm-examples does not parse

### DIFF
--- a/config/manifests/4.10/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.10/local-storage-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
             "storageClassDevices": [
               {
                 "devicePaths": [
-                  "/dev/disk/by-id/ata-crucial",
+                  "/dev/disk/by-id/ata-crucial"
                 ],
                 "fsType": "ext4",
                 "storageClassName": "foobar",


### PR DESCRIPTION
Need to remove the trailing comma to pass operator-sdk validator check.

This check is planned to be run in CI.