### PR TITLE
Bump to 4.13

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.19-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.13

--- a/config/manifests/local-storage-operator.package.yaml
+++ b/config/manifests/local-storage-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: local-storage-operator
 channels:
 - name: stable
-  currentCSV: local-storage-operator.v4.12.0
+  currentCSV: local-storage-operator.v4.13.0

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: local-storage-operator.v4.12.0
+  name: local-storage-operator.v4.13.0
   namespace: placeholder
   annotations:
     alm-examples: |-
@@ -99,7 +99,7 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes.
-    olm.skipRange: ">=4.3.0 <4.12.0"
+    olm.skipRange: ">=4.3.0 <4.13.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
     # This annotation injection is a workaround for BZ-1950047, since the associated
@@ -128,7 +128,7 @@ spec:
       url: https://github.com/openshift/local-storage-operator/tree/master/docs
     - name: Source Repository
       url: https://github.com/openshift/local-storage-operator
-  version: 4.12.0
+  version: 4.13.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -138,7 +138,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: local-storage-operator
-    alm-status-descriptors: local-storage-operator.v4.12.0
+    alm-status-descriptors: local-storage-operator.v4.13.0
   selector:
     matchLabels:
       alm-owner-metering: local-storage-operator


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-5087

Once configuration is bumped, the operator can be re-enabled in 4.13