### PR TITLE
STOR-2126: Enable readOnlyFileSystem

### DIFF
--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -457,6 +457,7 @@ spec:
                         cpu: 10m
                     terminationMessagePolicy: FallbackToLogsOnError
                     securityContext:
+                      readOnlyRootFilesystem: true
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:


### PR DESCRIPTION
Enable readOnlyFileSystem in the operator for security concerns.
Recommended for all containers running in kubernetes.