### PR TITLE
LVS: update doc text for DeviceTypes to include newer types

### DIFF
--- a/api/v1alpha1/localvolumeset_types.go
+++ b/api/v1alpha1/localvolumeset_types.go
@@ -52,8 +52,9 @@ const (
 // DeviceInclusionSpec holds the inclusion filter spec
 type DeviceInclusionSpec struct {
 	// Devices is the list of devices that should be used for automatic detection.
-	// This would be one of the types supported by the local-storage operator. Currently,
-	// the supported types are: disk, part. If the list is empty only `disk` types will be selected
+	// This would be one of the types supported by the local-storage operator.
+	// Currently, the supported types are: disk, part, loop, mpath.
+	// If the list is empty only `disk` types will be selected.
 	// +optional
 	DeviceTypes []DeviceType `json:"deviceTypes,omitempty"`
 	// DeviceMechanicalProperty denotes whether Rotational or NonRotational disks should be used.

--- a/config/manifests/stable/local.storage.openshift.io_localvolumesets.yaml
+++ b/config/manifests/stable/local.storage.openshift.io_localvolumesets.yaml
@@ -55,8 +55,9 @@ spec:
                   deviceTypes:
                     description: |-
                       Devices is the list of devices that should be used for automatic detection.
-                      This would be one of the types supported by the local-storage operator. Currently,
-                      the supported types are: disk, part. If the list is empty only `disk` types will be selected
+                      This would be one of the types supported by the local-storage operator.
+                      Currently, the supported types are: disk, part, loop, mpath.
+                      If the list is empty only `disk` types will be selected.
                     items:
                       description: DeviceType is the types that will be supported
                         by the LSO.


### PR DESCRIPTION
The `loop` and `mpath` device types have been supported for years but the doc text in DeviceInclusionSpec needs to be updated to reflect this.

/cc @openshift/storage
