### PR TITLE
Bug 2060532: LSO e2e tests are run against default image and namespace

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,53 +1,14 @@
 #!/bin/bash -x
 set -e
 
-ARTIFACT_DIR=${ARTIFACT_DIR:-_output}
-manifest=${ARTIFACT_DIR}/manifest.yaml
-global_manifest=${ARTIFACT_DIR}/global_manifest.yaml
-rm -f $manifest $global_manifest
-mkdir -p ${ARTIFACT_DIR}
-
-if [ -n "${IMAGE_FORMAT}" ] ; then
-    echo "IMAGE_FORMAT set as '${IMAGE_FORMAT}'"
-    IMAGE_LOCAL_STORAGE_OPERATOR=$(sed -e "s,\${component},local-storage-operator," <(echo $IMAGE_FORMAT))
-    IMAGE_LOCAL_DISKMAKER=$(sed -e "s,\${component},local-storage-diskmaker," <(echo $IMAGE_FORMAT))
-else
-    IMAGE_LOCAL_STORAGE_OPERATOR=${IMAGE_LOCAL_STORAGE_OPERATOR:-quay.io/openshift/origin-local-storage-operator}
-    IMAGE_LOCAL_DISKMAKER=${IMAGE_LOCAL_DISKMAKER:-quay.io/openshift/origin-local-storage-diskmaker}
-fi
-
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
-repo_dir="$(dirname $0)/.."
-cat ${repo_dir}/config/rbac/leader_election_role.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/leader_election_role_binding.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/diskmaker/role.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/diskmaker/role_binding.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/diskmaker/service_account.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/role.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/role_binding.yaml >> ${manifest}
-cat ${repo_dir}/config/rbac/service_account.yaml >> ${manifest}
-cat ${repo_dir}/config/manager/manager.yaml >> ${manifest}
-#cat ${repo_dir}/deploy/operator.yaml >> ${manifest}
-cat ${repo_dir}/config/crd/bases/local.storage.openshift.io_localvolumes.yaml >> ${global_manifest}
-cat ${repo_dir}/config/crd/bases/local.storage.openshift.io_localvolumesets.yaml >> ${global_manifest}
-cat ${repo_dir}/config/crd/bases/local.storage.openshift.io_localvolumediscoveries.yaml >> ${global_manifest}
-cat ${repo_dir}/config/crd/bases/local.storage.openshift.io_localvolumediscoveryresults.yaml >> ${global_manifest}
 
-sed -i "s,quay.io/openshift/origin-local-storage-operator,${IMAGE_LOCAL_STORAGE_OPERATOR}," ${manifest}
-sed -i "s,quay.io/openshift/origin-local-storage-diskmaker,${IMAGE_LOCAL_DISKMAKER}," ${manifest}
-export TEST_WATCH_NAMESPACE=${TEST_OPERATOR_NAMESPACE:-default}
-export TEST_OPERATOR_NAMESPACE=${TEST_OPERATOR_NAMESPACE:-default}
+export TEST_WATCH_NAMESPACE=${TEST_OPERATOR_NAMESPACE:-openshift-local-storage}
+export TEST_OPERATOR_NAMESPACE=${TEST_OPERATOR_NAMESPACE:-openshift-local-storage}
 export TEST_LOCAL_DISK=${TEST_LOCAL_DISK:-""}
-
-export \
-    IMAGE_LOCAL_STORAGE_OPERATOR \
-    IMAGE_LOCAL_DISKMAKER
 
 go test -timeout 0 ./test/e2e/... \
   -root=$(pwd) \
   -kubeconfig=${KUBECONFIG} \
-  -globalMan ${global_manifest} \
-  -namespacedMan ${manifest} \
   -v \
   -parallel=1 \
-  #-singleNamespace

--- a/test-framework/context.go
+++ b/test-framework/context.go
@@ -28,15 +28,11 @@ import (
 type Context struct {
 	id         string
 	cleanupFns []cleanupFn
-	// the  namespace is deprecated
-	// todo: remove before 1.0.0
-	// use operatorNamespace or watchNamespace  instead
-	namespace         string
+
 	operatorNamespace string
 	watchNamespace    string
 	t                 *testing.T
 
-	namespacedManPath  string
 	client             *frameworkClient
 	kubeclient         kubernetes.Interface
 	restMapper         *restmapper.DeferredDiscoveryRESTMapper
@@ -77,10 +73,8 @@ func (f *Framework) newContext(t *testing.T) *Context {
 	return &Context{
 		id:                 id,
 		t:                  t,
-		namespace:          operatorNamespace,
 		operatorNamespace:  operatorNamespace,
 		watchNamespace:     watchNamespace,
-		namespacedManPath:  *f.NamespacedManPath,
 		client:             f.Client,
 		kubeclient:         f.KubeClient,
 		restMapper:         f.restMapper,

--- a/test-framework/context_test.go
+++ b/test-framework/context_test.go
@@ -22,10 +22,7 @@ import (
 )
 
 func TestNewContextCreatesID(t *testing.T) {
-	fakeNamespacedManPath := "fakePath"
-	Global = &Framework{
-		NamespacedManPath: &fakeNamespacedManPath,
-	}
+	Global = &Framework{}
 
 	ctx := NewContext(t)
 

--- a/test-framework/resource_creator_test.go
+++ b/test-framework/resource_creator_test.go
@@ -26,12 +26,9 @@ const (
 	WatchNamespaceEnv    = "TEST_WATCH_NAMESPACE"
 )
 
-var fakeNamespacedManPath string = "fakePath"
-
 func TestGetOperatorNamespace(t *testing.T) {
 	Global = &Framework{
-		NamespacedManPath: &fakeNamespacedManPath,
-		KubeClient:        fake.NewSimpleClientset(),
+		KubeClient: fake.NewSimpleClientset(),
 	}
 
 	t.Run("should create a non-empty new Operator Namespace when OperatorNamespace env is not set",
@@ -81,8 +78,7 @@ func TestGetOperatorNamespace(t *testing.T) {
 
 func TestGetWatchNamespace(t *testing.T) {
 	Global = &Framework{
-		NamespacedManPath: &fakeNamespacedManPath,
-		KubeClient:        fake.NewSimpleClientset(),
+		KubeClient: fake.NewSimpleClientset(),
 	}
 
 	t.Run("should return Watch Namespace (==Operator Namespace) WatchNamespace Env is not set",

--- a/test/e2e/aws_disks.go
+++ b/test/e2e/aws_disks.go
@@ -49,7 +49,7 @@ type disk struct {
 // not specific to any platform
 func populateDeviceInfo(t *testing.T, ctx *framework.TestCtx, nodeEnv []nodeDisks) []nodeDisks {
 	f := framework.Global
-	namespace, err := ctx.GetNamespace()
+	namespace, err := ctx.GetOperatorNamespace()
 	if err != nil {
 		t.Fatalf("error fetching namespace : %v", err)
 	}

--- a/test/e2e/cleanup_hostdirs.go
+++ b/test/e2e/cleanup_hostdirs.go
@@ -21,7 +21,7 @@ func cleanupSymlinkDir(t *testing.T, ctx *framework.TestCtx, nodeEnv []nodeDisks
 	t.Logf("cleaning up hostdirs")
 	f := framework.Global
 	matcher := gomega.NewWithT(t)
-	namespace, err := ctx.GetNamespace()
+	namespace, err := ctx.GetOperatorNamespace()
 	if err != nil || namespace == "" {
 		return fmt.Errorf("could not determine namespace: %w", err)
 	}
@@ -188,10 +188,11 @@ set +x
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-					Containers:    containers,
-					Volumes:       volumes,
-					Affinity:      affinity,
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
+					Containers:         containers,
+					Volumes:            volumes,
+					Affinity:           affinity,
+					ServiceAccountName: "local-storage-admin",
 				},
 			},
 		},

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -42,7 +42,7 @@ var (
 func LocalVolumeTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(*testing.T) {
 	return func(t *testing.T) {
 		f := framework.Global
-		namespace, err := ctx.GetNamespace()
+		namespace, err := ctx.GetOperatorNamespace()
 		if err != nil {
 			t.Fatalf("error fetching namespace : %v", err)
 		}

--- a/test/e2e/localvolumediscovery_test.go
+++ b/test/e2e/localvolumediscovery_test.go
@@ -20,7 +20,7 @@ import (
 func LocalVolumeDiscoveryTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(*testing.T) {
 	return func(t *testing.T) {
 		f := framework.Global
-		namespace, err := ctx.GetNamespace()
+		namespace, err := ctx.GetOperatorNamespace()
 		if err != nil {
 			t.Fatalf("error fetching namespace : %v", err)
 		}

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -30,7 +30,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 	return func(t *testing.T) {
 
 		f := framework.Global
-		namespace, err := ctx.GetNamespace()
+		namespace, err := ctx.GetOperatorNamespace()
 		if err != nil {
 			t.Fatalf("error fetching namespace : %v", err)
 		}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -175,13 +175,7 @@ func addToCleanupFuncs(cleanupFuncs *[]cleanupFn, name string, fn func(*testing.
 }
 
 func waitForOperatorToBeReady(t *testing.T, ctx *framework.TestCtx) error {
-	t.Log("Initializing cluster resources...")
-	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		return err
-	}
-	t.Log("Initialized cluster resources")
-	namespace, err := ctx.GetNamespace()
+	namespace, err := ctx.GetOperatorNamespace()
 	if err != nil {
 		return err
 	}
@@ -196,14 +190,4 @@ func waitForOperatorToBeReady(t *testing.T, ctx *framework.TestCtx) error {
 		return err
 	}
 	return nil
-}
-
-// env var config helpers
-
-func getOperatorImage() string {
-	return os.Getenv("IMAGE_LOCAL_DISKMAKER")
-}
-
-func getDiskMakerImage() string {
-	return os.Getenv("IMAGE_LOCAL_DISKMAKER")
 }


### PR DESCRIPTION
This PR:
- Removes the code that generates custom install manifests during the e2e tests. We really don't need to maintain separate manifests and associated code to do that. The install is already handled by OLM (see https://github.com/openshift/release/pull/26479 for how the operator gets installed now).
- Removes some misc dead code. For example, there were some comments to remove `namespace` from context.go, and that field was set to the same value as `operatorNamespace` anyway. So I just removed that chunk of code and updated the callers to use `GetOperatorNamespace` instead of `GetNamespace`.
- Sets the default namespace to `openshift-local-storage`, where OLM installs the operator.
- Sets the `ServiceAccountName` field in `cleanup_hostdirs.go` to resolve a [test failure](https://github.com/openshift/local-storage-operator/pull/346#issuecomment-1097399744).

https://bugzilla.redhat.com/show_bug.cgi?id=2060532
/cc @openshift/storage