### PR TITLE
STOR-2408: Bump OLM metadata to 4.20

### DIFF
--- a/config/manifests/local-storage-operator.package.yaml
+++ b/config/manifests/local-storage-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: local-storage-operator
 channels:
 - name: stable
-  currentCSV: local-storage-operator.v4.19.0
+  currentCSV: local-storage-operator.v4.20.0

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: local-storage-operator.v4.19.0
+  name: local-storage-operator.v4.20.0
   namespace: placeholder
   annotations:
     alm-examples: |-
@@ -115,7 +115,7 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes.
-    olm.skipRange: ">=4.3.0 <4.19.0"
+    olm.skipRange: ">=4.3.0 <4.20.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
     # This annotation injection is a workaround for BZ-1950047, since the associated
@@ -152,7 +152,7 @@ spec:
       url: https://github.com/openshift/local-storage-operator/tree/main/docs
     - name: Source Repository
       url: https://github.com/openshift/local-storage-operator
-  version: 4.19.0
+  version: 4.20.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -162,7 +162,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: local-storage-operator
-    alm-status-descriptors: local-storage-operator.v4.19.0
+    alm-status-descriptors: local-storage-operator.v4.20.0
   selector:
     matchLabels:
       alm-owner-metering: local-storage-operator


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2408
/cc @openshift/storage
