### PR TITLE
OCPBUGS-396: Add alerts about empty DaemonSet

### DIFF
--- a/assets/templates/localmetrics/prometheus-rule.yaml
+++ b/assets/templates/localmetrics/prometheus-rule.yaml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: local-storage-operator
+  namespace: openshift-local-storage
+  labels:
+    app: local-storage-operator
+spec:
+  groups:
+    - name: local-storage-operator.rules
+      rules:
+      - alert: LSONoDiskManagerReplicas
+        expr:  max_over_time(kube_daemonset_status_desired_number_scheduled{namespace="openshift-local-storage", daemonset="diskmaker-manager"}[5m]) == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LocalVolume / LocalVolumeSet does not match any node"
+          description: |
+            Local Storage Operator disk-manager DaemonSet does not have any scheduled replicas.
+            This DaemonSet handles LocalVolume and LocalVolumeSet objects and creates
+            PersistentVolumes (PVs) for devices described in these objects. As result, Local
+            Storage Operator is not able to create the PVs.
+            Please check all LocalVolume and LocalVolumeSet objects and make sure that they have
+            correct "nodeSelector" and "tolerations" fields, and there are nodes that match the
+            nodeSelector and all taints of the matching nodes are tolerated.
+            A frequent issue is that nodes that run OpenShift Data Foundation (ODF) are tainted,
+            so only ODF runs on these nodes. In that case, LocalVolume / LocalVolumeSet objects
+            must tolerate such a taint to provide disks for ODF on the nodes.

--- a/assets/templates/localmetrics/prometheus-rule.yaml
+++ b/assets/templates/localmetrics/prometheus-rule.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: local-storage-operator
-  namespace: openshift-local-storage
+  namespace: ${OBJECT_NAMESPACE}
   labels:
     app: local-storage-operator
 spec:
@@ -10,7 +10,7 @@ spec:
     - name: local-storage-operator.rules
       rules:
       - alert: LSONoDiskManagerReplicas
-        expr:  max_over_time(kube_daemonset_status_desired_number_scheduled{namespace="openshift-local-storage", daemonset="diskmaker-manager"}[5m]) == 0
+        expr:  max_over_time(kube_daemonset_status_desired_number_scheduled{namespace="${OBJECT_NAMESPACE}", daemonset="${DAEMONSET_NAME}"}[5m]) == 0
         for: 10m
         labels:
           severity: warning

--- a/assets/templates/localmetrics/service-monitor.yaml
+++ b/assets/templates/localmetrics/service-monitor.yaml
@@ -1,17 +1,19 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: lso-metrics-exporter
-  namespace: openshift-local-storage
+  name: ${OBJECT_NAME}
+  namespace: ${OBJECT_NAMESPACE}
   labels:
-    app: lso-metrics-exporter
+    app: ${APP_LABEL}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ${SERVICE_CERT_NAME}
 spec:
   namespaceSelector:
     matchNames:
-      - openshift-local-storage
+      - ${OBJECT_NAMESPACE}
   selector:
     matchLabels:
-      app: lso-metrics-exporter
+      app: ${APP_LABEL}
   endpoints:
   - port: metrics
     path: /metrics
@@ -20,4 +22,4 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: lso-metrics-exporter.openshift-local-storage.svc
+      serverName: ${OBJECT_NAME}.${OBJECT_NAMESPACE}.svc

--- a/assets/templates/localmetrics/service.yaml
+++ b/assets/templates/localmetrics/service.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: lso-metrics-serving-cert
-  name: lso-metrics-exporter
-  namespace: openshift-local-storage
+    service.beta.openshift.io/serving-cert-secret-name: ${SERVICE_CERT_NAME}
+  name: ${OBJECT_NAME}
+  namespace: ${OBJECT_NAMESPACE}
   labels:
-    app: lso-metrics-exporter
+    app: ${APP_LABEL}
 spec:
   type: ClusterIP
   ports:
@@ -15,4 +15,4 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    app: lso-metrics-exporter
+    app: ${APP_LABEL}

--- a/common/names.go
+++ b/common/names.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"os"
 	"regexp"
+
+	"k8s.io/klog/v2"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
@@ -41,6 +42,7 @@ const (
 	DiskMakerDiscoveryDaemonSetTemplate = "templates/diskmaker-discovery-daemonset.yaml"
 	MetricsServiceTemplate              = "templates/localmetrics/service.yaml"
 	MetricsServiceMonitorTemplate       = "templates/localmetrics/service-monitor.yaml"
+	PrometheusRuleTemplate              = "templates/localmetrics/prometheus-rule.yaml"
 
 	// DiskMakerServiceName is the name of the service created for the diskmaker daemon
 	DiskMakerServiceName = "local-storage-diskmaker-metrics"

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -215,6 +215,7 @@ spec:
             - monitoring.coreos.com
             resources:
             - servicemonitors
+            - prometheusrules
             verbs:
             - get
             - list

--- a/controllers/localvolumediscovery/localvolumediscovery_controller.go
+++ b/controllers/localvolumediscovery/localvolumediscovery_controller.go
@@ -83,9 +83,8 @@ func (r *LocalVolumeDiscoveryReconciler) Reconcile(ctx context.Context, request 
 	}
 
 	// enable service and service monitor for Local Volume Discovery
-	serviceLabels := map[string]string{"app": DiskMakerDiscovery}
 	metricsExportor := localmetrics.NewExporter(ctx, r.Client, common.DiscoveryServiceName, instance.Namespace, common.DiscoveryMetricsServingCert,
-		getOwnerRefs(instance), serviceLabels)
+		getOwnerRefs(instance), DiskMakerDiscovery)
 	if err := metricsExportor.EnableMetricsExporter(); err != nil {
 		klog.ErrorS(err, "failed to create service and servicemonitors", "object", instance.Name)
 		return ctrl.Result{}, err

--- a/controllers/nodedaemon/reconcile.go
+++ b/controllers/nodedaemon/reconcile.go
@@ -92,6 +92,11 @@ func (r *DaemonReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	if err := localmetrics.CreateOrUpdateAlertRules(ctx, r.Client, request.Namespace, ownerRefs); err != nil {
+		klog.ErrorS(err, "failed to create alerting rules")
+		return ctrl.Result{}, err
+	}
+
 	configMapDataHash := dataHash(configMap.Data)
 
 	diskMakerDSMutateFn := getDiskMakerDSMutateFn(request, tolerations, ownerRefs, nodeSelector, configMapDataHash)

--- a/controllers/nodedaemon/reconcile.go
+++ b/controllers/nodedaemon/reconcile.go
@@ -84,15 +84,14 @@ func (r *DaemonReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 	}
 
 	// enable service and servicemonitor for diskmaker daemonset
-	serviceLabels := map[string]string{"app": DiskMakerName}
 	metricsExportor := localmetrics.NewExporter(ctx, r.Client, common.DiskMakerServiceName, request.Namespace, common.DiskMakerMetricsServingCert,
-		ownerRefs, serviceLabels)
+		ownerRefs, DiskMakerName)
 	if err := metricsExportor.EnableMetricsExporter(); err != nil {
 		klog.ErrorS(err, "failed to create service and servicemonitors for diskmaker daemonset")
 		return ctrl.Result{}, err
 	}
 
-	if err := localmetrics.CreateOrUpdateAlertRules(ctx, r.Client, request.Namespace, ownerRefs); err != nil {
+	if err := localmetrics.CreateOrUpdateAlertRules(ctx, r.Client, request.Namespace, DiskMakerName, ownerRefs); err != nil {
 		klog.ErrorS(err, "failed to create alerting rules")
 		return ctrl.Result{}, err
 	}

--- a/localmetrics/alerts.go
+++ b/localmetrics/alerts.go
@@ -1,0 +1,73 @@
+package localmetrics
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/openshift/local-storage-operator/assets"
+	"github.com/openshift/local-storage-operator/common"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sYAML "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CreateOrUpdateAlertRules installs all LSO alerting rules
+func CreateOrUpdateAlertRules(ctx context.Context, client client.Client, namespace string, ownerRefs []metav1.OwnerReference) error {
+	rule, err := getPrometheusRule()
+	if err != nil {
+		return fmt.Errorf("failed to get prometheus rule. %v", err)
+	}
+
+	rule.SetNamespace(namespace)
+	rule.SetOwnerReferences(ownerRefs)
+
+	if _, err = createOrUpdatePrometheusRule(ctx, client, rule); err != nil {
+		return fmt.Errorf("failed to enable prometheus rule. %v", err)
+	}
+
+	return nil
+}
+
+// createOrUpdatePrometheusRule creates prometheusRule object or an error
+func createOrUpdatePrometheusRule(ctx context.Context, client client.Client, rule *monitoringv1.PrometheusRule) (*monitoringv1.PrometheusRule, error) {
+	namespacedName := types.NamespacedName{Name: rule.Name, Namespace: rule.Namespace}
+	klog.InfoS("Reconciling prometheus rule", "namespace", rule.GetNamespace(), "name", rule.GetName())
+
+	oldRule := &monitoringv1.PrometheusRule{}
+	err := client.Get(ctx, namespacedName, oldRule)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			err = client.Create(ctx, rule)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create prometheusrule %v. %v", namespacedName, err)
+			}
+			return rule, nil
+		}
+		return nil, fmt.Errorf("failed to retrieve prometheusrule %v. %v", namespacedName, err)
+	}
+	oldRule.Spec = rule.Spec
+	err = client.Update(ctx, oldRule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update prometheusrule %v. %v", namespacedName, err)
+	}
+	return rule, nil
+}
+
+func getPrometheusRule() (*monitoringv1.PrometheusRule, error) {
+	file, err := assets.ReadFile(common.PrometheusRuleTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch prometheus rule file. %v", err)
+	}
+
+	var rule monitoringv1.PrometheusRule
+	err = k8sYAML.NewYAMLOrJSONDecoder(bytes.NewBufferString(string(file)), 10000).Decode(&rule)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode prometheus rule file: %s", err)
+	}
+	return &rule, nil
+}

--- a/localmetrics/exporter_test.go
+++ b/localmetrics/exporter_test.go
@@ -59,3 +59,18 @@ func TestEnableServiceMonitor(t *testing.T) {
 	assert.Equal(t, fakeLabels, expectedServce.Labels)
 	assert.Equal(t, fakeLabels, expectedServce.Spec.Selector.MatchLabels)
 }
+
+func TestEnablePrometheusRule(t *testing.T) {
+	fakeExporter := NewExporter(context.TODO(), getFakeClient(t), "test-service-monitor", "test-ns", "test-cert", []metav1.OwnerReference{}, fakeLabels)
+	err := fakeExporter.enablePrometheusRule()
+	assert.NoError(t, err)
+
+	// assert that service monitor was created with correct parameters.
+	expectedRule := &monitoringv1.PrometheusRule{}
+
+	err = fakeExporter.Client.Get(fakeExporter.Ctx,
+		types.NamespacedName{Name: "test-service-monitor", Namespace: "test-ns"}, expectedRule)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-service-monitor", expectedRule.Name)
+	assert.Equal(t, fakeLabels, expectedRule.Labels)
+}


### PR DESCRIPTION
Raise an alert when disk-manager DaemonSet has no scheduled replicas - that means either no node matched its `nodeSelector` or the nodes are tainted.

Reusing existing `kube_daemonset_status_desired_number_scheduled` metric and expecting that disk-maker DaemonSet name + namespace are fixed - the code suggests so.

@openshift/storage 