### PR TITLE
Bug 2059840: Use oc adm inspect to gather everything

### DIFF
--- a/must-gather/gather
+++ b/must-gather/gather
@@ -1,40 +1,13 @@
 #!/bin/bash
 
-resources=()
-pods=()
 subscriptionName="local-storage-operator"
 
-for I in $(/usr/bin/oc get crd | grep local.storage.openshift.io | awk '{print $1}'); do
-  resources+=($I)
-done
-
 lsoNamespace=$(/usr/bin/oc get subscription --all-namespaces | grep ${subscriptionName} | awk '{print $1}')
-for I in $(oc get pod -n ${lsoNamespace} -o custom-columns=NAME:.metadata.name --no-headers); do
-  pods+=($I)
-done
+/usr/bin/oc adm inspect namespace/${lsoNamespace} --dest-dir=must-gather/
 
-object_collection_path=must-gather/namespaces/${lsoNamespace}/pods
-mkdir -p ${object_collection_path}
-
-for pod in ${pods[@]}; do
-  /usr/bin/oc logs ${pod} -n ${lsoNamespace}> ${object_collection_path}/${pod}.log
-done
-
-for resource in ${resources[@]}; do
-  /usr/bin/oc get ${resource} --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace --no-headers 2> /dev/null | \
-  while read ocresource; do
-    ocobject=$(echo $ocresource | awk '{print $1}')
-    ocns=$(echo $ocresource | awk '{print $2}')
-    if [ -z "${ocns}" ]|[ "${ocns}" == "<none>" ]; then
-      object_collection_path=must-gather/cluster-scoped-resources/${resource}
-      mkdir -p ${object_collection_path}
-      /usr/bin/oc get ${resource} -o yaml ${ocobject} > ${object_collection_path}/${ocobject}.yaml
-    else
-      object_collection_path=must-gather/namespaces/${ocns}/crs/${resource}
-      mkdir -p ${object_collection_path}
-      /usr/bin/oc get ${resource} -n ${ocns} -o yaml ${ocobject} > ${object_collection_path}/${ocobject}.yaml
-    fi
-  done
+for I in $(/usr/bin/oc get crd | grep local.storage.openshift.io | awk '{print $1}'); do
+    echo "Gathering data for CRD $I"
+    /usr/bin/oc adm inspect $I --all-namespaces --dest-dir=must-gather/
 done
 
 exit 0


### PR DESCRIPTION
Simplifying must-gather collection:

`oc adm inspect namespace/<ns>` will collect all "well known" namespaced objects, like DaemonSets and Deployments, together with all pod logs.

`oc adm inspect <crd name> --all-namespaces` will then collect all CRs. 

stdout:
```
Gathering data for ns/openshift-local-storage...
Wrote inspect data to must-gather/.
Gathering data for CRD localvolumediscoveries.local.storage.openshift.io
Wrote inspect data to must-gather/.
Gathering data for CRD localvolumediscoveryresults.local.storage.openshift.io
Wrote inspect data to must-gather/.
Gathering data for CRD localvolumes.local.storage.openshift.io
Wrote inspect data to must-gather/.
Gathering data for CRD localvolumesets.local.storage.openshift.io
Wrote inspect data to must-gather/.
```

Resulting files:
```
.
./timestamp
./event-filter.html
./namespaces
./namespaces/openshift-local-storage
./namespaces/openshift-local-storage/pods
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator-7fbd55dcf8-6f6mn.yaml
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator/local-storage-operator
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator/local-storage-operator/logs
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator/local-storage-operator/logs/current.log
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator/local-storage-operator/logs/previous.insecure.log
./namespaces/openshift-local-storage/pods/local-storage-operator-7fbd55dcf8-6f6mn/local-storage-operator/local-storage-operator/logs/previous.log

[snip lot of pod logs]

./namespaces/openshift-local-storage/core
./namespaces/openshift-local-storage/core/events.yaml
./namespaces/openshift-local-storage/core/persistentvolumeclaims.yaml
./namespaces/openshift-local-storage/core/secrets.yaml
./namespaces/openshift-local-storage/core/endpoints.yaml
./namespaces/openshift-local-storage/core/pods.yaml
./namespaces/openshift-local-storage/core/configmaps.yaml
./namespaces/openshift-local-storage/core/replicationcontrollers.yaml
./namespaces/openshift-local-storage/core/services.yaml
./namespaces/openshift-local-storage/openshift-local-storage.yaml
./namespaces/openshift-local-storage/policy
./namespaces/openshift-local-storage/policy/poddisruptionbudgets.yaml
./namespaces/openshift-local-storage/apps.openshift.io
./namespaces/openshift-local-storage/apps.openshift.io/deploymentconfigs.yaml
./namespaces/openshift-local-storage/batch
./namespaces/openshift-local-storage/batch/jobs.yaml
./namespaces/openshift-local-storage/batch/cronjobs.yaml
./namespaces/openshift-local-storage/autoscaling
./namespaces/openshift-local-storage/autoscaling/horizontalpodautoscalers.yaml
./namespaces/openshift-local-storage/local.storage.openshift.io
./namespaces/openshift-local-storage/local.storage.openshift.io/localvolumes
./namespaces/openshift-local-storage/local.storage.openshift.io/localvolumes/example.yaml
./namespaces/openshift-local-storage/discovery.k8s.io
./namespaces/openshift-local-storage/discovery.k8s.io/endpointslices.yaml
./namespaces/openshift-local-storage/route.openshift.io
./namespaces/openshift-local-storage/route.openshift.io/routes.yaml
./namespaces/openshift-local-storage/image.openshift.io
./namespaces/openshift-local-storage/image.openshift.io/imagestreams.yaml
./namespaces/openshift-local-storage/build.openshift.io
./namespaces/openshift-local-storage/build.openshift.io/builds.yaml
./namespaces/openshift-local-storage/build.openshift.io/buildconfigs.yaml
./namespaces/openshift-local-storage/apps
./namespaces/openshift-local-storage/apps/statefulsets.yaml
./namespaces/openshift-local-storage/apps/deployments.yaml
./namespaces/openshift-local-storage/apps/daemonsets.yaml
./namespaces/openshift-local-storage/apps/replicasets.yaml

``` 