### PR TITLE
OCPBUGS-48098: Rename `master` branch to `main`

### DIFF
--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -149,7 +149,7 @@ spec:
     - local storage
   links:
     - name: Documentation
-      url: https://github.com/openshift/local-storage-operator/tree/master/docs
+      url: https://github.com/openshift/local-storage-operator/tree/main/docs
     - name: Source Repository
       url: https://github.com/openshift/local-storage-operator
   version: 4.19.0

--- a/docs/deploy-with-olm.md
+++ b/docs/deploy-with-olm.md
@@ -22,14 +22,14 @@ the operator using this method.
 
 
 Run
-`oc apply -f https://raw.githubusercontent.com/openshift/local-storage-operator/master/examples/olm/catalog-create-subscribe.yaml`
+`oc apply -f https://raw.githubusercontent.com/openshift/local-storage-operator/main/examples/olm/catalog-create-subscribe.yaml`
 For Kubernetes substitute `oc` with `kubectl`
 
 ### Create a CR with Node Selector
 
 The following example assumes that each worker node includes a raw disk attached at ``/dev/xvdf`` that we want to allocate for local-storage provisioning.  Of course you can have different devices, or only have disks on a subset of your worker nodes.
 
-Gather the kubernetes hostname value for your nodes, (in our example we're using only worker nodes, you can omit the label selector if you have master nodes you're deploying pods on):
+Gather the kubernetes hostname value for your nodes, (in our example we're using only worker nodes, you can omit the label selector if you have control plane nodes you're deploying pods on):
 
 ```bash
 oc describe no -l node-role.kubernetes.io/worker | grep hostname


### PR DESCRIPTION
and update doc to use the term "control plane nodes" instead of "master nodes".

/cc @openshift/storage 