### PR TITLE
OCPBUGS-15358: Improve logging existing symlinks

### DIFF
--- a/common/provisioner_utils.go
+++ b/common/provisioner_utils.go
@@ -88,7 +88,7 @@ func CreateLocalPV(
 	}
 
 	if cleanupTracker.InProgress(pvName, useJob) {
-		klog.InfoS("PV is still being cleaned, not going to recreate it", "pvName", pvName)
+		klog.InfoS("PV is still being cleaned, not going to recreate it", "pvName", pvName, "disk", deviceName)
 		return nil
 	}
 

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -346,7 +346,7 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 	unlockFunc := func() {
 		err := pvLock.Unlock()
 		if err != nil {
-			klog.ErrorS(err, "failed to unlock device")
+			klog.ErrorS(err, "failed to unlock device", "disk", devLabelPath)
 		}
 	}
 	defer unlockFunc()
@@ -369,9 +369,9 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 		}
 		err := fmt.Errorf("found existing symlinks for device %s in %s", dev.KName, filepath.Dir(symLinkDir))
 		klog.ErrorS(err, "skipping provisioning of PV")
-		return err
+		return nil
 	} else if err != nil || !pvLocked { // locking failed for some other reasion
-		klog.ErrorS(err, "not provisioning, could not get lock")
+		klog.ErrorS(err, "not provisioning, could not get lock", "disk", devLabelPath)
 		return err
 	}
 

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -164,11 +164,10 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 		r.eventReporter.Report(lvset, newDiskEvent(diskmaker.FoundMatchingDisk, "provisioning matching disk", blockDevice.KName, corev1.EventTypeNormal))
 		err = r.provisionPV(lvset, blockDevice, *storageClass, mountPointMap, symlinkSourcePath, symlinkPath, idExists)
 		if err != nil {
-			msg := fmt.Sprintf("provisioning failed for %s: %v",
-				blockDevice.Name, err)
+			msg := fmt.Sprintf("provisioning failed for %s: %v", blockDevice.Name, err)
 			r.eventReporter.Report(lvset, newDiskEvent(diskmaker.ErrorProvisioningDisk, msg, blockDevice.KName, corev1.EventTypeWarning))
 			klog.Error(msg)
-			return ctrl.Result{}, fmt.Errorf("could not provision disk: %w", err)
+			continue
 		}
 
 		klog.InfoS("provisioning succeeded", "blockDevice", blockDevice.Name)
@@ -369,7 +368,7 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 		}
 		err := fmt.Errorf("found existing symlinks for device %s in %s", dev.KName, filepath.Dir(symLinkDir))
 		klog.ErrorS(err, "skipping provisioning of PV")
-		return nil
+		return err
 	} else if err != nil || !pvLocked { // locking failed for some other reasion
 		klog.ErrorS(err, "not provisioning, could not get lock", "disk", devLabelPath)
 		return err

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -367,7 +367,9 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 				)
 			}
 		}
-		return nil
+		err := fmt.Errorf("found existing symlinks for device %s in %s", dev.KName, filepath.Dir(symLinkDir))
+		klog.ErrorS(err, "skipping provisioning of PV")
+		return err
 	} else if err != nil || !pvLocked { // locking failed for some other reasion
 		klog.ErrorS(err, "not provisioning, could not get lock")
 		return err


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-15358

After the fix:

```
E0627 18:20:18.432300  423801 reconcile.go:371] "skipping provisioning of PV" err="found existing symlinks for device sdb in /mnt/local-storage"
E0627 18:20:18.432317  423801 reconcile.go:170] provisioning failed for sdb: found existing symlinks for device sdb in /mnt/local-storage
2023-06-27T18:20:18.432Z        ERROR   controller/controller.go:329    Reconciler error        {"controller": "localvolumeset", "controllerGroup": "local.storage.openshift.io", "controllerKind": "LocalVolumeSet", "LocalVolumeSet": {"name":"example","name
space":"openshift-local-storage"}, "namespace": "openshift-local-storage", "name": "example", "reconcileID": "cb41a2ae-d354-409b-a87b-afbc7dc39239", "error": "could not provision disk: found existing symlinks for device sdb in /mnt/local-storage"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
```

