### PR TITLE
remove unnecessary builder image from Dockerfile.mustgather

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,9 +1,5 @@
-FROM registry.ci.openshift.org/ocp/4.14:must-gather AS builder
-WORKDIR /go/src/github.com/openshift/local-storage-operator
-COPY . .
-
 FROM registry.ci.openshift.org/ocp/4.14:cli
-COPY --from=builder /go/src/github.com/openshift/local-storage-operator/must-gather/* /usr/bin/
+COPY must-gather/gather /usr/bin/
 RUN chmod +x /usr/bin/gather
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
Follow up PR from https://github.com/openshift/secrets-store-csi-driver-operator/pull/9#discussion_r1288132661

The builder image is not really necessary for the must-gather image.

/cc @openshift/storage @jsafrane
