### PR TITLE
OCPBUGS-48322: Fast requeue when LV / LVS deletion is blocked

### DIFF
--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -324,7 +324,7 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 
 	// don't provision for deleted lvs
 	if !lv.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: fastRequeueTime}, nil
 	}
 
 	klog.InfoS("Looking for valid block devices", "namespace", request.Namespace, "name", request.Name)

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -111,7 +111,7 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 	if !lvset.DeletionTimestamp.IsZero() {
 		// update metrics for deletion timestamp
 		localmetrics.SetLVSDeletionTimestampMetric(lvset.GetName(), lvset.GetDeletionTimestamp().Unix())
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true, RequeueAfter: fastRequeueTime}, nil
 	}
 	// since deletion timestamp is notset, clear out its metrics
 	localmetrics.RemoveLVSDeletionTimestampMetric(lvset.GetName())


### PR DESCRIPTION
If users delete LV before deleting PVC LSO will put a finalizer on LV and start a cleanup job for the volume but won't reconcile again automatically to finish the cleanup and remove the finalizer and PV. Because of this a bulk deletion of resources with `oc delete` can hang forever, unless something else triggers reconcile.

This PR is basically a partial cherry-pick of https://github.com/openshift/local-storage-operator/commit/bd326bf1b3eba6af0632546b2fa5983671e4c68a to add a fast re-queue specifically for this case.

With this patch we can delete the resources in any order without getting into what appears to be a "stuck" state:

```
$ oc create -f /tmp/resources.yaml
namespace/mariadb-db created
localvolume.local.storage.openshift.io/local-disks created
persistentvolumeclaim/mariadb-persistent-storage created
configmap/mariadb-custom-config created
deployment.apps/mariadb-deployment created
service/mariadb-deployment created

$ oc -n mariadb-db get pod
NAME                                  READY   STATUS    RESTARTS   AGE
mariadb-deployment-5c6dc5b888-brc66   1/1     Running   0          23s

$ oc delete -f /tmp/resources.yaml
namespace "mariadb-db" deleted
localvolume.local.storage.openshift.io "local-disks" deleted
persistentvolumeclaim "mariadb-persistent-storage" deleted
configmap "mariadb-custom-config" deleted
deployment.apps "mariadb-deployment" deleted
service "mariadb-deployment" deleted
```

cc @openshift/storage 