### PR TITLE
Update bundle.Dockerfile to use 4.11 manifests

### DIFF
--- a/config/bundle.Dockerfile
+++ b/config/bundle.Dockerfile
@@ -7,5 +7,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=local-storage-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=preview
 LABEL operators.operatorframework.io.bundle.channel.default.v1=preview
 
-COPY manifests/4.10/*.yaml /manifests/
+COPY manifests/4.11/*.yaml /manifests/
 COPY metadata/annotations.yaml /metadata/annotations.yaml


### PR DESCRIPTION
Ran into this issue in https://github.com/openshift/release/pull/26479
It's easy to reproduce locally too. The manifests moved to 4.11 but bundle.Dockerfile needs to be updated to point to the right location.
/cc @openshift/storage 