### PR TITLE
Bug 2052757: [4.9] PVs are not being cleaned up after PVC deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,3 +67,5 @@ replace (
 replace github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 // Required by Helm
 
 replace bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // required by library-go
+
+replace sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220225145136-3b8b7b586be4 // for bug 2052757

--- a/go.sum
+++ b/go.sum
@@ -487,6 +487,8 @@ github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7 h1:iKVU5Tga76k
 github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8RkJzwdkBExQdYUnkWcePMLBiTeCCr8eQIQ7y8Dk=
 github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a h1:6g4CJQBz+mcxdFk19QBplFf6y1xqe1LaUNzTqMOpCS0=
 github.com/openshift/library-go v0.0.0-20210831102543-1a08f0c3bd9a/go.mod h1:ymWf1TnfDo0LgjihlqHzYoy81pTY5wBL+bl3XdHNEYI=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220225145136-3b8b7b586be4 h1:o0itOuTBB6f7FiZav2oZhcbmo+GsgWxickVxgeVTJUk=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220225145136-3b8b7b586be4/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
@@ -1102,8 +1104,6 @@ sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcL
 sigs.k8s.io/kustomize/kyaml v0.11.0/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0 h1:IKsKAnscMyIOqyl8s8V7guTcx0QBEa6OT57EPgAgpmM=
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0/go.mod h1:DhZ52sQMJHW21+JXyA2LRUPRIxKnrNrwh+QFV+2tVA4=
-sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 h1:Vc+R6zCUygflwVMuNdFhmKPFBclAQhSTVxGZ/eoJJdI=
-sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2 h1:Hr/htKFmJEbtMgS/UD0N+gtgctAqz81t3nu+sPzynno=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -782,7 +782,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1
 # sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/util
-# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2
+# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220225145136-3b8b7b586be4
 ## explicit
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common
@@ -825,3 +825,4 @@ sigs.k8s.io/yaml
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.22.1
 # github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
 # bitbucket.org/ww/goautoneg => github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+# sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220225145136-3b8b7b586be4

--- a/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
+++ b/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
@@ -72,6 +72,9 @@ func (d *Deleter) DeletePVs() {
 		if pv.Status.Phase != v1.VolumeReleased {
 			continue
 		}
+		if d.Cache.SuccessfullyCleanedPV(pv) {
+			continue
+		}
 		name := pv.Name
 		switch pv.Spec.PersistentVolumeReclaimPolicy {
 		case v1.PersistentVolumeReclaimRetain:
@@ -162,6 +165,7 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 	switch state {
 	case CSSucceeded:
 		// Found a completed cleaning entry
+		d.Cache.CleanPV(pv)
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2052757
This updates the vendor directory to pull in the rebase and fix from https://github.com/openshift/sig-storage-local-static-provisioner/pull/40
/cc @openshift/storage 