### PR TITLE
Bug 2091873: PVs get stuck in Released after PVC is deleted and Node UID changed

### DIFF
--- a/diskmaker/controllers/deleter/reconcile_test.go
+++ b/diskmaker/controllers/deleter/reconcile_test.go
@@ -1,0 +1,440 @@
+package deleter
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"github.com/openshift/client-go/security/clientset/versioned/scheme"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	v1api "github.com/openshift/local-storage-operator/api/v1"
+	v1alphav1api "github.com/openshift/local-storage-operator/api/v1alpha1"
+	"github.com/openshift/local-storage-operator/test-framework"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/mount"
+	"path/filepath"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	provCache "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache"
+	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
+	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
+	provDeleter "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
+	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
+	"testing"
+	"time"
+)
+
+//go:embed *
+var f embed.FS
+
+const (
+	storageClassName = "local-sc"
+)
+
+type testContext struct {
+	fakeClient     client.WithWatch
+	fakeRecorder   *record.FakeRecorder
+	eventStream    chan string
+	fakeMounter    *mount.FakeMounter
+	fakeVolUtil    *provUtil.FakeVolumeUtil
+	fakeDirFiles   map[string][]*provUtil.FakeDirEntry
+	runtimeConfig  *provCommon.RuntimeConfig
+	cleanupTracker *provDeleter.CleanupStatusTracker
+}
+
+type NodeConfigParams struct {
+	NodeName string
+	NodeUID  types.UID
+}
+
+func makeNodeList(params []NodeConfigParams) *corev1.NodeList {
+	mockNodeList := corev1.NodeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "NodeList",
+		},
+		Items: []corev1.Node{},
+	}
+
+	for _, p := range params {
+		node := corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: p.NodeName,
+				UID:  p.NodeUID,
+			},
+		}
+		mockNodeList.Items = append(mockNodeList.Items, node)
+	}
+
+	return &mockNodeList
+}
+
+type PVConfigParams struct {
+	PVName          string
+	PVAnnotation    string
+	PVReclaimPolicy corev1.PersistentVolumeReclaimPolicy
+	PVPhase         corev1.PersistentVolumePhase
+}
+
+func makePersistentVolumeList(params []PVConfigParams) *corev1.PersistentVolumeList {
+
+	mockPersistentVolumeList := corev1.PersistentVolumeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "PersistentVolumeList",
+		},
+		Items: nil,
+	}
+
+	if params == nil {
+		return &mockPersistentVolumeList
+	}
+
+	for _, p := range params {
+		pv := corev1.PersistentVolume{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "PersistentVolume",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					provCommon.AnnProvisionedBy: p.PVAnnotation,
+				},
+				Name: p.PVName,
+			},
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeReclaimPolicy: p.PVReclaimPolicy,
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					Local: &corev1.LocalVolumeSource{
+						Path: filepath.Join("/mnt/local-storage", storageClassName, p.PVName),
+					},
+				},
+				StorageClassName: storageClassName, //Has to match with ConfigMap (data.storageClassMap)
+			},
+			Status: corev1.PersistentVolumeStatus{
+				Phase: p.PVPhase,
+			},
+		}
+		mockPersistentVolumeList.Items = append(mockPersistentVolumeList.Items, pv)
+	}
+
+	return &mockPersistentVolumeList
+}
+
+func newFakeDeleteReconciler(t *testing.T, objs ...runtime.Object) (*DeleteReconciler, *testContext) {
+	scheme := scheme.Scheme
+
+	err := v1api.AddToScheme(scheme)
+	assert.NoErrorf(t, err, "creating scheme")
+
+	err = v1alphav1api.AddToScheme(scheme)
+	assert.NoErrorf(t, err, "creating scheme")
+
+	err = corev1.AddToScheme(scheme)
+	assert.NoErrorf(t, err, "adding corev1 to scheme")
+
+	err = appsv1.AddToScheme(scheme)
+	assert.NoErrorf(t, err, "adding appsv1 to scheme")
+
+	err = storagev1.AddToScheme(scheme)
+	assert.NoErrorf(t, err, "adding storagev1 to scheme")
+
+	fakeClient := crFake.NewFakeClientWithScheme(scheme, objs...)
+
+	fakeRecorder := record.NewFakeRecorder(20)
+	eventChannel := fakeRecorder.Events
+	mounter := &mount.FakeMounter{
+		MountPoints: []mount.MountPoint{},
+	}
+
+	fakeVolUtil := provUtil.NewFakeVolumeUtil(false /*deleteShouldFail*/, map[string][]*provUtil.FakeDirEntry{})
+
+	//Caution: runtimeConfig actually gets rewritten in Reconcile()!
+	//TODO: refactor DeleteReconciler to have a proper constructor
+	runtimeConfig := &provCommon.RuntimeConfig{
+		UserConfig: &provCommon.UserConfig{
+			Node: &corev1.Node{},
+		},
+		Cache:    provCache.NewVolumeCache(),
+		VolUtil:  fakeVolUtil,
+		APIUtil:  test.ApiUtil{Client: fakeClient},
+		Recorder: fakeRecorder,
+		Mounter:  mounter,
+	}
+
+	cleanupTracker := &provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()}
+
+	tc := &testContext{
+		fakeClient:     fakeClient,
+		fakeRecorder:   fakeRecorder,
+		eventStream:    eventChannel,
+		fakeMounter:    mounter,
+		runtimeConfig:  runtimeConfig,
+		fakeVolUtil:    fakeVolUtil,
+		cleanupTracker: cleanupTracker,
+	}
+
+	del := provDeleter.NewDeleter(runtimeConfig, cleanupTracker)
+
+	return &DeleteReconciler{ //TODO: use constructor here
+		Client:         fakeClient,
+		Scheme:         scheme,
+		cleanupTracker: &provDeleter.CleanupStatusTracker{ProcTable: deleter.NewProcTable()},
+		runtimeConfig:  runtimeConfig,
+		deleter:        del,
+	}, tc
+}
+
+func TestDeleterReconcile(t *testing.T) {
+	tests := []struct {
+		name                      string
+		deviceName                string
+		dirEntries                []*provUtil.FakeDirEntry
+		nodeList                  *corev1.NodeList
+		targetNodeName            string
+		initialPVs                *corev1.PersistentVolumeList
+		expectedPVs               *corev1.PersistentVolumeList
+		provisionedByPVAnnotation string
+	}{
+		{
+			name:       "Reconcile does not delete a PV with Retain policy",
+			dirEntries: nil,
+			nodeList: makeNodeList([]NodeConfigParams{
+				{
+					NodeName: "Node1", NodeUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				},
+			}),
+			// Name of a node that deleter Reconcile() will see, normally it would get it from env var - it's the name of the node the code runs on.
+			targetNodeName: "Node1",
+			initialPVs: makePersistentVolumeList([]PVConfigParams{
+				{
+					PVName:          "PV-1",
+					PVAnnotation:    "local-volume-provisioner-Node1-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+					PVPhase:         corev1.VolumeReleased,
+				},
+			}),
+			expectedPVs: makePersistentVolumeList([]PVConfigParams{
+				{
+					PVName:          "PV-1",
+					PVAnnotation:    "local-volume-provisioner-Node1-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
+					PVPhase:         corev1.VolumeReleased,
+				},
+			}),
+		},
+		{
+			name: "Reconcile deletes only PVs on its node",
+			dirEntries: []*provUtil.FakeDirEntry{
+				{
+					Name:       "PV-1",
+					VolumeType: provUtil.FakeEntryFile,
+				},
+				{
+					Name:       "PV-2",
+					VolumeType: provUtil.FakeEntryFile,
+				},
+			},
+			nodeList: makeNodeList([]NodeConfigParams{
+				{
+					NodeName: "Node1", NodeUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				},
+			}),
+			targetNodeName: "Node1",
+			initialPVs: makePersistentVolumeList([]PVConfigParams{
+				{
+					PVName:          "PV-1",
+					PVAnnotation:    "local-volume-provisioner-Node1-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+					PVPhase:         corev1.VolumeReleased,
+				},
+				{
+					PVName:          "PV-2",
+					PVAnnotation:    "local-volume-provisioner-Node2-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+					PVPhase:         corev1.VolumeReleased,
+				},
+			}),
+			expectedPVs: makePersistentVolumeList([]PVConfigParams{
+				{
+					PVName:          "PV-2",
+					PVAnnotation:    "local-volume-provisioner-Node2-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+					PVPhase:         corev1.VolumeReleased,
+				},
+			}),
+		},
+		{
+			name: "Reconcile deletes a PV with Delete policy",
+			dirEntries: []*provUtil.FakeDirEntry{
+				{
+					Name:       "PV-1",
+					VolumeType: provUtil.FakeEntryFile,
+				},
+			},
+			nodeList: makeNodeList([]NodeConfigParams{
+				{
+					NodeName: "Node1", NodeUID: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				},
+			}),
+			targetNodeName: "Node1",
+			initialPVs: makePersistentVolumeList([]PVConfigParams{
+				{
+					PVName:          "PV-1",
+					PVAnnotation:    "local-volume-provisioner-Node1-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+					PVReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+					PVPhase:         corev1.VolumeReleased,
+				},
+			}),
+			expectedPVs: &corev1.PersistentVolumeList{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objects := []runtime.Object{
+				test.nodeList,
+				test.initialPVs,
+			}
+
+			cmBytes, err := f.ReadFile("testfiles/provisioner_conf.yaml")
+			if err != nil {
+				t.Fatalf("Failed to load config map: %v", err)
+			}
+			configMap := resourceread.ReadConfigMapV1OrDie(cmBytes)
+
+			r, tc := newFakeDeleteReconciler(t, objects...)
+
+			err = tc.fakeClient.Create(context.TODO(), configMap)
+			if err != nil {
+				t.Fatalf("Failed to create ConfigMap: %v", err)
+			}
+
+			// Rewrite nodeName which is set in init() of the module (from env var).
+			nodeName = test.targetNodeName
+
+			cmNamespace := configMap.GetObjectMeta().GetNamespace()
+			cmName := configMap.GetObjectMeta().GetName()
+			reconRequest := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: cmName, Namespace: cmNamespace},
+			}
+
+			// Create fake directory entries.
+			dirFiles := map[string][]*provUtil.FakeDirEntry{
+				storageClassName: test.dirEntries,
+			}
+			tc.fakeVolUtil.AddNewDirEntries("/mnt/local-storage", dirFiles)
+
+			// Run Reconcile() attempts evaluating state of PVs in each iteration.
+			retries := 5
+			retryWait := 1 * time.Second
+			checkPassed := false
+			for i := retries; i >= 0; i-- {
+				if !checkPassed {
+					result, err := r.Reconcile(context.TODO(), reconRequest)
+					if err != nil {
+						t.Fatalf("Reconcile failed: %v", err)
+					}
+					if result.Requeue {
+						time.Sleep(result.RequeueAfter)
+						result, err = r.Reconcile(context.TODO(), reconRequest)
+					}
+					ok, msg := evaluate(tc, test.expectedPVs)
+					if !ok {
+						t.Logf("Reconcile evaluation did not pass with message: %v attempts remaining: %v", msg, i)
+						t.Logf("Retry after %v", retryWait)
+						time.Sleep(retryWait)
+						continue
+					} else {
+						checkPassed = true
+						t.Log("Reconcile check passed!")
+					}
+
+				}
+			}
+			if !checkPassed {
+				t.Fatalf("Reconcile check failed!")
+			}
+		})
+	}
+}
+
+func evaluate(tc *testContext, expectedPVs *corev1.PersistentVolumeList) (bool, string) {
+	// Get PVs after reconcile.
+	currentPVs := &corev1.PersistentVolumeList{}
+	err := tc.fakeClient.List(context.TODO(), currentPVs)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to get PVs: %v", err)
+		return false, msg
+	}
+
+	var actualPVsValues []corev1.PersistentVolume
+	actualPVsValues = currentPVs.Items
+
+	actualPVsValuesCopy := make([]corev1.PersistentVolume, len(actualPVsValues))
+	copy(actualPVsValuesCopy, actualPVsValues)
+
+	actualPVsValuesCopy2 := make([]corev1.PersistentVolume, len(actualPVsValues))
+	copy(actualPVsValuesCopy2, actualPVsValues)
+
+	// Test that there are no extra PVs left apart from expected ones.
+	for a, actualPV := range actualPVsValuesCopy {
+		for _, expectedPV := range expectedPVs.Items {
+			actualPV.SetResourceVersion("")
+			expectedPV.SetResourceVersion("")
+			if reflect.DeepEqual(actualPV, expectedPV) {
+				actualPVsValuesCopy = RemoveIndex(actualPVsValuesCopy, a)
+			}
+
+		}
+	}
+
+	if len(expectedPVs.Items) == 0 && len(actualPVsValuesCopy) != 0 {
+		msg := fmt.Sprintf("\nExpected to find no PVs after reconcile but some were still found: %v", actualPVsValuesCopy)
+		return false, msg
+	}
+
+	if len(actualPVsValuesCopy) != 0 {
+		msg := fmt.Sprintf("\nFound PVs that were not expected!\nThese PVs are actually present but should not be:\n%v", actualPVsValuesCopy)
+		return false, msg
+	}
+
+	// Test that every expected PV is found.
+	expectedPVsValuesCopy := make([]corev1.PersistentVolume, len(expectedPVs.Items))
+	copy(expectedPVsValuesCopy, expectedPVs.Items)
+
+	if len(expectedPVs.Items) != 0 {
+		for _, actualPV := range actualPVsValuesCopy2 {
+			for e, expectedPV := range expectedPVsValuesCopy {
+				actualPV.SetResourceVersion("")
+				expectedPV.SetResourceVersion("")
+				if reflect.DeepEqual(actualPV, expectedPV) {
+					expectedPVsValuesCopy = RemoveIndex(expectedPVsValuesCopy, e)
+				}
+
+			}
+		}
+	}
+
+	if len(expectedPVsValuesCopy) != 0 {
+		msg := fmt.Sprintf("\nNot all expected PVs found!\nThese PVs were expected but not found:\n%v", expectedPVsValuesCopy)
+		return false, msg
+	}
+
+	return true, ""
+}
+
+func RemoveIndex(s []corev1.PersistentVolume, index int) []corev1.PersistentVolume {
+	ret := make([]corev1.PersistentVolume, 0)
+	ret = append(ret, s[:index]...)
+	return append(ret, s[index+1:]...)
+}

--- a/diskmaker/controllers/deleter/testfiles/provisioner_conf.yaml
+++ b/diskmaker/controllers/deleter/testfiles/provisioner_conf.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+  storageClassMap: |
+    local-sc:
+      fstype: xfs
+      hostDir: /mnt/local-storage/local-sc
+      mountDir: /mnt/local-storage/local-sc
+      volumeMode: Filesystem
+kind: ConfigMap
+metadata:
+  creationTimestamp: "2019-06-28T02:17:43Z"
+  labels:
+    app: local-provisioner
+    local.storage.openshift.io/owner-name: local-disks
+    local.storage.openshift.io/owner-namespace: local-storage
+  name: local-provisioner
+  namespace: local-storage
+  ownerReferences:
+    - apiVersion: local.storage.openshift.io/v1
+      controller: true
+      kind: LocalVolume
+      name: local-disks
+      uid: e96db637-994a-11e9-aa0d-5254002691cd
+  selfLink: /api/v1/namespaces/local-storage/configmaps/local-provisioner
+  uid: e9771a23-994a-11e9-aa0d-5254002691cd

--- a/diskmaker/controllers/lv/reconcile.go
+++ b/diskmaker/controllers/lv/reconcile.go
@@ -280,8 +280,7 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		}
 		for _, pv := range pvList.Items {
 			// skip non-owned PVs
-			name, found := pv.Annotations[provCommon.AnnProvisionedBy]
-			if !found || name != r.runtimeConfig.Name {
+			if !common.PVMatchesProvisioner(pv, r.runtimeConfig.Name) {
 				continue
 			}
 			addOrUpdatePV(r.runtimeConfig, pv)
@@ -732,8 +731,7 @@ func (r *LocalVolumeReconciler) SetupWithManager(mgr ctrl.Manager, cleanupTracke
 
 func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.PersistentVolume, q workqueue.RateLimitingInterface, isDelete bool) {
 	// skip non-owned PVs
-	name, found := pv.Annotations[provCommon.AnnProvisionedBy]
-	if !found || name != runtimeConfig.Name {
+	if !common.PVMatchesProvisioner(*pv, runtimeConfig.Name) {
 		return
 	}
 

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -543,8 +543,7 @@ func (r *LocalVolumeSetReconciler) SetupWithManager(mgr ctrl.Manager, cleanupTra
 
 func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.PersistentVolume, q workqueue.RateLimitingInterface, isDelete bool) {
 	// skip non-owned PVs
-	name, found := pv.Annotations[provCommon.AnnProvisionedBy]
-	if !found || name != runtimeConfig.Name {
+	if !common.PVMatchesProvisioner(*pv, runtimeConfig.Name) {
 		return
 	}
 

--- a/test-framework/framework.go
+++ b/test-framework/framework.go
@@ -184,6 +184,7 @@ func (f *Framework) addToScheme(addToScheme addToSchemeFunc, obj client.ObjectLi
 		}
 		if err != nil {
 			f.restMapper.Reset()
+			log.Warn(err)
 			return false, nil
 		}
 		f.Client = &frameworkClient{Client: dynClient}

--- a/test-framework/utils.go
+++ b/test-framework/utils.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/rogpeppe/go-internal/modfile"
 	log "github.com/sirupsen/logrus"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"


### PR DESCRIPTION
cc @openshift/storage 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2091873

The patch changes PV matching in deleter reconcile loop so it will match also PVs that have node UID in the annotation, effectively ignoring the UID in the cleanup/delete flow. This is needed because node UID is not persistent and if a node gets deleted the UID changes. This can not work because reconcile tired to do exact matching and so PVs were getting stuck in Released state when UID changed.

Manually verified with following steps:

1) PV is bound (with annotation containing random UID)
```
$ oc get pv
NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM           STORAGECLASS   REASON   AGE
local-pv-56c29ba0   10Gi       RWO            Delete           Bound    default/mypvc   mylvs                   80s

$ oc get pv/local-pv-56c29ba0 -o json | jq '.metadata.annotations["pv.kubernetes.io/provisioned-by"]'
"local-volume-provisioner-ip-10-0-135-68.ec2.internal-dca4aa94-fb64-4803-b576-0a8b7019a86c"
```

2) Delete deployment and PVC to release the PV:
```
$ oc delete pvc/mypvc deployment/myapp
persistentvolumeclaim "mypvc" deleted
deployment.apps "myapp" deleted
```

3) Verify PV is Available again and not stuck in Released state:
```
$ oc get pv
NAME                CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS   REASON   AGE
local-pv-56c29ba0   10Gi       RWO            Delete           Available           mylvs                   7s
```


4) Check the diskmaker pod to see that we log info about UID being ignored

`I0708 13:33:35.486306  303623 names.go:117] "PV matches provisioner name (UID is ignored)." pvName="local-pv-56c29ba0" pvAnnotation="local-volume-provisioner-ip-10-0-135-68.ec2.internal-dca4aa94-fb64-4803-b576-0a8b7019a86c" provisionerName="local-volume-provisioner-ip-10-0-135-68.ec2.internal" UID="dca4aa94-fb64-4803-b576-0a8b7019a86c"`

5) Check that LSO re-created PV without UID in annotation
```
$ oc get pv/local-pv-56c29ba0 -o json | jq '.metadata.annotations["pv.kubernetes.io/provisioned-by"]'
"local-volume-provisioner-ip-10-0-135-68.ec2.internal"
```
