### PR TITLE
Bug 2089387: Add multi path support for LocalVolumeSet objects

### DIFF
--- a/api/v1alpha1/localvolumeset_types.go
+++ b/api/v1alpha1/localvolumeset_types.go
@@ -45,6 +45,8 @@ const (
 	Partition DeviceType = "part"
 	// Loop type device
 	Loop DeviceType = "loop"
+	// Multipath device type
+	MultiPath DeviceType = "mpath"
 )
 
 // DeviceInclusionSpec holds the inclusion filter spec

--- a/config/manifests/stable/local-volume-sets.crd.yaml
+++ b/config/manifests/stable/local-volume-sets.crd.yaml
@@ -53,6 +53,8 @@ spec:
                         enum:
                           - disk
                           - part
+                          - loop
+                          - mpath
                       type: array
                     maxSize:
                       description: MaxSize is the maximum size of the device which needs

--- a/config/rbac/diskmaker/role.yaml
+++ b/config/rbac/diskmaker/role.yaml
@@ -1,3 +1,4 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -31,6 +32,7 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -28,7 +28,7 @@ const (
 	resultCRName                  = "discovery-result-%s"
 )
 
-var supportedDeviceTypes = sets.NewString("disk", "part", "lvm")
+var supportedDeviceTypes = sets.NewString("disk", "part", "lvm", "mpath")
 
 // DeviceDiscovery instance
 type DeviceDiscovery struct {


### PR DESCRIPTION
Add support for multipath device types.

Please note, by default only "disk" type is supported but following CR can provision mpath volumes:

```
spec:
  deviceInclusionSpec:
    deviceTypes:
    - disk
    - part
    - loop
    - mpath
    minSize: 10Mi
  fsType: ext4
  nodeSelector:
    nodeSelectorTerms:
    - matchExpressions:
      - key: kubernetes.io/hostname
        operator: In
        values:
        - co8-tpptx-worker-9phmf
  storageClassName: mpath
  volumeMode: Filesystem
```

I tested and it works as expected.

