### PR TITLE
OCPBUGS-16595: Add nodeSelector to sample LocalVolume CR

### DIFF
--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -13,6 +13,22 @@ metadata:
             "name": "example"
           },
           "spec": {
+            "nodeSelector": {
+              "nodeSelectorTerms": [
+                {
+                  "matchExpressions": [
+                    {
+                      "key": "kubernetes.io/hostname",
+                      "operator": "In",
+                      "values": [
+                        "worker-0",
+                        "worker-1"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
             "storageClassDevices": [
               {
                 "devicePaths": [


### PR DESCRIPTION
`nodeSelector` should be present in majority of LocalVolume, so add it to the example.