### PR TITLE
OCPBUGS-10865: Gather Node and PersistentVolume objects

### DIFF
--- a/must-gather/gather
+++ b/must-gather/gather
@@ -10,4 +10,7 @@ for I in $(/usr/bin/oc get crd | grep local.storage.openshift.io | awk '{print $
     /usr/bin/oc adm inspect $I --all-namespaces --dest-dir=must-gather/
 done
 
+# Nodes and PVs
+/usr/bin/oc adm inspect nodes,persistentvolumes --dest-dir=must-gather/
+
 exit 0


### PR DESCRIPTION
The patch ensures that must-gather contains all node and pvs yaml-s. This is useful for debugging problems (see Problem Description in OCPBUGS-10865).

For example, in SNO setup I have one node and two pvs:
```
$ oc get nodes
NAME                 STATUS   ROLES                         AGE   VERSION
crc-8tnb7-master-0   Ready    control-plane,master,worker   13d   v1.25.7+eab9cc9

$ oc get pv
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                                 STORAGECLASS                   REASON   AGE
local-pv-53799107                          1Gi        RWO            Delete           Bound    default/claim1                                        local-sc                                5h3m
pvc-50372074-2c2b-4600-a4f1-c0bbc6917dd0   30Gi       RWX            Delete           Bound    openshift-image-registry/crc-image-registry-storage   crc-csi-hostpath-provisioner            12d
```

With this diff applied, must-gather contains:
```
$ ls -l cluster-scoped-resources/core/nodes/
total 16
-rwxr-xr-x. 1 maxim maxim 15780 Apr 10 15:15 crc-8tnb7-master-0.yaml

$ ls -l cluster-scoped-resources/core/persistentvolumes/
total 8
-rwxr-xr-x. 1 maxim maxim 3064 Apr 10 15:15 local-pv-53799107.yaml
-rwxr-xr-x. 1 maxim maxim 3008 Apr 10 15:15 pvc-50372074-2c2b-4600-a4f1-c0bbc6917dd0.yaml
```