### PR TITLE
OCPBUGS-34323: Use must-gather image

### DIFF
--- a/Dockerfile.mustgather
+++ b/Dockerfile.mustgather
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:must-gather
 
 COPY must-gather/gather /usr/bin/
 RUN chmod +x /usr/bin/gather


### PR DESCRIPTION
Update to must-gather image

followup to https://github.com/openshift/local-storage-operator/pull/485
