### PR TITLE
OCPBUGS-10884: add multipath support for volume discovery

### DIFF
--- a/api/v1alpha1/localvolumediscovery_types.go
+++ b/api/v1alpha1/localvolumediscovery_types.go
@@ -43,6 +43,8 @@ const (
 	PartType DiscoveredDeviceType = "part"
 	// LVMType is an LVM type
 	LVMType DiscoveredDeviceType = "lvm"
+	// MultiPathType is a multipath type
+	MultiPathType DiscoveredDeviceType = "mpath"
 )
 
 // LocalVolumeDiscoverySpec defines the desired state of LocalVolumeDiscovery

--- a/diskmaker/controllers/lvset/matcher_test.go
+++ b/diskmaker/controllers/lvset/matcher_test.go
@@ -395,6 +395,12 @@ func TestInTypeList(t *testing.T) {
 		},
 		{
 			matcherMap: matcherMap, matcher: matcher,
+			dev:         internal.BlockDevice{Type: string(localv1alpha1.MultiPathType)},
+			spec:        &localv1alpha1.DeviceInclusionSpec{DeviceTypes: []localv1alpha1.DeviceType{"MPATH"}},
+			expectMatch: true, expectErr: false,
+		},
+		{
+			matcherMap: matcherMap, matcher: matcher,
 			dev:         internal.BlockDevice{Type: string(localv1alpha1.Partition)},
 			spec:        &localv1alpha1.DeviceInclusionSpec{DeviceTypes: []localv1alpha1.DeviceType{"DISK", "PART"}},
 			expectMatch: true, expectErr: false,

--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -194,7 +194,26 @@ func getDiscoverdDevices(blockDevices []internal.BlockDevice) []v1alpha1.Discove
 		discoveredDevices = append(discoveredDevices, discoveredDevice)
 	}
 
-	return discoveredDevices
+	return uniqueDevices(discoveredDevices)
+}
+
+// uniqueDevices removes duplicate devices from the list using DeviceID as a key
+// TODO: remove this and use lsblk with -M flag once base images are updated and lsblk v2.34 or higher is available
+// See: https://github.com/util-linux/util-linux/blob/3be31a106c52e093928afbea2cddbdbe44cfb357/Documentation/releases/v2.34-ReleaseNotes#L18
+func uniqueDevices(sample []v1alpha1.DiscoveredDevice) []v1alpha1.DiscoveredDevice {
+	var unique []v1alpha1.DiscoveredDevice
+	type key struct{ value string }
+	m := make(map[key]int)
+	for _, v := range sample {
+		k := key{v.DeviceID}
+		if i, ok := m[k]; ok {
+			unique[i] = v
+		} else {
+			m[k] = len(unique)
+			unique = append(unique, v)
+		}
+	}
+	return unique
 }
 
 // ignoreDevices checks if a device should be ignored during discovery

--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -179,8 +179,12 @@ func getDiscoverdDevices(blockDevices []internal.BlockDevice) []v1alpha1.Discove
 			klog.Warningf("failed to parse size for the device %q. Error %v", blockDevice.Name, err)
 		}
 
+		path, err := blockDevice.GetDevPath()
+		if err != nil {
+			klog.Warningf("failed to parse path for the device %q. Error %v", blockDevice.KName, err)
+		}
 		discoveredDevice := v1alpha1.DiscoveredDevice{
-			Path:     fmt.Sprintf("/dev/%s", blockDevice.Name),
+			Path:     path,
 			Model:    blockDevice.Model,
 			Vendor:   blockDevice.Vendor,
 			FSType:   blockDevice.FSType,
@@ -308,6 +312,8 @@ func parseDeviceType(deviceType string) v1alpha1.DiscoveredDeviceType {
 		return v1alpha1.PartType
 	case deviceType == "lvm":
 		return v1alpha1.LVMType
+	case deviceType == "mpath":
+		return v1alpha1.MultiPathType
 	}
 
 	return ""

--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -206,10 +206,10 @@ func getDiscoverdDevices(blockDevices []internal.BlockDevice) []v1alpha1.Discove
 // See: https://github.com/util-linux/util-linux/blob/3be31a106c52e093928afbea2cddbdbe44cfb357/Documentation/releases/v2.34-ReleaseNotes#L18
 func uniqueDevices(sample []v1alpha1.DiscoveredDevice) []v1alpha1.DiscoveredDevice {
 	var unique []v1alpha1.DiscoveredDevice
-	type key struct{ value string }
+	type key struct{ value, value2 string }
 	m := make(map[key]int)
 	for _, v := range sample {
-		k := key{v.DeviceID}
+		k := key{v.DeviceID, v.Path}
 		if i, ok := m[k]; ok {
 			unique[i] = v
 		} else {

--- a/diskmaker/discovery/discovery.go
+++ b/diskmaker/discovery/discovery.go
@@ -147,12 +147,9 @@ func (discovery *DeviceDiscovery) discoverDevices() error {
 
 // getValidBlockDevices fetchs all the block devices sutitable for discovery
 func getValidBlockDevices() ([]internal.BlockDevice, error) {
-	blockDevices, badRows, err := internal.ListBlockDevices([]string{})
+	blockDevices, output, err := internal.ListBlockDevices([]string{})
 	if err != nil {
-
-		return blockDevices, errors.Wrapf(err, "failed to list all the block devices in the node.")
-	} else if len(badRows) > 0 {
-		klog.Warningf("failed to parse all the lsblk rows. Bad rows: %+v", badRows)
+		return blockDevices, errors.Wrapf(err, "failed to list all the block devices in the node, stderr=%v", output)
 	}
 
 	// Get valid list of devices

--- a/diskmaker/discovery/discovery_test.go
+++ b/diskmaker/discovery/discovery_test.go
@@ -151,6 +151,21 @@ func TestIgnoreDevices(t *testing.T) {
 			errMessage: fmt.Errorf("ignored wrong device"),
 		},
 		{
+			label: "don't ignore mpath type",
+			blockDevice: internal.BlockDevice{
+				Name:     "sdc",
+				KName:    "dm-0",
+				ReadOnly: "0",
+				State:    "running",
+				Type:     "mpath",
+			},
+			fakeGlobfunc: func(name string) ([]string, error) {
+				return []string{"removable", "subsytem"}, nil
+			},
+			expected:   false,
+			errMessage: fmt.Errorf("ignored wrong device"),
+		},
+		{
 			label: "ignore read only devices",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",

--- a/diskmaker/discovery/discovery_test.go
+++ b/diskmaker/discovery/discovery_test.go
@@ -121,7 +121,7 @@ func TestIgnoreDevices(t *testing.T) {
 		errMessage   error
 	}{
 		{
-			label: "Case 1: don't ignore disk type",
+			label: "don't ignore disk type",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",
 				KName:    "sdb",
@@ -136,7 +136,7 @@ func TestIgnoreDevices(t *testing.T) {
 			errMessage: fmt.Errorf("ignored wrong device"),
 		},
 		{
-			label: "Case 2: don't ignore lvm type",
+			label: "don't ignore lvm type",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",
 				KName:    "sdb",
@@ -151,7 +151,7 @@ func TestIgnoreDevices(t *testing.T) {
 			errMessage: fmt.Errorf("ignored wrong device"),
 		},
 		{
-			label: "Case 3: ignore read only devices",
+			label: "ignore read only devices",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",
 				KName:    "sdb",
@@ -166,7 +166,7 @@ func TestIgnoreDevices(t *testing.T) {
 			errMessage: fmt.Errorf("failed to ignore read only device"),
 		},
 		{
-			label: "Case 4: ignore devices in suspended state",
+			label: "ignore devices in suspended state",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",
 				KName:    "sdb",
@@ -181,7 +181,7 @@ func TestIgnoreDevices(t *testing.T) {
 			errMessage: fmt.Errorf("ignored wrong suspended device"),
 		},
 		{
-			label: "Case 5: ignore root device with children",
+			label: "ignore root device with children",
 			blockDevice: internal.BlockDevice{
 				Name:     "sdb",
 				KName:    "sdb",

--- a/diskmaker/discovery/discovery_test.go
+++ b/diskmaker/discovery/discovery_test.go
@@ -467,7 +467,7 @@ func TestGetDiscoveredDevices(t *testing.T) {
 				{
 					Name:       "sda",
 					KName:      "dm-0",
-					FSType:     "xfs",
+					FSType:     "",
 					Type:       "mpath",
 					Size:       "62913494528",
 					Model:      "",
@@ -487,15 +487,15 @@ func TestGetDiscoveredDevices(t *testing.T) {
 			expected: []v1alpha1.DiscoveredDevice{
 				{
 					DeviceID: "/dev/disk/by-id/dm-name-mpatha",
-					Path:     "/dev/mapper/mpatha",
+					Path:     "/dev/dm-0",
 					Model:    "",
 					Type:     "mpath",
 					Vendor:   "",
 					Serial:   "",
 					Size:     int64(62913494528),
 					Property: "NonRotational",
-					FSType:   "xfs",
-					Status:   v1alpha1.DeviceStatus{State: v1alpha1.NotAvailable},
+					FSType:   "",
+					Status:   v1alpha1.DeviceStatus{State: v1alpha1.Unknown},
 				},
 			},
 			fakeGlobfunc: func(name string) ([]string, error) {

--- a/internal/diskutil.go
+++ b/internal/diskutil.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/klog/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -214,9 +215,10 @@ func ListBlockDevices(devices []string) ([]BlockDevice, []string, error) {
 	columns := "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,KNAME,SERIAL,PARTLABEL"
 	args := []string{"--pairs", "-b", "-o", columns}
 	cmd := ExecCommand("lsblk", args...)
+	klog.Infof("Executing command: %#v", cmd)
 	output, err := executeCmdWithCombinedOutput(cmd)
 	if err != nil {
-		return []BlockDevice{}, []string{}, err
+		return []BlockDevice{}, []string{output}, err
 	}
 	badRows := make([]string, 0)
 	// convert to json and then Marshal.
@@ -249,6 +251,9 @@ func ListBlockDevices(devices []string) ([]BlockDevice, []string, error) {
 		if len(strings.Trim(name, " ")) == 0 {
 			badRows = append(badRows, row)
 			break
+		}
+		if len(badRows) > 0 {
+			klog.Warningf("failed to parse all the lsblk rows. Bad rows: %+v", badRows)
 		}
 
 		// Update device filesystem using `blkid`
@@ -441,7 +446,7 @@ func (e *ExclusiveFileLock) Unlock() error {
 func executeCmdWithCombinedOutput(cmd *exec.Cmd) (string, error) {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", err
+		return string(output), err
 	}
 	return strings.TrimSpace(string(output)), nil
 }

--- a/internal/diskutil.go
+++ b/internal/diskutil.go
@@ -27,6 +27,8 @@ const (
 	StateSuspended = "suspended"
 	// DiskByIDDir is the path for symlinks to the device by id.
 	DiskByIDDir = "/dev/disk/by-id/"
+	// DiskDMDir is the path for symlinks of device mapper disks (e.g. mpath)
+	DiskDMDir = "/dev/mapper/"
 )
 
 // IDPathNotFoundError indicates that a symlink to the device was not found in /dev/disk/by-id/
@@ -146,11 +148,15 @@ func (b BlockDevice) HasBindMounts() (bool, string, error) {
 }
 
 // GetDevPath for block device (/dev/sdx)
-func (b BlockDevice) GetDevPath() (string, error) {
+func (b BlockDevice) GetDevPath() (path string, err error) {
 	if b.KName == "" {
-		return "", fmt.Errorf("empty KNAME")
+		path = ""
+		err = fmt.Errorf("empty KNAME")
 	}
-	return filepath.Join("/dev/", b.KName), nil
+
+	path = filepath.Join("/dev/", b.KName)
+
+	return
 }
 
 // GetPathByID check on BlockDevice


### PR DESCRIPTION
Adds multipath devices to discovery result.

Unrelated to discovery: we should expose multipath in console to improve user experience when creating `LocalVolumeSet` with multipath: https://github.com/openshift/console/pull/12723

cc @openshift/storage 