### PR TITLE
Bug 1984785: LSO CSV does not contain disconnected annotation

### DIFF
--- a/config/manifests/4.11/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/4.11/local-storage-operator.clusterserviceversion.yaml
@@ -100,6 +100,7 @@ metadata:
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes.
     olm.skipRange: ">=4.3.0 <4.11.0"
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
     # This annotation injection is a workaround for BZ-1950047, since the associated
     # annotation in spec.install.spec.deployments.template.metadata is presently ignored.


### PR DESCRIPTION
Adding disconnected annotation, this operator should not require an internet connection to provision local storage.
https://bugzilla.redhat.com/show_bug.cgi?id=1984785
/cc @openshift/storage 