### PR TITLE
[release-4.16] OCPBUGS-59193: fix no warning for drift between ocp and lso versions

### DIFF
--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -116,6 +116,7 @@ metadata:
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes.
     olm.skipRange: ">=4.3.0 <4.16.0"
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
     # This annotation injection is a workaround for BZ-1950047, since the associated


### PR DESCRIPTION
… lso versions