### PR TITLE
OCPBUGS-17131: Add mustgather to relatedImages

### DIFF
--- a/config/manifests/stable/image-references
+++ b/config/manifests/stable/image-references
@@ -15,3 +15,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:latest
+  - name: local-storage-mustgather
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-local-storage-mustgather:latest


### PR DESCRIPTION
So it is mirrored in disconnected environments.

`relatedImages` will be also populated by ART pipeline with the diskmaker, kube-rbac-proxy and the operator image itself. Let's hope the pipeline will keep the mustgather image there.


cc @openshift/storage 