### PR TITLE
[release-4.10] OCPBUGS-2477: do not flag PV as cleaned in cache too early

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 	sigs.k8s.io/controller-runtime v0.11.0
 	sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2
-	sigs.k8s.io/yaml v1.3.0
 )
 
 replace (
@@ -64,4 +63,4 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.0
 )
 
-replace sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220215091038-b6e8dca7c955 // for bug 2052756
+replace sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170411-067d1a5bfbe1 // BUG: https://issues.redhat.com/browse/OCPBUGS-2450

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6b
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
 github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492 h1:oj/rSQqVWVj6YJUydZwLz2frrJreiyI4oa9g/YPgMsM=
 github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
-github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220215091038-b6e8dca7c955 h1:V0TfvEmtamNR6ux4mMJgqzBu8c7Ja9HzANXUm5ORTV8=
-github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220215091038-b6e8dca7c955/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170411-067d1a5bfbe1 h1:AskWkKD1ezuvmDOuSP8MuaH3ByPoI7S2xZr6jS0f+K0=
+github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170411-067d1a5bfbe1/go.mod h1:9IxtMY+/rQNK7aQ3MMjrcMOF8M/ej8ql9493/24p/KU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -796,7 +796,7 @@ sigs.k8s.io/json/internal/golang/encoding/json
 sigs.k8s.io/kube-storage-version-migrator/pkg/apis/migration/v1alpha1
 # sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 sigs.k8s.io/sig-storage-lib-external-provisioner/v6/util
-# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220215091038-b6e8dca7c955
+# sigs.k8s.io/sig-storage-local-static-provisioner v0.0.0-20210414025242-c96e27d784e2 => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170411-067d1a5bfbe1
 ## explicit
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache
 sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common
@@ -809,7 +809,6 @@ sigs.k8s.io/structured-merge-diff/v4/schema
 sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
-## explicit
 sigs.k8s.io/yaml
 # k8s.io/api => k8s.io/api v0.23.0
 # k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.23.0
@@ -837,4 +836,4 @@ sigs.k8s.io/yaml
 # k8s.io/mount-utils => k8s.io/mount-utils v0.23.0
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.0
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.23.0
-# sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20220215091038-b6e8dca7c955
+# sigs.k8s.io/sig-storage-local-static-provisioner => github.com/openshift/sig-storage-local-static-provisioner v0.0.0-20221017170411-067d1a5bfbe1

--- a/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache/cache.go
+++ b/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/cache/cache.go
@@ -100,6 +100,15 @@ func (cache *VolumeCache) CleanPV(pv *v1.PersistentVolume) {
 	klog.Infof("Marked pv %q as cleaned in the cache", pv.Name)
 }
 
+// UncleanPV marks the PV object as not cleaned in the cache
+func (cache *VolumeCache) UncleanPV(pv *v1.PersistentVolume) {
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+
+	cache.cleaned[pv.Name] = false
+	klog.Infof("Marked pv %q as not clean in the cache", pv.Name)
+}
+
 // SuccessfullyCleanedPV returns true if the PV was already cleaned once
 // since the cache entry was created, or if the cache entry no longer exists.
 func (cache *VolumeCache) SuccessfullyCleanedPV(pv *v1.PersistentVolume) bool {

--- a/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
+++ b/vendor/sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter/deleter.go
@@ -169,6 +169,8 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 		klog.Infof("Deleting pv %s after successful cleanup", pv.Name)
 		if err = d.APIUtil.DeletePV(pv.Name); err != nil {
 			if !errors.IsNotFound(err) {
+				// PV failed to delete in API server, flag the PV as not cleaned so next reconcile attempts the deletion again.
+				d.Cache.UncleanPV(pv)
 				d.RuntimeConfig.Recorder.Eventf(pv, v1.EventTypeWarning, common.EventVolumeFailedDelete,
 					err.Error())
 				return fmt.Errorf("Error deleting PV %q: %v", pv.Name, err.Error())


### PR DESCRIPTION
Carry patch with a fix has been merged to 4.10: https://github.com/openshift/sig-storage-local-static-provisioner/pull/44.

Bump to the fixed version and vendor.