### PR TITLE
Move builder & base images to RHEL 9

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.20-openshift-4.15
+  tag: rhel-9-release-golang-1.20-openshift-4.15

--- a/Dockerfile.diskmaker.rhel7
+++ b/Dockerfile.diskmaker.rhel7
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/local-storage-operator
 COPY . .
 RUN make build-diskmaker
 
-FROM registry.ci.openshift.org/ocp/4.15:base
+FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
 
 COPY --from=builder /go/src/github.com/openshift/local-storage-operator/_output/bin/diskmaker /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/local-storage-operator/hack/scripts /scripts


### PR DESCRIPTION
Reconciling with https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.15/images/local-storage-diskmaker.yml.