### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - vendor/**
+    - "**/*_test.go"


### PR DESCRIPTION
Ignore these two snyk errors. They're helper functions for unit tests that append arguments to a test command. Does not pose a risk to real clusters.

```
 ✗ [Low] Command Injection
   ID: 6efa8846-bd0f-46b7-872d-479a06965d19 
   Path: pkg/diskmaker/discovery/discovery_test.go, line 23 
   Info: Unsanitized input from a CLI argument flows into os.exec.Command, where it is used as a shell command. This may result in a Command Injection vulnerability.
 ✗ [Low] Command Injection
   ID: 16da69c5-18b4-434d-88fd-0cb7bd283704 
   Path: pkg/internal/diskutil_test.go, line 32 
   Info: Unsanitized input from a CLI argument flows into os.exec.Command, where it is used as a shell command. This may result in a Command Injection vulnerability.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-local-storage-operator-master-security/1745954193371303936

/cc @openshift/storage
