### PR TITLE
STOR-2331: Add NetworkPolicy manifests for LSO

### DIFF
--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: diskmaker-discovery
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.diskmaker-metrics: allow
     spec:
       containers:
       - args:

--- a/assets/templates/diskmaker-manager-daemonset.yaml
+++ b/assets/templates/diskmaker-manager-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: diskmaker-manager
+        openshift.storage.network-policy.dns: allow
+        openshift.storage.network-policy.api-server: allow
+        openshift.storage.network-policy.diskmaker-metrics: allow
     spec:
       containers:
       - args:

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -433,6 +433,9 @@ spec:
                   target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
                 labels:
                   name: local-storage-operator
+                  openshift.storage.network-policy.dns: allow
+                  openshift.storage.network-policy.api-server: allow
+                  openshift.storage.network-policy.operator-metrics: allow
               spec:
                 serviceAccountName: local-storage-operator
                 priorityClassName: openshift-user-critical

--- a/config/manifests/stable/network-policy-allow-egress-to-api-server.yaml
+++ b/config/manifests/stable/network-policy-allow-egress-to-api-server.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-egress-to-api-server
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.api-server: allow
+ egress:
+ - ports:
+   - protocol: TCP
+     port: 6443
+ policyTypes:
+ - Egress

--- a/config/manifests/stable/network-policy-allow-egress-to-dns.yaml
+++ b/config/manifests/stable/network-policy-allow-egress-to-dns.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-egress-to-dns
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.dns: allow
+ egress:
+ - to:
+   - namespaceSelector:
+       matchLabels:
+         kubernetes.io/metadata.name: openshift-dns
+     podSelector:
+       matchLabels:
+         dns.operator.openshift.io/daemonset-dns: default
+   ports:
+   - protocol: TCP
+     port: dns-tcp
+   - protocol: UDP
+     port: dns
+ policyTypes:
+ - Egress

--- a/config/manifests/stable/network-policy-allow-ingress-to-diskmaker-metrics.yaml
+++ b/config/manifests/stable/network-policy-allow-ingress-to-diskmaker-metrics.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-ingress-to-diskmaker-metrics
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.diskmaker-metrics: allow
+ ingress:
+ - ports:
+   - protocol: TCP
+     port: 8383
+   - protocol: TCP
+     port: 9393
+ policyTypes:
+ - Ingress

--- a/config/manifests/stable/network-policy-allow-ingress-to-operator-metrics.yaml
+++ b/config/manifests/stable/network-policy-allow-ingress-to-operator-metrics.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-ingress-to-operator-metrics
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.operator-metrics: allow
+ ingress:
+ - ports:
+   - protocol: TCP
+     port: 8080
+   - protocol: TCP
+     port: 8081
+ policyTypes:
+ - Ingress

--- a/config/manifests/stable/network-policy-default-deny-all.yaml
+++ b/config/manifests/stable/network-policy-default-deny-all.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: default-deny-all
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector: {}
+ policyTypes:
+ - Ingress
+ - Egress


### PR DESCRIPTION
https://issues.redhat.com/browse/STOR-2331

Manually verified:
1) These NetworkPolicy manifests are deployed to the same namespace as the operator (`openshift-local-storage`) when the operator is installed
2) local-storage-operator, diskmaker-discovery, and diskmaker-manager pods have the correct labels + policies applied. Used nmap to verify expected ingress ports are accessible and others are not.
3) A standalone pod in the namespace without any labels applied can not reach the outside world (deny-all policy is in effect).

/cc @openshift/storage @mpatlasov
