### PR TITLE
OCPBUGS-16745: prefer wwn, scsi and nvme devices

### DIFF
--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -33,11 +33,15 @@ func TestFindMatchingDisk(t *testing.T) {
 	tests := []struct {
 		name                  string
 		availableBlockDevices []internal.BlockDevice
+		fakeGlobFunc          func(string) ([]string, error)
 		userSpecifiedDisk     []string
 		matchingDevices       []DiskLocation
 	}{
 		{
 			name: "when devices match by their device names",
+			fakeGlobFunc: func(string) ([]string, error) {
+				return []string{"/dev/disk/by-id/abcde", "/dev/disk/by-id/wwn-abcde"}, nil
+			},
 			availableBlockDevices: []internal.BlockDevice{
 				{
 					Name:  "sdc1",
@@ -75,9 +79,8 @@ func TestFindMatchingDisk(t *testing.T) {
 					},
 				},
 			}
-			allDiskIds := getDeiveIDs()
 			d.fsInterface = FakeFileSystemInterface{}
-			deviceMap, err := d.findMatchingDisks(diskConfig, test.availableBlockDevices, allDiskIds)
+			deviceMap, err := d.findMatchingDisks(diskConfig, test.availableBlockDevices)
 			if err != nil {
 				t.Fatalf("error finding matchin device %v", err)
 			}

--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -34,13 +34,28 @@ func TestFindMatchingDisk(t *testing.T) {
 		name                  string
 		availableBlockDevices []internal.BlockDevice
 		fakeGlobFunc          func(string) ([]string, error)
+		fakeEvalSymlink       func(string) (string, error)
 		userSpecifiedDisk     []string
 		matchingDevices       []DiskLocation
 	}{
 		{
 			name: "when devices match by their device names",
 			fakeGlobFunc: func(string) ([]string, error) {
-				return []string{"/dev/disk/by-id/abcde", "/dev/disk/by-id/wwn-abcde"}, nil
+				return []string{
+					"/dev/disk/by-id/abcde",
+					"/dev/disk/by-id/wwn-abcde",
+					"/dev/disk/by-id/wwn-xyz",
+				}, nil
+			},
+			fakeEvalSymlink: func(path string) (string, error) {
+				switch path {
+				case "/dev/disk/by-id/wwn-abcde":
+					return "/dev/sdc1", nil
+				case "/dev/disk/by-id/wwn-xyz":
+					return "/dev/sdc2", nil
+				default:
+					return "", nil
+				}
 			},
 			availableBlockDevices: []internal.BlockDevice{
 				{
@@ -57,12 +72,12 @@ func TestFindMatchingDisk(t *testing.T) {
 				{
 					diskNamePath:     "/dev/sdc1",
 					userProvidedPath: "/dev/sdc1",
-					diskID:           "",
+					diskID:           "/dev/disk/by-id/wwn-abcde",
 				},
 				{
 					diskNamePath:     "/dev/sdc2",
 					userProvidedPath: "/dev/sdc2",
-					diskID:           "",
+					diskID:           "/dev/disk/by-id/wwn-xyz",
 				},
 			},
 		},
@@ -80,6 +95,13 @@ func TestFindMatchingDisk(t *testing.T) {
 				},
 			}
 			d.fsInterface = FakeFileSystemInterface{}
+			internal.FilePathGlob = test.fakeGlobFunc
+			internal.FilePathEvalSymLinks = test.fakeEvalSymlink
+			defer func() {
+				internal.FilePathGlob = filepath.Glob
+				internal.FilePathEvalSymLinks = filepath.EvalSymlinks
+			}()
+
 			deviceMap, err := d.findMatchingDisks(diskConfig, test.availableBlockDevices)
 			if err != nil {
 				t.Fatalf("error finding matchin device %v", err)

--- a/internal/diskutil.go
+++ b/internal/diskutil.go
@@ -175,27 +175,22 @@ func (b *BlockDevice) GetPathByID() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error listing files in %s: %v", DiskByIDDir, err)
 	}
-	preferredPatterns := []string{"wwn", "scsi", "nvme"}
+	preferredPatterns := []string{"wwn", "scsi", "nvme", ""}
 
 	// sortedSymlinks sorts symlinks in 4 buckets.
 	// 	- [0] - syminks that match wwn
 	//	- [1] - symlinks that match scsi
 	//	- [2] - symlinks that match nvme
 	//	- [3] - symlinks that does not any of these
-	sortedSymlinks := [4][]string{}
+	sortedSymlinks := make([][]string, len(preferredPatterns))
 
 	for _, path := range allDisks {
-		pathMatched := false
 		for i, pattern := range preferredPatterns {
 			symLinkName := filepath.Base(path)
 			if strings.HasPrefix(symLinkName, pattern) {
 				sortedSymlinks[i] = append(sortedSymlinks[i], path)
-				pathMatched = true
 				break
 			}
-		}
-		if !pathMatched {
-			sortedSymlinks[3] = append(sortedSymlinks[3], path)
 		}
 	}
 

--- a/internal/diskutil_test.go
+++ b/internal/diskutil_test.go
@@ -352,7 +352,7 @@ func TestGetPathByID(t *testing.T) {
 		{
 			label:       "Case 1: pathByID is already available",
 			blockDevice: BlockDevice{Name: "sdb", KName: "sdb", PathByID: "/dev/disk/by-id/sdb"},
-			fakeGlobfunc: func(name string) ([]string, error) {
+			fakeGlobfunc: func(path string) ([]string, error) {
 				return []string{"/dev/disk/by-id/dm-home", "/dev/disk/by-id/dm-uuid-LVM-6p00g8KptCD", "/dev/disk/by-id/sdb"}, nil
 			},
 			fakeEvalSymlinkfunc: func(path string) (string, error) {
@@ -364,13 +364,37 @@ func TestGetPathByID(t *testing.T) {
 		{
 			label:       "Case 2: pathByID is not available",
 			blockDevice: BlockDevice{Name: "sdb", KName: "sdb", PathByID: ""},
-			fakeGlobfunc: func(name string) ([]string, error) {
+			fakeGlobfunc: func(path string) ([]string, error) {
 				return []string{"/dev/disk/by-id/sdb"}, nil
 			},
 			fakeEvalSymlinkfunc: func(path string) (string, error) {
 				return "/dev/disk/by-id/sdb", nil
 			},
 			expected: "/dev/disk/by-id/sdb",
+		},
+		{
+			label:       "Prefer wwn-paths if available",
+			blockDevice: BlockDevice{Name: "sdb", KName: "sdb", PathByID: ""},
+			fakeGlobfunc: func(path string) ([]string, error) {
+				return []string{"/dev/disk/by-id/abcde", "/dev/disk/by-id/wwn-abcde"}, nil
+
+			},
+			fakeEvalSymlinkfunc: func(string) (string, error) {
+				return "/dev/sdb", nil
+			},
+			expected: "/dev/disk/by-id/wwn-abcde",
+		},
+		{
+			label:       "Prefer wwn path even if scsi is if available",
+			blockDevice: BlockDevice{Name: "sdb", KName: "sdb", PathByID: ""},
+			fakeGlobfunc: func(path string) ([]string, error) {
+				return []string{"/dev/disk/by-id/abcde", "/dev/disk/by-id/wwn-abcde", "/dev/disk/by-id/scsi-abcde"}, nil
+
+			},
+			fakeEvalSymlinkfunc: func(string) (string, error) {
+				return "/dev/sdb", nil
+			},
+			expected: "/dev/disk/by-id/wwn-abcde",
 		},
 	}
 


### PR DESCRIPTION
Prefer wwn, scsi and nvme device symlinks first.

Fixes https://issues.redhat.com/browse/OCPBUGS-16745

Note fore reviewers - I know this is slower than processing `/dev/disk/by-id` exactly once but I have benchmarked and evaluated various approaches.

One of the more faster solution is using a prefixtree (or a trie):

```
preferredPatterns := []string{"wwn", "scsi", "nvme",  ""}
	for _, pattern := range preferredPatterns {
		preferrdPaths := tree.FindKeys(pattern)
		for _, path := range preferrdPaths {
			matchPath, err := matchSymlink(path)
			if err != nil {
				return "", err
			}
			if matchPath != "" {
				return matchPath, nil
			}
		}
	}
```

I was using "github.com/beevik/prefixtree" library for that and is generally 30-40% faster. Not sure how much it matters in actual practice though. 
