### PR TITLE
STOR-977: Refactor reconcilers

### DIFF
--- a/common/controller_runtime_utils.go
+++ b/common/controller_runtime_utils.go
@@ -1,13 +1,19 @@
 package common
 
 import (
+	"context"
 	"fmt"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
 	"os"
+	ctrl "sigs.k8s.io/controller-runtime"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	staticProvisioner "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 )
 
 // EnqueueOnlyLabeledSubcomponents returns a predicate that filters only objects that
@@ -60,4 +66,47 @@ func GetWatchNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", "WATCH_NAMESPACE")
 	}
 	return ns, nil
+}
+
+// ReloadRuntimeConfig obtains all values needed by runtime config during Reconcile and writes them to the existing RuntimeConfig provided
+func ReloadRuntimeConfig(ctx context.Context, client client.Client, request ctrl.Request, nodeName string, rc *staticProvisioner.RuntimeConfig) error {
+	// get associated provisioner config
+	cm := &corev1.ConfigMap{}
+	err := client.Get(ctx, types.NamespacedName{Name: ProvisionerConfigMapName, Namespace: request.Namespace}, cm)
+	if err != nil {
+		klog.ErrorS(err, "could not get provisioner configmap", "name", ProvisionerConfigMapName, "namespace", request.Namespace)
+		return err
+	}
+
+	// get current node
+	node := &corev1.Node{}
+	err = client.Get(ctx, types.NamespacedName{Name: nodeName}, node)
+	if err != nil {
+		klog.ErrorS(err, "could not get current Node", "name", nodeName, "namespace", request.Namespace)
+		return err
+	}
+
+	// read provisioner config
+	provisionerConfig := staticProvisioner.ProvisionerConfiguration{}
+	if err := staticProvisioner.ConfigMapDataToVolumeConfig(cm.Data, &provisionerConfig); err != nil {
+		klog.ErrorS(err, "could not load provisioner config from ConfigMap")
+		return err
+	}
+
+	rc.Name = GetProvisionedByValue(*node)
+	rc.Node = node
+	rc.Namespace = request.Namespace
+	rc.DiscoveryMap = provisionerConfig.StorageClassConfig
+	rc.NodeLabelsForPV = provisionerConfig.NodeLabelsForPV
+	rc.SetPVOwnerRef = provisionerConfig.SetPVOwnerRef
+	rc.UseNodeNameOnly = provisionerConfig.UseNodeNameOnly
+	rc.MinResyncPeriod = provisionerConfig.MinResyncPeriod
+	rc.UseAlphaAPI = provisionerConfig.UseAlphaAPI
+	rc.LabelsForPV = provisionerConfig.LabelsForPV
+
+	// unsupported
+	rc.UseJobForCleaning = false
+
+	return nil
+
 }

--- a/diskmaker/controllers/lv/reconcile.go
+++ b/diskmaker/controllers/lv/reconcile.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"time"
 
+	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	"github.com/openshift/local-storage-operator/common"
 	"github.com/openshift/local-storage-operator/internal"
 	"github.com/openshift/local-storage-operator/localmetrics"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/mount"
@@ -25,10 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	staticProvisioner "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
-
-	localv1 "github.com/openshift/local-storage-operator/api/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 
 	provCache "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache"
@@ -265,16 +263,14 @@ func addOwnerLabels(meta *metav1.ObjectMeta, cr *localv1.LocalVolume) bool {
 func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	klog.InfoS("Reconciling LocalVolume", "namespace", request.Namespace, "name", request.Name)
 
-	if !r.cacheSynced {
-		r.runtimeConfig.Node = &corev1.Node{}
-		err := r.Client.Get(ctx, types.NamespacedName{Name: os.Getenv("MY_NODE_NAME")}, r.runtimeConfig.Node)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-		r.runtimeConfig.Name = common.GetProvisionedByValue(*r.runtimeConfig.Node)
+	err := common.ReloadRuntimeConfig(ctx, r.Client, request, os.Getenv("MY_NODE_NAME"), r.runtimeConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 
+	if !r.cacheSynced {
 		pvList := &corev1.PersistentVolumeList{}
-		err = r.Client.List(context.TODO(), pvList)
+		err := r.Client.List(context.TODO(), pvList)
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to initialize PV cache: %w", err)
 		}
@@ -289,7 +285,7 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	}
 
 	lv := &localv1.LocalVolume{}
-	err := r.Client.Get(ctx, request.NamespacedName, lv)
+	err = r.Client.Get(ctx, request.NamespacedName, lv)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -318,34 +314,6 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	if !matches {
 		return ctrl.Result{}, nil
 	}
-
-	// get associated provisioner config
-	cm := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: common.ProvisionerConfigMapName, Namespace: request.Namespace}, cm)
-	if err != nil {
-		klog.ErrorS(err, "could not get provisioner configmap")
-		return ctrl.Result{}, err
-	}
-
-	// read provisioner config
-	provisionerConfig := staticProvisioner.ProvisionerConfiguration{}
-	staticProvisioner.ConfigMapDataToVolumeConfig(cm.Data, &provisionerConfig)
-
-	r.runtimeConfig.DiscoveryMap = provisionerConfig.StorageClassConfig
-	r.runtimeConfig.NodeLabelsForPV = provisionerConfig.NodeLabelsForPV
-	r.runtimeConfig.Namespace = request.Namespace
-	r.runtimeConfig.SetPVOwnerRef = provisionerConfig.SetPVOwnerRef
-	r.runtimeConfig.Name = common.GetProvisionedByValue(*r.runtimeConfig.Node)
-
-	// ignored by our implementation of static-provisioner,
-	// but not by deleter (if applicable)
-	r.runtimeConfig.UseNodeNameOnly = provisionerConfig.UseNodeNameOnly
-	r.runtimeConfig.MinResyncPeriod = provisionerConfig.MinResyncPeriod
-	r.runtimeConfig.UseAlphaAPI = provisionerConfig.UseAlphaAPI
-	r.runtimeConfig.LabelsForPV = provisionerConfig.LabelsForPV
-
-	// unsupported
-	r.runtimeConfig.UseJobForCleaning = false
 
 	err = os.MkdirAll(r.symlinkLocation, 0755)
 	if err != nil {

--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -247,7 +247,7 @@ func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Obje
 	fakeClient := fake.NewFakeClientWithScheme(scheme, objs...)
 
 	fakeRecorder := record.NewFakeRecorder(10)
-	fakeEventSync := newEventReporter(fakeRecorder)
+
 	mounter := &mount.FakeMounter{
 		MountPoints: []mount.MountPoint{},
 	}
@@ -272,16 +272,16 @@ func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Obje
 		runtimeConfig: runtimeConfig,
 		fakeVolUtil:   fakeVolUtil,
 	}
-	cleanupTracker := &provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()}
-	return &LocalVolumeReconciler{
-		symlinkLocation: symlinkLocation,
-		Client:          fakeClient,
-		Scheme:          scheme,
-		eventSync:       fakeEventSync,
-		cleanupTracker:  cleanupTracker,
-		runtimeConfig:   runtimeConfig,
-		deleter:         provDeleter.NewDeleter(runtimeConfig, cleanupTracker),
-	}, tc
+
+	lvReconciler := NewLocalVolumeReconciler(
+		fakeClient,
+		scheme,
+		symlinkLocation,
+		&provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()},
+		runtimeConfig,
+	)
+
+	return lvReconciler, tc
 
 }
 

--- a/diskmaker/controllers/lvset/device_age.go
+++ b/diskmaker/controllers/lvset/device_age.go
@@ -16,9 +16,9 @@ type timeInterface interface {
 	getCurrentTime() time.Time
 }
 
-type wallTime struct{}
+type WallTime struct{}
 
-func (t *wallTime) getCurrentTime() time.Time {
+func (t *WallTime) getCurrentTime() time.Time {
 	return time.Now()
 }
 

--- a/diskmaker/controllers/lvset/reconcile_test.go
+++ b/diskmaker/controllers/lvset/reconcile_test.go
@@ -19,7 +19,6 @@ import (
 	crFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	provCache "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
-	"sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
 	provDeleter "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
 	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 )
@@ -90,14 +89,13 @@ func newFakeLocalVolumeSetReconciler(t *testing.T, objs ...runtime.Object) (*Loc
 		fakeVolUtil:   fakeVolUtil,
 	}
 
-	cleanupTracker := &provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()}
-	return &LocalVolumeSetReconciler{
-		Client:         fakeClient,
-		Scheme:         scheme,
-		eventReporter:  newEventReporter(fakeRecorder),
-		deviceAgeMap:   newAgeMap(fakeClock),
-		cleanupTracker: &provDeleter.CleanupStatusTracker{ProcTable: deleter.NewProcTable()},
-		runtimeConfig:  runtimeConfig,
-		deleter:        provDeleter.NewDeleter(runtimeConfig, cleanupTracker),
-	}, tc
+	lvsReconciler := NewLocalVolumeSetReconciler(
+		fakeClient,
+		scheme,
+		fakeClock,
+		&provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()},
+		runtimeConfig,
+	)
+
+	return lvsReconciler, tc
 }

--- a/diskmaker_manager/manager.go
+++ b/diskmaker_manager/manager.go
@@ -95,10 +95,13 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = (&diskmakerControllerLv.LocalVolumeReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, &provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()}, provCache.NewVolumeCache()); err != nil {
+	if err = diskmakerControllerLv.NewLocalVolumeReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		common.GetLocalDiskLocationPath(),
+		&provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()},
+		getRuntimeConfig(diskmakerControllerLv.ComponentName, mgr),
+	).WithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create LocalVolume diskmaker controller")
 		return err
 	}

--- a/diskmaker_manager/manager.go
+++ b/diskmaker_manager/manager.go
@@ -103,10 +103,13 @@ func startManager(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = (&diskmakerControllerLvSet.LocalVolumeSetReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr, &provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()}, provCache.NewVolumeCache()); err != nil {
+	if err = diskmakerControllerLvSet.NewLocalVolumeSetReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		&diskmakerControllerLvSet.WallTime{},
+		&provDeleter.CleanupStatusTracker{ProcTable: provDeleter.NewProcTable()},
+		getRuntimeConfig(diskmakerControllerLvSet.ComponentName, mgr),
+	).WithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create LocalVolumeSet diskmaker controller")
 		return err
 	}


### PR DESCRIPTION
Introduce a new helper function - ReloadRuntimeConfig() that loads runtime config values needed for reconcile loops at one place. This should help make the code cleaner by removing copy-paste code and scattered runtime config changes.

Also adding proper constructors to reconcilers which should improve readability and ease constructing them with fakes in tests.

cc @openshift/storage 