### PR TITLE
[release-4.11] OCPBUGS-2476: do not flag PV as cleaned in cache too early

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,6 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.0
 )
 
-replace sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220208224017-4561a388c9eb // for bug 2032924
+replace sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170331-33a18b720643 // BUG: https://issues.redhat.com/browse/OCPBUGS-2450
 
 replace github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -530,8 +530,8 @@ github.com/openshift/client-go v0.0.0-20220504114320-6aec01bb0754 h1:E/SORtM8rYR
 github.com/openshift/client-go v0.0.0-20220504114320-6aec01bb0754/go.mod h1:0KyRH70L+vAGs8wkOkqbsE9qR4lgjW2ugJsCzl1nj5w=
 github.com/openshift/library-go v0.0.0-20220512194226-3c66b317b110 h1:5lgF3YD1XwaJVtasYsWKFTwI3ZUwuVMcMAwJf2x4YSY=
 github.com/openshift/library-go v0.0.0-20220512194226-3c66b317b110/go.mod h1:1QSdymJBGXSOgBj7tWhj4cV+i1+AvkQ/Tq78ebWjXCU=
-github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220208224017-4561a388c9eb h1:3lWe/gOwI0oMBmVkacbKA/JA6JyRnZDFxQorMtRVifs=
-github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220208224017-4561a388c9eb/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170331-33a18b720643 h1:3BGcwHCByPSXWDwgEMLP+bx6EY7vH0RqDXPiLPcSHis=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170331-33a18b720643/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -904,7 +904,7 @@ sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1
 # sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 ## explicit; go 1.13
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/util
-# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220208224017-4561a388c9eb
+# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170331-33a18b720643
 ## explicit; go 1.13
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common
@@ -946,5 +946,5 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.24.0
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.24.0
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.24.0
-# sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220208224017-4561a388c9eb
+# sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170331-33a18b720643
 # github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt v3.2.1+incompatible

--- a/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache/cache.go
+++ b/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache/cache.go
@@ -100,6 +100,15 @@ func (cache *VolumeCache) CleanPV(pv *v1.PersistentVolume) {
 	klog.Infof("Marked pv %q as cleaned in the cache", pv.Name)
 }
 
+// UncleanPV marks the PV object as not cleaned in the cache
+func (cache *VolumeCache) UncleanPV(pv *v1.PersistentVolume) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.cleaned[pv.Name] = false
+	klog.Infof("Marked pv %q as not clean in the cache", pv.Name)
+}
+
 // SuccessfullyCleanedPV returns true if the PV was already cleaned once
 // since the cache entry was created, or if the cache entry no longer exists.
 func (cache *VolumeCache) SuccessfullyCleanedPV(pv *v1.PersistentVolume) bool {

--- a/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
+++ b/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
@@ -169,6 +169,8 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {
+				// PV failed to delete in API server, flag the PV as not cleaned so next reconcile attempts the deletion again.
+				d.Cache.UncleanPV(pv)
 				d.RuntimeConfig.Recorder.Eventf(pv, v1.EventTypeWarning, common.EventVolumeFailedDelete,
 					err.Error())
 				return fmt.Errorf("Error deleting PV %q: %v", pv.Name, err.Error())


### PR DESCRIPTION
Carry patch with a fix has been merged to 4.11: https://github.com/openshift/sig-storage-local-static-provisioner/pull/43.

Bump to the fixed version and vendor.