### PR TITLE
OCPBUGS-12887: remove misleading messages from diskmaker-manager log

### DIFF
--- a/diskmaker/controllers/deleter/reconcile.go
+++ b/diskmaker/controllers/deleter/reconcile.go
@@ -66,7 +66,6 @@ func (r *DeleteReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 		r.firstRunOver = true
 	}
 
-	klog.Info("Deleting PVs through sig storage deleter")
 	r.deleter.DeletePVs()
 	return ctrl.Result{RequeueAfter: time.Second * 30}, nil
 }

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -44,16 +44,10 @@ const (
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	klog.InfoS("Reconciling LocalVolumeSet", "namespace", request.Namespace, "name", request.Name)
-
-	err := common.ReloadRuntimeConfig(ctx, r.Client, request, r.nodeName, r.runtimeConfig)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
 
 	// Fetch the LocalVolumeSet instance
 	lvset := &localv1alpha1.LocalVolumeSet{}
-	err = r.Client.Get(ctx, request.NamespacedName, lvset)
+	err := r.Client.Get(ctx, request.NamespacedName, lvset)
 	if err != nil {
 		if kerrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -61,6 +55,13 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	klog.InfoS("Reconciling LocalVolumeSet", "namespace", request.Namespace, "name", request.Name)
+
+	err = common.ReloadRuntimeConfig(ctx, r.Client, request, r.nodeName, r.runtimeConfig)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/diskmaker/controllers/lvset/reconcile.go
+++ b/diskmaker/controllers/lvset/reconcile.go
@@ -514,7 +514,7 @@ func handlePVChange(runtimeConfig *provCommon.RuntimeConfig, pv *corev1.Persiste
 	if !found {
 		return
 	}
-	ownerNamespace, found := pv.Labels[common.PVOwnerNameLabel]
+	ownerNamespace, found := pv.Labels[common.PVOwnerNamespaceLabel]
 	if !found {
 		return
 	}


### PR DESCRIPTION
There are multiple unrelated smaller fixes (one per commit) which should clean up diskmaker logs which was full of misleading messages like:

#### Getting LVSet reconcile errors with only LV created:
```
426 04:19:50.027715  786279 controller_runtime_utils.go:77] "could not get provisioner configmap" err="ConfigMap \"local-provisioner\" not found" name="local-provisioner" namespace="local-disks"                                         
2023-04-26T04:19:50.027Z        ERROR   controller/controller.go:326    Reconciler error        {"controller": "localvolumeset", "controllerGroup": "local.storage.openshift.io", "controllerKind": "LocalVolumeSet", "LocalVolumeSet":
{"name":"local-disks","namespace":"local-disks"} 
```

#### Overhaul of PV deletion messages while PVs are not actually deleted

```
I0426 04:20:30.012965  786279 reconcile.go:70] Deleting PVs through sig storage deleter
```

### After applying the patch the logs are much cleaner:
(Trace log level is used)

#### Diskmaker log with single LV:
```
I0919 15:38:00.510698 147258 reconcile.go:272] "Reconciling LocalVolume" namespace="openshift-local-storage" name="lv-1"

I0919 15:38:00.510935 147258 common.go:348] StorageClass "foobar" configured with MountDir "/mnt/local-storage/foobar", HostDir "/mnt/local-storage/foobar", VolumeMode "Filesystem", FsType "ext4", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:38:00.521002 147258 diskutil.go:246] Executing command: &exec.Cmd{Path:"/usr/bin/lsblk", Args:[]string{"lsblk", "--pairs", "-b", "-o", "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,KNAME,SERIAL,PARTLABEL"}, Env:[]string(nil), Dir:"", Stdin:io.Reader(nil), Stdout:io.Writer(nil), Stderr:io.Writer(nil), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(nil), ProcessState:(*os.ProcessState)(nil), ctx:context.Context(nil), Err:error(nil), Cancel:(func() error)(nil), WaitDelay:0, childIOFiles:[]io.Closer(nil), parentIOPipes:[]io.Closer(nil), goroutine:[]func() error(nil), goroutineErr:(<-chan error)(nil), ctxResult:(<-chan exec.ctxResult)(nil), createdByStack:[]uint8(nil), lookPathErr:error(nil)}

I0919 15:38:00.525183 147258 reconcile.go:478] "ignoring root device" devName="nvme0n1"

I0919 15:38:00.528044 147258 reconcile.go:473] "ignoring mount device" devName="nvme0n1p3"

I0919 15:38:00.529234 147258 reconcile.go:473] "ignoring mount device" devName="nvme0n1p4"

2023-09-19T15:38:00.531Z DEBUG events recorder/recorder.go:104 ip-10-0-93-127.us-west-1.compute.internal - found matching disk /dev/nvme1n1 with id /dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol00c702d43a7f60ba1 {"type": "Normal", "object": {"kind":"LocalVolume","namespace":"openshift-local-storage","name":"lv-1","uid":"25ae0fca-7d13-4577-9248-727ec7dfda4a","apiVersion":"local.storage.openshift.io/v1","resourceVersion":"92302"}, "reason": "FoundMatchingDisk"}

I0919 15:38:00.607435 147258 common.go:348] StorageClass "foobar" configured with MountDir "/mnt/local-storage/foobar", HostDir "/mnt/local-storage/foobar", VolumeMode "Filesystem", FsType "ext4", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:38:00.607460 147258 reconcile.go:51] "first run, initializing PV cache" provisionerName="local-volume-provisioner-ip-10-0-93-127.us-west-1.compute.internal"

2023-09-19T15:38:00.609Z INFO controller/controller.go:219 Starting workers {"controller": "localvolumeset", "controllerGroup": "local.storage.openshift.io", "controllerKind": "LocalVolumeSet", "worker count": 1}

I0919 15:38:00.634733 147258 provisioner_utils.go:188] "creating PV" pvName="local-pv-3e2837c6"

I0919 15:38:00.640399 147258 cache.go:60] Added pv "local-pv-3e2837c6" to cache

I0919 15:38:00.640407 147258 cache.go:60] Added pv "local-pv-3e2837c6" to cache

I0919 15:38:00.640450 147258 reconcile.go:41] "Looking for released PVs to cleanup" namespace="openshift-local-storage" name=""

I0919 15:38:00.640639 147258 common.go:348] StorageClass "foobar" configured with MountDir "/mnt/local-storage/foobar", HostDir "/mnt/local-storage/foobar", VolumeMode "Filesystem", FsType "ext4", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:38:00.640699 147258 provisioner_utils.go:227] "PV changed" pvName="local-pv-3e2837c6" status="created"

I0919 15:38:00.640825 147258 reconcile.go:272] "Reconciling LocalVolume" namespace="openshift-local-storage" name="lv-1"

I0919 15:38:00.640946 147258 common.go:348] StorageClass "foobar" configured with MountDir "/mnt/local-storage/foobar", HostDir "/mnt/local-storage/foobar", VolumeMode "Filesystem", FsType "ext4", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:38:00.649685 147258 diskutil.go:246] Executing command: &exec.Cmd{Path:"/usr/bin/lsblk", Args:[]string{"lsblk", "--pairs", "-b", "-o", "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,KNAME,SERIAL,PARTLABEL"}, Env:[]string(nil), Dir:"", Stdin:io.Reader(nil), Stdout:io.Writer(nil), Stderr:io.Writer(nil), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(nil), ProcessState:(*os.ProcessState)(nil), ctx:context.Context(nil), Err:error(nil), Cancel:(func() error)(nil), WaitDelay:0, childIOFiles:[]io.Closer(nil), parentIOPipes:[]io.Closer(nil), goroutine:[]func() error(nil), goroutineErr:(<-chan error)(nil), ctxResult:(<-chan exec.ctxResult)(nil), createdByStack:[]uint8(nil), lookPathErr:error(nil)}

I0919 15:38:00.653005 147258 reconcile.go:478] "ignoring root device" devName="nvme0n1"

I0919 15:38:00.656389 147258 reconcile.go:473] "ignoring mount device" devName="nvme0n1p3"

I0919 15:38:00.657264 147258 reconcile.go:473] "ignoring mount device" devName="nvme0n1p4"

I0919 15:38:00.659160 147258 provisioner_utils.go:188] "creating PV" pvName="local-pv-3e2837c6"

I0919 15:38:00.668568 147258 cache.go:69] Updated pv "local-pv-3e2837c6" to cache
```

#### Diskmager log with single LVSet:
```
I0919 15:58:44.970996 162255 reconcile.go:61] "Reconciling LocalVolumeSet" namespace="openshift-local-storage" name="example-localvolumeset"

I0919 15:58:44.971160 162255 common.go:348] StorageClass "example-storageclass" configured with MountDir "/mnt/local-storage/example-storageclass", HostDir "/mnt/local-storage/example-storageclass", VolumeMode "Block", FsType "", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:58:44.985106 162255 diskutil.go:246] Executing command: &exec.Cmd{Path:"/usr/bin/lsblk", Args:[]string{"lsblk", "--pairs", "-b", "-o", "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,KNAME,SERIAL,PARTLABEL"}, Env:[]string(nil), Dir:"", Stdin:io.Reader(nil), Stdout:io.Writer(nil), Stderr:io.Writer(nil), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(nil), ProcessState:(*os.ProcessState)(nil), ctx:context.Context(nil), Err:error(nil), Cancel:(func() error)(nil), WaitDelay:0, childIOFiles:[]io.Closer(nil), parentIOPipes:[]io.Closer(nil), goroutine:[]func() error(nil), goroutineErr:(<-chan error)(nil), ctxResult:(<-chan exec.ctxResult)(nil), createdByStack:[]uint8(nil), lookPathErr:error(nil)}

I0919 15:58:44.988778 162255 reconcile.go:235] "filter negative" device="nvme0n1" filter="noChildren"

I0919 15:58:44.988792 162255 reconcile.go:235] "filter negative" device="nvme0n1p1" filter="noBiosBootInPartLabel"

I0919 15:58:44.988800 162255 reconcile.go:235] "filter negative" device="nvme0n1p2" filter="noFilesystemSignature"

I0919 15:58:44.988811 162255 reconcile.go:235] "filter negative" device="nvme0n1p3" filter="canOpenExclusively"

I0919 15:58:44.988815 162255 reconcile.go:235] "filter negative" device="nvme0n1p4" filter="noFilesystemSignature"

I0919 15:58:44.990018 162255 reconcile.go:176] "total devices provisioned" storagecClass="example-storageclass" count=0

I0919 15:59:14.122947 162255 reconcile.go:41] "Looking for released PVs to cleanup" namespace="openshift-local-storage" name="local-provisioner"

I0919 15:59:14.123114 162255 common.go:348] StorageClass "example-storageclass" configured with MountDir "/mnt/local-storage/example-storageclass", HostDir "/mnt/local-storage/example-storageclass", VolumeMode "Block", FsType "", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:59:44.123733 162255 reconcile.go:41] "Looking for released PVs to cleanup" namespace="openshift-local-storage" name="local-provisioner"

I0919 15:59:44.123931 162255 common.go:348] StorageClass "example-storageclass" configured with MountDir "/mnt/local-storage/example-storageclass", HostDir "/mnt/local-storage/example-storageclass", VolumeMode "Block", FsType "", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:59:44.257976 162255 reconcile.go:61] "Reconciling LocalVolumeSet" namespace="openshift-local-storage" name="example-localvolumeset"

I0919 15:59:44.258158 162255 common.go:348] StorageClass "example-storageclass" configured with MountDir "/mnt/local-storage/example-storageclass", HostDir "/mnt/local-storage/example-storageclass", VolumeMode "Block", FsType "", BlockCleanerCommand ["/scripts/quick_reset.sh"], NamePattern "*"

I0919 15:59:44.293519 162255 diskutil.go:246] Executing command: &exec.Cmd{Path:"/usr/bin/lsblk", Args:[]string{"lsblk", "--pairs", "-b", "-o", "NAME,ROTA,TYPE,SIZE,MODEL,VENDOR,RO,RM,STATE,KNAME,SERIAL,PARTLABEL"}, Env:[]string(nil), Dir:"", Stdin:io.Reader(nil), Stdout:io.Writer(nil), Stderr:io.Writer(nil), ExtraFiles:[]*os.File(nil), SysProcAttr:(*syscall.SysProcAttr)(nil), Process:(*os.Process)(nil), ProcessState:(*os.ProcessState)(nil), ctx:context.Context(nil), Err:error(nil), Cancel:(func() error)(nil), WaitDelay:0, childIOFiles:[]io.Closer(nil), parentIOPipes:[]io.Closer(nil), goroutine:[]func() error(nil), goroutineErr:(<-chan error)(nil), ctxResult:(<-chan exec.ctxResult)(nil), createdByStack:[]uint8(nil), lookPathErr:error(nil)}

I0919 15:59:44.296257 162255 reconcile.go:235] "filter negative" device="nvme0n1" filter="noChildren"

I0919 15:59:44.296354 162255 reconcile.go:235] "filter negative" device="nvme0n1p1" filter="noBiosBootInPartLabel"

I0919 15:59:44.296403 162255 reconcile.go:235] "filter negative" device="nvme0n1p2" filter="noFilesystemSignature"

I0919 15:59:44.296430 162255 reconcile.go:235] "filter negative" device="nvme0n1p3" filter="noBiosBootInPartLabel"

I0919 15:59:44.296453 162255 reconcile.go:235] "filter negative" device="nvme0n1p4" filter="canOpenExclusively"

I0919 15:59:44.298777 162255 reconcile.go:274] "matched disk" device="nvme1n1"

I0919 15:59:44.299010 162255 reconcile.go:163] "provisioning PV" blockDevice="nvme1n1"
```