### PR TITLE
OCPBUGS-44879, OCPBUGS-45095: remove symlink dir, optimize requeue time

### DIFF
--- a/pkg/common/provisioner_utils.go
+++ b/pkg/common/provisioner_utils.go
@@ -305,3 +305,15 @@ func IsLocalVolumeSetPV(pv *corev1.PersistentVolume) bool {
 	ownerKind, found := pv.Labels[PVOwnerKindLabel]
 	return found && ownerKind == localv1.LocalVolumeSetKind
 }
+
+// OwnerHasReleasedPVs returns true if at least one PV in the cache
+// has the provided owner labels and is in the Released phase.
+func OwnerHasReleasedPVs(r *provCommon.RuntimeConfig, ownerLabels map[string]string) bool {
+	for _, pv := range r.Cache.ListPVs() {
+		if pvHasLabels(pv, ownerLabels) &&
+			pv.Status.Phase == corev1.VolumeReleased {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -130,7 +130,14 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 	if !lvset.DeletionTimestamp.IsZero() {
 		// update metrics for deletion timestamp
 		localmetrics.SetLVSDeletionTimestampMetric(lvset.GetName(), lvset.GetDeletionTimestamp().Unix())
-		return ctrl.Result{Requeue: true, RequeueAfter: fastRequeueTime}, nil
+		// If there are released PV's for this owner in the cache, use
+		// the fast requeue time, as it implies a cleanup job may be in
+		// progress and we should call DeletePVs() again soon to check
+		// for job completion and to delete the PV.
+		if common.OwnerHasReleasedPVs(r.runtimeConfig, ownerLabels) {
+			requeueTime = fastRequeueTime
+		}
+		return ctrl.Result{Requeue: true, RequeueAfter: requeueTime}, nil
 	}
 	// since deletion timestamp is notset, clear out its metrics
 	localmetrics.RemoveLVSDeletionTimestampMetric(lvset.GetName())


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-44879

- **OCPBUGS-44879: remove symlink dir when LV / LVS is deleted**

https://issues.redhat.com/browse/OCPBUGS-45095

- **OCPBUGS-45095: optimize requeue time when LV / LVS is deleted**

/cc @openshift/storage
