### PR TITLE
bump builder image golang to 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 RUN make build-operator


### PR DESCRIPTION
Recent [update](https://github.com/openshift/local-storage-operator/pull/387/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3) bumped golang version in go.mod. CI passed due to ci-operator image replacement, but local builds now fail:

```
$ ./hack/sync_bundle -o quay.io/rbednar/test:lso -d quay.io/rbednar/test:diskmaker -b quay.io/rbednar/test:bundle -i quay.io/rbednar/test:index bundle
.
.
.
 => ERROR [builder 4/4] RUN make build-diskmaker                                                                                                                                                                                                                    310.9s
------                                                                                                                                                                                                                                                                     
 > [builder 4/4] RUN make build-diskmaker:                                                                                                                                                                                                                                 
#10 0.702 env GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags '-X main.version=7049fd98cfc87360dbe4f86bd7070992767c423a' -o /go/src/github.com/openshift/local-storage-operator/_output/bin/diskmaker /go/src/github.com/openshift/local-storage-operator/diskmaker_manager                                                                                                                                                                                                                                                                     
#10 96.13 # k8s.io/component-base/metrics                                                                                                                                                                                                                                  
#10 96.13 vendor/k8s.io/component-base/metrics/registry.go:35:29: undefined: atomic.Bool
#10 96.13 note: module requires Go 1.19
#10 310.6 make: *** [Makefile:223: build-diskmaker] Error 2
------
executor failed running [/bin/sh -c make build-diskmaker]: exit code: 2

```

cc @openshift/storage 