### PR TITLE
STOR-1377: Add option `forceWipeDevicesAndDestroyAllData` to wipe local volumes

### DIFF
--- a/api/v1/localvolume_types.go
+++ b/api/v1/localvolume_types.go
@@ -64,6 +64,9 @@ type StorageClassDevice struct {
 	// A list of device paths which would be chosen for local storage.
 	// For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"]
 	DevicePaths []string `json:"devicePaths,omitempty"`
+	// This option will destroy all leftover data on the devices before they're used as PersistentVolumes. Use with care.
+	// +optional
+	ForceWipeDevicesAndDestroyAllData bool `json:"forceWipeDevicesAndDestroyAllData,omitempty"`
 }
 
 // LocalVolumeStatus defines the observed state of LocalVolume

--- a/config/manifests/stable/local-volumes.crd.yaml
+++ b/config/manifests/stable/local-volumes.crd.yaml
@@ -62,6 +62,9 @@ spec:
                       fsType:
                         description: File system type to create on empty volumes, such as "ext4" or "xfs". Used only when volumeMode is "Filesystem". Leave blank when volumeMode is "Block".
                         type: string
+                      forceWipeDevicesAndDestroyAllData:
+                        description: This option will destroy all leftover data on the devices before they're used as PersistentVolumes. Use with care.
+                        type: boolean
                       devicePaths:
                         description: 'A list of devices which would be chosen for local storage.
                         For example - ["/dev/sda", "/dev/sdb", "/dev/disk/by-id/ata-crucial"].

--- a/diskmaker/controllers/lv/diskconfig.go
+++ b/diskmaker/controllers/lv/diskconfig.go
@@ -10,7 +10,8 @@ import (
 
 // Disks defines disks to be used for local volumes
 type Disks struct {
-	DevicePaths []string `json:"devicePaths,omitempty"`
+	DevicePaths                       []string `json:"devicePaths,omitempty"`
+	ForceWipeDevicesAndDestroyAllData bool     `json:"forceWipeDevicesAndDestroyAllData,omitempty"`
 }
 
 // DeviceNames returns devices which are used by name.

--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -206,7 +206,7 @@ func TestCreateSymLinkByDeviceID(t *testing.T) {
 	}
 	d, _ := getFakeDiskMaker(t, tmpSymLinkTargetDir, lv, sc)
 	d.fsInterface = FakeFileSystemInterface{}
-	diskLocation := DiskLocation{fakeDisk.Name(), fakeDiskByID.Name(), fakeDisk.Name(), internal.BlockDevice{}}
+	diskLocation := DiskLocation{fakeDisk.Name(), fakeDiskByID.Name(), fakeDisk.Name(), internal.BlockDevice{}, false}
 
 	d.runtimeConfig = &provCommon.RuntimeConfig{
 		UserConfig: &provCommon.UserConfig{
@@ -253,7 +253,7 @@ func TestCreateSymLinkByDeviceName(t *testing.T) {
 
 	d, _ := getFakeDiskMaker(t, tmpSymLinkTargetDir, lv, sc)
 	d.fsInterface = FakeFileSystemInterface{}
-	diskLocation := DiskLocation{fakeDisk.Name(), "", fakeDisk.Name(), internal.BlockDevice{}}
+	diskLocation := DiskLocation{fakeDisk.Name(), "", fakeDisk.Name(), internal.BlockDevice{}, false}
 	d.createSymlink(diskLocation, fakeDisk.Name(), path.Join(tmpSymLinkTargetDir, "diskName"), false)
 
 	// assert that target symlink is created for disk name when no disk ID is available

--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/local-storage-operator/internal"
 
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
+	"github.com/openshift/local-storage-operator/test-framework/testutils"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +27,11 @@ import (
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 	provDeleter "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/deleter"
 	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
+)
+
+const (
+	emptyFile = 0
+	tinyFile  = 1024 * 1024 // bytes
 )
 
 func TestFindMatchingDisk(t *testing.T) {
@@ -182,8 +188,8 @@ func TestLoadConfig(t *testing.T) {
 
 func TestCreateSymLinkByDeviceID(t *testing.T) {
 	tmpSymLinkTargetDir := createTmpDir(t, "", "target")
-	fakeDisk := createTmpFile(t, "", "diskName")
-	fakeDiskByID := createTmpFile(t, "", "diskID")
+	fakeDisk := createTmpFile(t, "", "diskName", emptyFile)
+	fakeDiskByID := createTmpFile(t, "", "diskID", emptyFile)
 	defer os.RemoveAll(tmpSymLinkTargetDir)
 	defer os.Remove(fakeDisk.Name())
 	defer os.Remove(fakeDiskByID.Name())
@@ -228,35 +234,60 @@ func TestCreateSymLinkByDeviceID(t *testing.T) {
 	assert.Truef(t, hasFile(t, tmpSymLinkTargetDir, "diskID"), "failed to find symlink with disk ID in %s directory", tmpSymLinkTargetDir)
 }
 
-func TestCreateSymLinkByDeviceName(t *testing.T) {
-	tmpSymLinkTargetDir := createTmpDir(t, "", "target")
-	fakeDisk := createTmpFile(t, "", "diskName")
-	defer os.Remove(fakeDisk.Name())
-	defer os.RemoveAll(tmpSymLinkTargetDir)
-
-	lv := &localv1.LocalVolume{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "local.storage.openshift.io",
-			Kind:       "LocalVolume",
+func TestWipeDeviceWhenCreateSymLinkByDeviceName(t *testing.T) {
+	tests := []struct {
+		name      string
+		forceWipe bool
+	}{
+		{
+			name:      "forceWipeDevicesAndDestroyAllData is False",
+			forceWipe: false,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foobar",
-			Namespace: "default",
-		},
-	}
-	sc := &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foobar",
+		{
+			name:      "forceWipeDevicesAndDestroyAllData is True",
+			forceWipe: true,
 		},
 	}
 
-	d, _ := getFakeDiskMaker(t, tmpSymLinkTargetDir, lv, sc)
-	d.fsInterface = FakeFileSystemInterface{}
-	diskLocation := DiskLocation{fakeDisk.Name(), "", fakeDisk.Name(), internal.BlockDevice{}, false}
-	d.createSymlink(diskLocation, fakeDisk.Name(), path.Join(tmpSymLinkTargetDir, "diskName"), false)
+	for i := range tests {
+		test := tests[i]
+		volHelper := util.NewVolumeHelper()
+		t.Run(test.name, func(t *testing.T) {
+			tmpSymLinkTargetDir := createTmpDir(t, "", "target")
+			fakeDisk := createTmpFile(t, "", "diskName", tinyFile)
+			fname := fakeDisk.Name()
+			volHelper.FormatAsExt4(t, fname)
+			defer os.Remove(fname)
+			defer os.RemoveAll(tmpSymLinkTargetDir)
 
-	// assert that target symlink is created for disk name when no disk ID is available
-	assert.Truef(t, hasFile(t, tmpSymLinkTargetDir, "diskName"), "failed to find symlink with disk name in %s directory", tmpSymLinkTargetDir)
+			lv := &localv1.LocalVolume{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "local.storage.openshift.io",
+					Kind:       "LocalVolume",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foobar",
+					Namespace: "default",
+				},
+			}
+			sc := &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foobar",
+				},
+			}
+
+			d, _ := getFakeDiskMaker(t, tmpSymLinkTargetDir, lv, sc)
+			d.fsInterface = FakeFileSystemInterface{}
+			diskLocation := DiskLocation{fname, "", fname, internal.BlockDevice{}, test.forceWipe}
+			d.createSymlink(diskLocation, fname, path.Join(tmpSymLinkTargetDir, "diskName"), false)
+
+			// assert that target symlink is created for disk name when no disk ID is available
+			assert.Truef(t, hasFile(t, tmpSymLinkTargetDir, "diskName"), "failed to find symlink with disk name in %s directory", tmpSymLinkTargetDir)
+
+			// assert that disk was (or wasn't) wiped
+			assert.Truef(t, volHelper.HasExt4(t, fname) != test.forceWipe, "unexpected wiping disk %s", fname)
+		})
+	}
 }
 
 func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Object) (*LocalVolumeReconciler, *testContext) {
@@ -324,10 +355,14 @@ func createTmpDir(t *testing.T, dir, prefix string) string {
 	return tmpDir
 }
 
-func createTmpFile(t *testing.T, dir, pattern string) *os.File {
+func createTmpFile(t *testing.T, dir, pattern string, size int64) *os.File {
 	tmpFile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		t.Fatalf("error creating tmp file: %v", err)
+	}
+	err = tmpFile.Truncate(size)
+	if err != nil {
+		t.Fatalf("error truncating tmp file: %v", err)
 	}
 	return tmpFile
 }

--- a/diskmaker/controllers/lv/reconcile_test.go
+++ b/diskmaker/controllers/lv/reconcile_test.go
@@ -1,7 +1,6 @@
 package lv
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -160,7 +159,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Fatalf("error marshalling yaml : %v", err)
 	}
 	filename := filepath.Join(tempDir, "config")
-	err = ioutil.WriteFile(filename, []byte(yaml), 0755)
+	err = os.WriteFile(filename, []byte(yaml), 0755)
 	if err != nil {
 		t.Fatalf("error writing yaml to disk : %v", err)
 	}
@@ -318,7 +317,7 @@ func getDeiveIDs() []string {
 }
 
 func createTmpDir(t *testing.T, dir, prefix string) string {
-	tmpDir, err := ioutil.TempDir(dir, prefix)
+	tmpDir, err := os.MkdirTemp(dir, prefix)
 	if err != nil {
 		t.Fatalf("error creating temp directory : %v", err)
 	}
@@ -326,7 +325,7 @@ func createTmpDir(t *testing.T, dir, prefix string) string {
 }
 
 func createTmpFile(t *testing.T, dir, pattern string) *os.File {
-	tmpFile, err := ioutil.TempFile(dir, pattern)
+	tmpFile, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		t.Fatalf("error creating tmp file: %v", err)
 	}
@@ -334,12 +333,12 @@ func createTmpFile(t *testing.T, dir, pattern string) *os.File {
 }
 
 func hasFile(t *testing.T, dir, file string) bool {
-	files, err := ioutil.ReadDir(dir)
+	dentries, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("error reading directory %s : %v", dir, err)
 	}
-	for _, f := range files {
-		if strings.Contains(f.Name(), file) {
+	for _, d := range dentries {
+		if strings.Contains(d.Name(), file) {
 			return true
 		}
 	}

--- a/internal/diskutil.go
+++ b/internal/diskutil.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -127,7 +126,7 @@ func (b BlockDevice) HasChildren() (bool, error) {
 // HasBindMounts checks for bind mounts and returns mount point for a device by parsing `proc/1/mountinfo`.
 // HostPID should be set to true inside the POD spec to get details of host's mount points inside `proc/1/mountinfo`.
 func (b *BlockDevice) HasBindMounts() (bool, string, error) {
-	data, err := ioutil.ReadFile(mountFile)
+	data, err := os.ReadFile(mountFile)
 	if err != nil {
 		return false, "", fmt.Errorf("failed to read file %s: %v", mountFile, err)
 	}

--- a/internal/diskutil_test.go
+++ b/internal/diskutil_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -258,7 +257,7 @@ func TestHasChildren(t *testing.T) {
 }
 
 func TestHasBindMounts(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "discovery")
+	tempDir, err := os.MkdirTemp("", "discovery")
 	if err != nil {
 		t.Fatalf("error creating temp directory : %v", err)
 	}
@@ -303,7 +302,7 @@ func TestHasBindMounts(t *testing.T) {
 
 	for _, tc := range testcases {
 		filename := filepath.Join(tempDir, "mountfile")
-		err = ioutil.WriteFile(filename, []byte(tc.mountInfo), 0755)
+		err = os.WriteFile(filename, []byte(tc.mountInfo), 0755)
 		if err != nil {
 			t.Fatalf("error writing mount info to file : %v", err)
 		}

--- a/test-framework/testutils/volume_util.go
+++ b/test-framework/testutils/volume_util.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	"testing"
+)
+
+type VolumeHelper interface {
+	FormatAsExt4(*testing.T, string)
+	HasExt4(*testing.T, string) bool
+}

--- a/test-framework/testutils/volume_util_linux.go
+++ b/test-framework/testutils/volume_util_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+// +build linux
+
+package util
+
+import (
+	"os/exec"
+	"testing"
+)
+
+var _ VolumeHelper = &volumeHelper{}
+
+type volumeHelper struct{}
+
+func NewVolumeHelper() VolumeHelper {
+	return &volumeHelper{}
+}
+
+func (h *volumeHelper) FormatAsExt4(t *testing.T, fname string) {
+	cmd := exec.Command("mkfs.ext4", fname)
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("error formatting file: %v; command error: %v", fname, cmd.Err)
+	}
+}
+
+func (h *volumeHelper) HasExt4(t *testing.T, fname string) bool {
+	cmd := exec.Command("fsck.ext4", "-n", fname)
+	err := cmd.Run()
+	if err != nil {
+		// Exit status 8 is returned if fname doesn't contain valid file system
+		if exiterr, ok := err.(*exec.ExitError); ok {
+			if exiterr.ExitCode() == 8 {
+				return false
+			}
+			t.Fatalf("error checking file system: %v; fsck.ext4 returned: %v", fname, exiterr.ExitCode())
+		}
+		t.Fatalf("error checking file system: %v; command error: %v", fname, cmd.Err)
+	}
+	return true
+}

--- a/test-framework/testutils/volume_util_unsupported.go
+++ b/test-framework/testutils/volume_util_unsupported.go
@@ -1,0 +1,22 @@
+//go:build !linux
+// +build !linux
+
+package util
+
+import "testing"
+
+var _ VolumeHelper = &volumeHelper{}
+
+type volumeHelper struct{}
+
+func NewVolumeHelper() VolumeHelper {
+	return &volumeHelper{}
+}
+
+func (h *volumeHelper) FormatAsExt4(t *testing.T, fname string) {
+	panic("FormatAsExt4 is unsupported in this build")
+}
+
+func (h *volumeHelper) HasExt4(t *testing.T, fname string) bool {
+	panic("HasExt4 is unsupported in this build")
+}

--- a/test-framework/utils.go
+++ b/test-framework/utils.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -123,7 +122,7 @@ func GetGoPkg() string {
 	if _, err := os.Stat(goModFile); err != nil && !os.IsNotExist(err) {
 		log.Fatalf("Failed to read go.mod: %v", err)
 	} else if err == nil {
-		b, err := ioutil.ReadFile(goModFile)
+		b, err := os.ReadFile(goModFile)
 		if err != nil {
 			log.Fatalf("Read go.mod: %v", err)
 		}


### PR DESCRIPTION
An exampe of LocalVolume with new option set:
```
apiVersion: "local.storage.openshift.io/v1"
kind: "LocalVolume"
metadata:
  name: "local-disks"
  namespace: "openshift-local-storage"
spec:
  nodeSelector:
    nodeSelectorTerms:
    - matchExpressions:
        - key: kubernetes.io/hostname
          operator: In
          values:
          - ip-10-0-7-58.us-west-2.compute.internal
  storageClassDevices:
    - storageClassName: "local-sc"
      forceWipeDevicesAndDestroyAllData: true
      volumeMode: Filesystem
      fsType: xfs
      devicePaths:
        - /dev/loop0
```

`forceWipeDevicesAndDestroyAllData` is optional. The default is false. If it is set explicitly to true (as in example above), corresponding `devicePaths` will be wiped out before exposing as PVs. Wiping must happen only once, along with creating symlink in `/mnt/local-storage/<storageClassName>/`.