### PR TITLE
Bug 2012111: Stop enqueing LocalVolumeSet after NotFound error

### DIFF
--- a/controllers/localvolumeset/status.go
+++ b/controllers/localvolumeset/status.go
@@ -102,7 +102,7 @@ func (r *LocalVolumeSetReconciler) addAvailabilityConditions(ctx context.Context
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			r.LvSetMap.DeregisterStorageClassOwner(lvSet.Spec.StorageClassName, request.NamespacedName)
-			return result, err
+			return result, reconcileError
 		}
 		return result, fmt.Errorf("failed to get localvolumeset: %w", err)
 	}


### PR DESCRIPTION
Return `reconcileError` from `addAvailabilityConditions` to stop enqueing LocalVolumeSet after NotFound error.

`reconcileError` should be already `nil` if related LocalVolumeSet does not exist, unless something serious happened when cleaning up the object (and in that case requeue is expected).