### PR TITLE
OCPBUGS-4346: fix naming convention

### DIFF
--- a/config/manifests/art.yaml
+++ b/config/manifests/art.yaml
@@ -3,7 +3,7 @@ updates:
     update_list:
     # replace metadata.name value
     - search: "local-storage-operator.v{MAJOR}.{MINOR}.0"
-      replace: "local-storage-operator.{FULL_VER}"
+      replace: "local-storage-operator.v{FULL_VER}"
     # replace entire version line, otherwise would replace 4.3.0 anywhere
     - search: "version: {MAJOR}.{MINOR}.0"
       replace: "version: {FULL_VER}"


### PR DESCRIPTION
there is a warning reported in CVP check for 4.12
`Warning: Value : (local-storage-operator.4.12.0-202211081106) csv.metadata.Name local-storage-operator.4.12.0-202211081106 is not following the recommended naming convention: <operator-name>.v<semver> e.g. memcached-operator.v0.0.1`
http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/local-storage-operator-metadata-container-v4.12.0.202211081106.p0.g9621dbf.assembly.stream-1/eb7a6164-8072-45c9-8c1b-1509785971c9/operator-metadata-linting-bundle-image-output.txt
I think this could be a common issue, so pr against master can cherry-pick to 4.12 branch later.