### PR TITLE
Bug 2044783: [4.8] bundle CSV alm-examples does not parse

### DIFF
--- a/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/4.8/local-storage-operator.v4.8.0.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
             "storageClassDevices": [
               {
                 "devicePaths": [
-                  "/dev/disk/by-id/ata-crucial",
+                  "/dev/disk/by-id/ata-crucial"
                 ],
                 "fsType": "ext4",
                 "storageClassName": "foobar",


### PR DESCRIPTION
Need to remove the trailing comma to pass operator-sdk validator check.

This check is planned to be run in CI.

This is a followup for PR #310 in which the fix was done in different directory.