### PR TITLE
Bug 2077797: LSO pods do not have any resource requests

### DIFF
--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -40,6 +40,10 @@ spec:
         name: diskmaker-discovery
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -65,7 +69,10 @@ spec:
         - containerPort: 9393
           name: metrics
           protocol: TCP
-        resources: {}
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/assets/templates/diskmaker-manager-daemonset.yaml
+++ b/assets/templates/diskmaker-manager-daemonset.yaml
@@ -40,6 +40,10 @@ spec:
         name: diskmaker-manager
         securityContext:
           privileged: true
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -68,7 +72,10 @@ spec:
         - containerPort: 9393
           name: metrics
           protocol: TCP
-        resources: {}
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -357,6 +357,10 @@ spec:
                     - local-storage-operator
                     args:
                     - --leader-elect
+                    resources:
+                      requests:
+                        memory: 50Mi
+                        cpu: 10m
                     env:
                       - name: WATCH_NAMESPACE
                         valueFrom:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2077797

I followed [this guide](https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#resources-and-limits) to measure resource usage of the LSO and diskmaker pods.

CPU:
```
scalar(
      max(kube_pod_container_resource_requests{namespace="openshift-sdn", container="sdn", resource="cpu"}) / max(max_over_time(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="openshift-sdn", container="sdn"}[120m]))) *
max by (pod, container) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="openshift-local-storage"})
```
results: 5m - 10m

MEM:
(this query is a bit different, the one from the guide wasn't working)
```
sum( container_memory_working_set_bytes{container="", namespace="openshift-local-storage"} )
by (pod)
```
results: 20Mi - 50Mi

This is roughly inline with the CSI drivers we deploy, so I settled on the same values we use for [AWS EBS](https://github.com/openshift/aws-ebs-csi-driver-operator/blob/master/assets/controller.yaml) and others.

```
$ oc get pods -n openshift-local-storage local-storage-operator-5c6f866b84-8vklb -o yaml | grep -A3 resources
    resources:
      requests:
        cpu: 10m
        memory: 50Mi
$ oc get pods -n openshift-local-storage diskmaker-manager-gdhql -o yaml | grep -A3 resources
    resources:
      requests:
        cpu: 10m
        memory: 50Mi
--
    resources:
      requests:
        cpu: 10m
        memory: 20Mi
$ oc get pods -n openshift-local-storage diskmaker-discovery-zgm7z -o yaml | grep -A3 resources
    resources:
      requests:
        cpu: 10m
        memory: 50Mi
--
    resources:
      requests:
        cpu: 10m
        memory: 20Mi
```

/cc @openshift/storage
