### PR TITLE
OCPBUGS-12222: Fix permissions in `examples/olm/catalog-create-subscribe.yaml`

### DIFF
--- a/examples/olm/catalog-create-subscribe.yaml
+++ b/examples/olm/catalog-create-subscribe.yaml
@@ -3,6 +3,8 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
   name: openshift-local-storage
 ---
 apiVersion: operators.coreos.com/v1alpha2


### PR DESCRIPTION
`HACKING.md` suggests to run the following command to install LSO:
```
~> oc create -f examples/olm/catalog-create-subscribe.yaml
```

However it doesn't have expected effect because afterwards:
```
$ oc describe catalogsource -n openshift-local-storage
...
Status:
  Message:  couldn't ensure registry server - error ensuring pod: : error creating new pod: localstorage-operator-manifests-: pods "localstorage-operator-manifests-ts4np" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "registry-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "registry-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "registry-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "registry-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
  Reason:   RegistryServerError
```