### PR TITLE
OCPBUGS-60033: Prefer nvme-eui symlinks over nvme-

### DIFF
--- a/pkg/internal/diskutil.go
+++ b/pkg/internal/diskutil.go
@@ -174,13 +174,14 @@ func (b *BlockDevice) GetPathByID(existingDeviceID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error listing files in %s: %v", DiskByIDDir, err)
 	}
-	preferredPatterns := []string{"wwn", "scsi", "nvme", ""}
+	preferredPatterns := []string{"wwn", "scsi", "nvme-eui", "nvme", ""}
 
 	// sortedSymlinks sorts symlinks in 4 buckets.
 	// 	- [0] - syminks that match wwn
 	//	- [1] - symlinks that match scsi
-	//	- [2] - symlinks that match nvme
-	//	- [3] - symlinks that does not any of these
+	//	- [2] - symlinks that match nvme.eui - those are stable on vSphere
+	//	- [3] - symlinks that match nvme - those are not stable on vSphere, but should be stable on other platforms
+	//	- [4] - symlinks that does not any of these
 	sortedSymlinks := make([][]string, len(preferredPatterns))
 
 	for _, path := range allDisks {

--- a/pkg/internal/diskutil_test.go
+++ b/pkg/internal/diskutil_test.go
@@ -409,6 +409,18 @@ func TestGetPathByID(t *testing.T) {
 			},
 			expected: "/dev/disk/by-id/scsi-abcde",
 		},
+		{
+			label:       "Prefer nvme-eui paths if available",
+			blockDevice: BlockDevice{Name: "nvme0n1", KName: "nvme0n1", PathByID: ""},
+			fakeGlobfunc: func(path string) ([]string, error) {
+				return []string{"/dev/disk/by-id/nvme-VMware_Virtual_NVMe_Disk_VMware_NVME_0000_2", "/dev/disk/by-id/nvme-eui.252745b7300c1778000c296efa5e7ea0"}, nil
+
+			},
+			fakeEvalSymlinkfunc: func(string) (string, error) {
+				return "/dev/nvme0n1", nil
+			},
+			expected: "/dev/disk/by-id/nvme-eui.252745b7300c1778000c296efa5e7ea0",
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
On vSphere, symlink `/dev/disk/by-id/nvme-VMware_Virtual_NVMe_Disk_VMware_NVME_0000` is not stable. It get reordered when a disk is added/removed to/from a VM + the VM is rebooted.

Prefer using `/dev/disk/by-id/nvme-eui.XYZ` if it's available.