### PR TITLE
OCPBUGS-34420: Add metric and alert for LocalVolumeSet deletion

### DIFF
--- a/assets/templates/localmetrics/prometheus-rule.yaml
+++ b/assets/templates/localmetrics/prometheus-rule.yaml
@@ -27,3 +27,13 @@ spec:
             A frequent issue is that nodes that run OpenShift Data Foundation (ODF) are tainted,
             so only ODF runs on these nodes. In that case, LocalVolume / LocalVolumeSet objects
             must tolerate such a taint to provide disks for ODF on the nodes.
+    - name: lvset_deletion_alerts
+      rules:
+      - alert: LvSetDeletionAlert
+        expr: lso_lvset_deletion_timestamp > 0 and time() - lso_lvset_deletion_timestamp > 72 * 3600
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LocalVolumeSet has had a deletion timestamp older than 72 hours"
+          description: "LocalVolumeSet {{ $labels.lvSetName }} has been marked for deletion for more than 72 hours."

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -67,8 +67,12 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 
 	// don't provision for deleted lvsets
 	if !lvset.DeletionTimestamp.IsZero() {
+		// update metrics for deletion timestamp
+		localmetrics.SetLVSDeletionTimestampMetric(lvset.GetName(), lvset.GetDeletionTimestamp().Unix())
 		return ctrl.Result{}, nil
 	}
+	// since deletion timestamp is notset, clear out its metrics
+	localmetrics.RemoveLVSDeletionTimestampMetric(lvset.GetName())
 
 	// ignore LocalVolmeSets whose LabelSelector doesn't match this node
 	// NodeSelectorTerms.MatchExpressions are ORed

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -27,6 +27,11 @@ var (
 		Help: "Total symlinks that became orphan after updating the Local Volume Set filter",
 	}, []string{"nodeName", "storageClass"})
 
+	metricLocalVolumeSetDeletionTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lso_lvset_deletion_timestamp",
+		Help: "Timestamp when the LocalVolumeSet was marked for deletion",
+	}, []string{"lvSetName"})
+
 	// LocalVolume metrics
 	metricLocalVolumeProvisionedPVs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "lso_lv_provisioned_PV_count",
@@ -46,6 +51,7 @@ var (
 		metricLocalVolumeSetProvisionedPVs,
 		metricLocalVolumeSetUnmatchedDisks,
 		metricLocalVolumeSetOrphanedSymlinks,
+		metricLocalVolumeSetDeletionTimestamp,
 		metricLocalVolumeProvisionedPVs,
 		metricLocalVolumeOrphanedSymlinks,
 	}
@@ -73,6 +79,17 @@ func SetLVSOrphanedSymlinksMetric(nodeName, storageClassName string, count int) 
 	metricLocalVolumeSetOrphanedSymlinks.
 		With(prometheus.Labels{"nodeName": nodeName, "storageClass": storageClassName}).
 		Set(float64(count))
+}
+
+func SetLVSDeletionTimestampMetric(lvSetName string, ts int64) {
+	metricLocalVolumeSetDeletionTimestamp.
+		With(prometheus.Labels{"lvSetName": lvSetName}).
+		Set(float64(ts))
+}
+
+func RemoveLVSDeletionTimestampMetric(lvSetName string) {
+	metricLocalVolumeSetDeletionTimestamp.
+		Delete(prometheus.Labels{"lvSetName": lvSetName})
 }
 
 func SetLVProvisionedPVMetric(nodeName, storageClassName string, count int) {


### PR DESCRIPTION
This will warn users when the LocalVolumeSet has a deletion timestamp older than 24 hours.