### PR TITLE
OCPBUGS-51038: fix cleanup storageclass for localvolumeset

### DIFF
--- a/pkg/common/names.go
+++ b/pkg/common/names.go
@@ -22,6 +22,8 @@ const (
 	OwnerNamespaceLabel = "local.storage.openshift.io/owner-namespace"
 	// OwnerNameLabel references the owning object
 	OwnerNameLabel = "local.storage.openshift.io/owner-name"
+	// OwnerKindLabel references the owning object's kind
+	OwnerKindLabel = "local.storage.openshift.io/owner-kind"
 
 	// DiskMakerImageEnv is used by the operator to read the DISKMAKER_IMAGE from the environment
 	DiskMakerImageEnv = "DISKMAKER_IMAGE"

--- a/pkg/common/resourceapply.go
+++ b/pkg/common/resourceapply.go
@@ -1,4 +1,4 @@
-package localvolume
+package common
 
 import (
 	"context"
@@ -11,8 +11,9 @@ import (
 	storageclientv1 "k8s.io/client-go/kubernetes/typed/storage/v1"
 )
 
-// ApplyStorageclass
-func applyStorageClass(ctx context.Context, client storageclientv1.StorageClassesGetter, required *storagev1.StorageClass) (*storagev1.StorageClass, bool, error) {
+// ApplyStorageClass applies the given StorageClass to the cluster if it does not already exist or is different
+// Returns the StorageClass as it exists in the cluster, whether it was created or updated, and any error that occurred.
+func ApplyStorageClass(ctx context.Context, client storageclientv1.StorageClassesGetter, required *storagev1.StorageClass) (*storagev1.StorageClass, bool, error) {
 	existing, err := client.StorageClasses().Get(ctx, required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.StorageClasses().Create(ctx, required, metav1.CreateOptions{})

--- a/pkg/controllers/localvolume/api_updater.go
+++ b/pkg/controllers/localvolume/api_updater.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
+	"github.com/openshift/local-storage-operator/pkg/common"
 	commontypes "github.com/openshift/local-storage-operator/pkg/common"
 
 	corev1 "k8s.io/api/core/v1"
@@ -86,7 +87,7 @@ func (s *sdkAPIUpdater) syncStatus(oldInstance, newInstance *localv1.LocalVolume
 }
 
 func (s *sdkAPIUpdater) applyStorageClass(ctx context.Context, sc *storagev1.StorageClass) (*storagev1.StorageClass, bool, error) {
-	return applyStorageClass(ctx, s.clientset.StorageV1(), sc)
+	return common.ApplyStorageClass(ctx, s.clientset.StorageV1(), sc)
 }
 
 func (s *sdkAPIUpdater) listStorageClasses(listOptions metav1.ListOptions) (*storagev1.StorageClassList, error) {

--- a/pkg/controllers/localvolume/localvolume_controller.go
+++ b/pkg/controllers/localvolume/localvolume_controller.go
@@ -48,11 +48,8 @@ import (
 type localDiskData map[string]map[string]string
 
 const (
-	componentName       = "local-storage-operator"
-	localDiskLocation   = "/mnt/local-storage"
-	ownerNamespaceLabel = "local.storage.openshift.io/owner-namespace"
-	ownerNameLabel      = "local.storage.openshift.io/owner-name"
-
+	componentName        = "local-storage-operator"
+	localDiskLocation    = "/mnt/local-storage"
 	localVolumeFinalizer = "storage.openshift.com/local-volume-protection"
 )
 
@@ -336,12 +333,16 @@ func addOwnerLabels(meta *metav1.ObjectMeta, cr *localv1.LocalVolume) bool {
 		meta.Labels = map[string]string{}
 		changed = true
 	}
-	if v, exists := meta.Labels[ownerNamespaceLabel]; !exists || v != cr.Namespace {
-		meta.Labels[ownerNamespaceLabel] = cr.Namespace
+	if v, exists := meta.Labels[common.OwnerNamespaceLabel]; !exists || v != cr.Namespace {
+		meta.Labels[common.OwnerNamespaceLabel] = cr.Namespace
 		changed = true
 	}
-	if v, exists := meta.Labels[ownerNameLabel]; !exists || v != cr.Name {
-		meta.Labels[ownerNameLabel] = cr.Name
+	if v, exists := meta.Labels[common.OwnerNameLabel]; !exists || v != cr.Name {
+		meta.Labels[common.OwnerNameLabel] = cr.Name
+		changed = true
+	}
+	if v, exists := meta.Labels[common.OwnerKindLabel]; !exists || v != localv1.LocalVolumeKind {
+		meta.Labels[common.OwnerKindLabel] = localv1.LocalVolumeKind
 		changed = true
 	}
 
@@ -366,8 +367,9 @@ func generateStorageClass(cr *localv1.LocalVolume, scName string) (*storagev1.St
 
 func getOwnerLabelSelector(cr *localv1.LocalVolume) labels.Selector {
 	ownerLabels := labels.Set{
-		ownerNamespaceLabel: cr.Namespace,
-		ownerNameLabel:      cr.Name,
+		common.OwnerNamespaceLabel: cr.Namespace,
+		common.OwnerNameLabel:      cr.Name,
+		common.OwnerKindLabel:      localv1.LocalVolumeKind,
 	}
 	return labels.SelectorFromSet(ownerLabels)
 }

--- a/pkg/controllers/localvolumeset/api_updater.go
+++ b/pkg/controllers/localvolumeset/api_updater.go
@@ -1,0 +1,57 @@
+package localvolumeset
+
+import (
+	"context"
+	goctx "context"
+	"time"
+
+	"github.com/openshift/local-storage-operator/pkg/common"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	apiTimeout = time.Minute
+)
+
+type apiUpdater interface {
+	applyStorageClass(ctx context.Context, required *storagev1.StorageClass) (*storagev1.StorageClass, bool, error)
+	listStorageClasses(listOptions metav1.ListOptions) (*storagev1.StorageClassList, error)
+}
+
+type sdkAPIUpdater struct {
+	recorder record.EventRecorder
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client    client.Client
+	clientset kubernetes.Interface
+}
+
+func newAPIUpdater(mgr manager.Manager) apiUpdater {
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		panic(err)
+	}
+	apiClient := &sdkAPIUpdater{
+		recorder:  mgr.GetEventRecorderFor(ComponentName),
+		client:    mgr.GetClient(),
+		clientset: clientset,
+	}
+	return apiClient
+}
+
+var _ apiUpdater = &sdkAPIUpdater{}
+
+func (s *sdkAPIUpdater) applyStorageClass(ctx context.Context, sc *storagev1.StorageClass) (*storagev1.StorageClass, bool, error) {
+	return common.ApplyStorageClass(ctx, s.clientset.StorageV1(), sc)
+}
+
+func (s *sdkAPIUpdater) listStorageClasses(listOptions metav1.ListOptions) (*storagev1.StorageClassList, error) {
+	return s.clientset.StorageV1().StorageClasses().List(goctx.Background(), listOptions)
+}

--- a/pkg/controllers/localvolumeset/localvolumeset_controller.go
+++ b/pkg/controllers/localvolumeset/localvolumeset_controller.go
@@ -133,8 +133,7 @@ func (r *LocalVolumeSetReconciler) syncStorageClass(ctx context.Context, lvs *lo
 	firstConsumerBinding := storagev1.VolumeBindingWaitForFirstConsumer
 	storageClass := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      lvs.Spec.StorageClassName,
-			Namespace: lvs.GetNamespace(),
+			Name: lvs.Spec.StorageClassName,
 			Labels: map[string]string{
 				common.OwnerNameLabel:      lvs.GetName(),
 				common.OwnerNamespaceLabel: lvs.GetNamespace(),


### PR DESCRIPTION
### OCPBUGS-51038: fix cleanup storageclass for localvolumeset
- Remove duplicated consts unify use the common package consts
- Add OwnerKindLabel for both localvolume/localvolumeset owned storageClasses, which could be helpful to avoid conflict reconcile storageClasses(remove) if the lv and lvset the same name.
- Fix the cleanup storageclass for localvolumeset deletion.

**Test records**
- Verify that both localvolume/localvolumeset owned storageClasses could be removed after they are deleted.
```console
 wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE     LABELS
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   3h41m   <none>
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   3h41m   <none>
lv-sc               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  2m14s   local.storage.openshift.io/owner-kind=LocalVolume,local.storage.openshift.io/owner-name=my-lv,local.storage.openshift.io/owner-namespace=openshift-local-storage
lvset-sc            kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  9s      local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=my-lvset,local.storage.openshift.io/owner-namespace=openshift-local-storage
 wangpenghao@pewang-mac  ~  oc get localvolume,localvolumeset
NAME                                           AGE
localvolume.local.storage.openshift.io/my-lv   3h6m

NAME                                                 AGE
localvolumeset.local.storage.openshift.io/my-lvset   2m33s
 wangpenghao@pewang-mac  ~  oc delete localvolumeset my-lvset
localvolumeset.local.storage.openshift.io "my-lvset" deleted
 wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE     LABELS
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   3h44m   <none>
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   3h44m   <none>
lv-sc               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  5m8s    local.storage.openshift.io/owner-kind=LocalVolume,local.storage.openshift.io/owner-name=my-lv,local.storage.openshift.io/owner-namespace=openshift-local-storage
 wangpenghao@pewang-mac  ~  oc delete localvolume my-lv
localvolume.local.storage.openshift.io "my-lv" deleted
 wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER       RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE     LABELS
gp2-csi             ebs.csi.aws.com   Delete          WaitForFirstConsumer   true                   3h44m   <none>
gp3-csi (default)   ebs.csi.aws.com   Delete          WaitForFirstConsumer   true                   3h44m   <none>

wangpenghao@pewang-mac  ~  oc logs local-storage-operator-84dbfdfbff-87znv|tail -n 50
I0227 05:12:22.850309       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:22.859302       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:22.863995       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:22.869153       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.441062       1 localvolumeset_controller.go:68] "Reconciling LocalVolumeSet" namespace="openshift-local-storage" name="my-lvset"
I0227 05:12:26.441110       1 finalizer.go:19] deletionTimeStamp found, waiting for 0 bound PVs
I0227 05:12:26.441149       1 finalizer.go:36] no owned PVs found, removing finalizer
I0227 05:12:26.441624       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.445860       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.450340       1 localvolumeset_controller.go:242] "removing storageClass" storageClassName="lvset-sc"
I0227 05:12:26.451036       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.457103       1 localvolumeset_controller.go:266] "Successfully deleted storageClass" storageClassName="lvset-sc"
I0227 05:12:26.457117       1 localvolumeset_controller.go:102] updating status
I0227 05:12:26.457232       1 localvolumeset_controller.go:68] "Reconciling LocalVolumeSet" namespace="openshift-local-storage" name="my-lvset"
I0227 05:12:26.468551       1 reconcile.go:82] "provisioner configmap" configMap="local-provisioner" result="updated"
I0227 05:12:26.468764       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.476588       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.483725       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.490775       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:26.490799       1 localvolumeset_controller.go:68] "Reconciling LocalVolumeSet" namespace="openshift-local-storage" name="my-lvset"
I0227 05:12:26.505109       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:26.505253       1 reconcile.go:105] "daemonset changed" dsName="diskmaker-manager" opResult="updated"
I0227 05:12:26.505717       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.510731       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.517791       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.571555       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.576438       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.581755       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.607865       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:26.608195       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.611985       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.616719       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.624404       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.628601       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.634382       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:26.777747       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:26.778848       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.787383       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:26.793178       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:55.045730       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:55.045789       1 localvolume_controller.go:217] "Deleting localvolume" Namespace-Name="openshift-local-storage/my-lv"
I0227 05:12:55.046165       1 exporter.go:103] "Reconciling metrics service" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:55.050037       1 localvolume_controller.go:288] "removing storageClass" scName="lv-sc"
I0227 05:12:55.054303       1 exporter.go:129] "Reconciling metrics service monitor" namespace="openshift-local-storage" name="local-storage-diskmaker-metrics"
I0227 05:12:55.057022       1 api_updater.go:62] Updating localvolume openshift-local-storage/my-lv
I0227 05:12:55.059337       1 alerts.go:43] "Reconciling prometheus rule" namespace="openshift-local-storage" name="local-storage-operator"
I0227 05:12:55.066493       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:55.066539       1 localvolume_controller.go:94] requested LocalVolume CR is not found, could have been deleted after the reconcile request
I0227 05:12:55.092342       1 localvolume_controller.go:86] "Reconciling LocalVolume" namespace="openshift-local-storage" name="my-lv"
I0227 05:12:55.092405       1 localvolume_controller.go:94] requested LocalVolume CR is not found, could have been deleted after the reconcile request
```
- Verify after operator upgrade the missed OwnerKindLabel for both localvolume/localvolumeset owned storageClasses added and the owned storageClasses could be removed after deletion.
```console
  wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    LABELS
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   117m   <none>
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   117m   <none>
lvset-b             kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  87s   local.storage.openshift.io/owner-name=lvset-b,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lv               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  76m   local.storage.openshift.io/owner-name=my-lv,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lvset            kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  77m    local.storage.openshift.io/owner-name=my-lvset,local.storage.openshift.io/owner-namespace=openshift-local-storage
 
# After upgrade operator to the fix version the owner-kind label synced successfully
 wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    LABELS
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   117m   <none>
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   117m   <none>
lvset-b             kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  101s   local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=lvset-b,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lv               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  79m    local.storage.openshift.io/owner-kind=LocalVolume,local.storage.openshift.io/owner-name=my-lv,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lvset            kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  80m    local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=my-lvset,local.storage.openshift.io/owner-namespace=openshift-local-storage
 wangpenghao@pewang-mac  ~  oc get sc
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
data                kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  39s
  1 # Please edit the object below. Lines beginning with a '#' will be ignored,
  2 # and an empty file will abort the edit. If an error occurs while saving this file will be
  3 # reopened with the relevant failures.
391                 name: local-storage-operator
 wangpenghao@pewang-mac  ~  oc get sc --show-labels
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE    LABELS
data                kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  11s   local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=data,local.storage.openshift.io/owner-namespace=openshift-local-storage
data-lv             kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  4s   local.storage.openshift.io/owner-kind=LocalVolume,local.storage.openshift.io/owner-name=data,local.storage.openshift.io/owner-namespace=openshift-local-storage
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   119m  <none>
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   119m  <none>
lvset-b             kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  3m21s   local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=lvset-b,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lv               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  81m    local.storage.openshift.io/owner-kind=LocalVolume,local.storage.openshift.io/owner-name=my-lv,local.storage.openshift.io/owner-namespace=openshift-local-storage
my-lvset            kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  82m    local.storage.openshift.io/owner-kind=LocalVolumeSet,local.storage.openshift.io/owner-name=my-lvset,local.storage.openshift.io/owner-namespace=openshift-local-storage

 ✘ wangpenghao@pewang-mac  ~  oc get localvolume,localvolumeset
NAME                                           AGE
localvolume.local.storage.openshift.io/data    47s
localvolume.local.storage.openshift.io/my-lv   82m

NAME                                                 AGE
localvolumeset.local.storage.openshift.io/data       82s
localvolumeset.local.storage.openshift.io/lvset-b    4m4s
localvolumeset.local.storage.openshift.io/my-lvset   82m
 wangpenghao@pewang-mac  ~  oc delete localvolume data
localvolume.local.storage.openshift.io "data" deleted

# Verify even if the lv and lvset the same name their owned sc reconcile(remove) won't be confilcted, only localvolume data owned sc "data-lv" was removed
 wangpenghao@pewang-mac  ~  oc get sc
NAME                PROVISIONER                    RECLAIMPOLICY   VOLUMEBINDINGMODE      ALLOWVOLUMEEXPANSION   AGE
data                kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  101s
gp2-csi             ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   120m
gp3-csi (default)   ebs.csi.aws.com                Delete          WaitForFirstConsumer   true                   120m
lvset-b             kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  4m23s
my-lv               kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  82m
my-lvset            kubernetes.io/no-provisioner   Delete          WaitForFirstConsumer   false                  83m

```