### PR TITLE
[WIP] STOR-2331: Add NetworkPolicy manifests for LSO operands

### DIFF
--- a/assets/network-policy/allow-operand-egress-to-api-server.yaml
+++ b/assets/network-policy/allow-operand-egress-to-api-server.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-operand-egress-to-api-server
+ namespace: ${OBJECT_NAMESPACE}
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.operand-api-server: allow
+ egress:
+ - ports:
+   - protocol: TCP
+     port: 6443
+ policyTypes:
+ - Egress

--- a/assets/network-policy/allow-operand-egress-to-dns.yaml
+++ b/assets/network-policy/allow-operand-egress-to-dns.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-operand-egress-to-dns
+ namespace: ${OBJECT_NAMESPACE}
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.operand-dns: allow
+ egress:
+ - to:
+   - namespaceSelector:
+       matchLabels:
+         kubernetes.io/metadata.name: openshift-dns
+     podSelector:
+       matchLabels:
+         dns.operator.openshift.io/daemonset-dns: default
+   ports:
+   - protocol: TCP
+     port: dns-tcp
+   - protocol: UDP
+     port: dns
+ policyTypes:
+ - Egress

--- a/assets/network-policy/allow-operand-ingress-to-metrics.yaml
+++ b/assets/network-policy/allow-operand-ingress-to-metrics.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: allow-operand-ingress-to-metrics
+ namespace: ${OBJECT_NAMESPACE}
+ annotations:
+  include.release.openshift.io/hypershift: "true"
+  include.release.openshift.io/ibm-cloud-managed: "true"
+  include.release.openshift.io/self-managed-high-availability: "true"
+  include.release.openshift.io/single-node-developer: "true"
+  capability.openshift.io/name: Storage
+spec:
+ podSelector:
+   matchLabels:
+     openshift.storage.network-policy.operand-metrics: allow
+ ingress:
+ - ports:
+   - protocol: TCP
+     port: 8383
+   - protocol: TCP
+     port: 9393
+ policyTypes:
+ - Ingress

--- a/assets/templates/diskmaker-discovery-daemonset.yaml
+++ b/assets/templates/diskmaker-discovery-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: diskmaker-discovery
+        openshift.storage.network-policy.operand-dns: allow
+        openshift.storage.network-policy.operand-api-server: allow
+        openshift.storage.network-policy.operand-metrics: allow
     spec:
       containers:
       - args:

--- a/assets/templates/diskmaker-manager-daemonset.yaml
+++ b/assets/templates/diskmaker-manager-daemonset.yaml
@@ -15,6 +15,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: diskmaker-manager
+        openshift.storage.network-policy.operand-dns: allow
+        openshift.storage.network-policy.operand-api-server: allow
+        openshift.storage.network-policy.operand-metrics: allow
     spec:
       containers:
       - args:

--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -33,6 +33,7 @@ import (
 	lvcontroller "github.com/openshift/local-storage-operator/pkg/controllers/localvolume"
 	lvdcontroller "github.com/openshift/local-storage-operator/pkg/controllers/localvolumediscovery"
 	lvscontroller "github.com/openshift/local-storage-operator/pkg/controllers/localvolumeset"
+	networkpolicy "github.com/openshift/local-storage-operator/pkg/controllers/networkpolicy"
 	nodedaemoncontroller "github.com/openshift/local-storage-operator/pkg/controllers/nodedaemon"
 	"github.com/openshift/local-storage-operator/pkg/utils"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -115,6 +116,14 @@ func main() {
 	})
 	if err != nil {
 		klog.ErrorS(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err = (&networkpolicy.NetworkPolicyReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create NetworkPolicy controller")
 		os.Exit(1)
 	}
 

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -182,6 +182,18 @@ spec:
       permissions:
         - rules:
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - watch
+                - list
+                - get
+                - create
+                - delete
+                - patch
+                - update
+            - apiGroups:
                 - ""
                 - coordination.k8s.io
               resources:

--- a/go.mod
+++ b/go.mod
@@ -147,3 +147,6 @@ replace (
 )
 
 replace k8s.io/kms => k8s.io/kms v0.33.3
+
+// DO NOT MERGE: testing https://github.com/openshift/library-go/pull/1992
+replace github.com/openshift/library-go => github.com/dobsonj/library-go v0.0.0-20250813170550-0bb8ed551982

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dobsonj/library-go v0.0.0-20250813170550-0bb8ed551982 h1:btGpajzY1UgbZE4whKUfNudVX7tsIBla/z2mu2gO/jY=
+github.com/dobsonj/library-go v0.0.0-20250813170550-0bb8ed551982/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
@@ -268,8 +270,6 @@ github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c h1:gJ
 github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee h1:tOtrrxfDEW8hK3eEsHqxsXurq/D6LcINGfprkQC3hqY=
 github.com/openshift/client-go v0.0.0-20250710075018-396b36f983ee/go.mod h1:zhRiYyNMk89llof2qEuGPWPD+joQPhCRUc2IK0SB510=
-github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a h1:wZ0M/4DgILzW+8NKcARzBSG7w/BlSjtjQlBUj/VCk+0=
-github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a/go.mod h1:tptKNust9MdRI0p90DoBSPHIrBa9oh+Rok59tF0vT8c=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
 github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/pkg/controllers/networkpolicy/reconcile.go
+++ b/pkg/controllers/networkpolicy/reconcile.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 The Local Storage Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpolicy
+
+import (
+	"context"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/openshift/local-storage-operator/assets"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type NetworkPolicyReconciler struct {
+	Client client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *NetworkPolicyReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	klog.InfoS("Reconciling NetworkPolicies", "namespace", request.Namespace, "name", request.Name)
+
+	manifests := [...]string{
+		"network-policy/allow-operand-egress-to-api-server.yaml",
+		"network-policy/allow-operand-egress-to-dns.yaml",
+		"network-policy/allow-operand-ingress-to-metrics.yaml",
+	}
+
+	for _, manifest := range manifests {
+		npBytes, err := assets.ReadFileAndReplace(
+			manifest,
+			[]string{
+				"${OBJECT_NAMESPACE}", request.Namespace,
+			},
+		)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+		np := resourceread.ReadNetworkPolicyV1OrDie(npBytes)
+
+		opResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, np, nil)
+		if err != nil {
+			return ctrl.Result{Requeue: true}, err
+		} else if opResult == controllerutil.OperationResultUpdated ||
+			opResult == controllerutil.OperationResultCreated {
+			klog.InfoS("NetworkPolicy changed", "Name", np.GetName(), "opResult", opResult)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *NetworkPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	enqueueOnlyNamespace := handler.EnqueueRequestsFromMapFunc(
+		func(ctx context.Context, obj client.Object) []reconcile.Request {
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: obj.GetNamespace()},
+			}
+			return []reconcile.Request{req}
+		})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&networkingv1.NetworkPolicy{}).
+		Watches(&networkingv1.NetworkPolicy{}, enqueueOnlyNamespace).
+		Complete(r)
+
+	// TODO: enqueue at least one initial request
+
+	// TODO: can we handle cleanup too? How will it get deleted?
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/networking.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func ReadNetworkPolicyV1OrDie(objBytes []byte) *networkingv1.NetworkPolicy {
-	requiredObj, err := runtime.Decode(coreCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(netCodecs.UniversalDecoder(networkingv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -275,7 +275,7 @@ github.com/openshift/client-go/config/applyconfigurations/internal
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
 github.com/openshift/client-go/security/clientset/versioned/scheme
-# github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a
+# github.com/openshift/library-go v0.0.0-20250725103737-7f9bc3eb865a => github.com/dobsonj/library-go v0.0.0-20250813170550-0bb8ed551982
 ## explicit; go 1.24.0
 github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/leaderelection
@@ -1221,3 +1221,4 @@ sigs.k8s.io/yaml/goyaml.v2
 # k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.33.3
 # k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.33.3
 # k8s.io/kms => k8s.io/kms v0.33.3
+# github.com/openshift/library-go => github.com/dobsonj/library-go v0.0.0-20250813170550-0bb8ed551982


### PR DESCRIPTION
This PR is a rework of https://github.com/openshift/local-storage-operator/pull/530 (reverted in https://github.com/openshift/local-storage-operator/pull/539) to deploy network policies only for operands as requested in [OCPSTRAT-819](https://issues.redhat.com/browse/OCPSTRAT-819?focusedId=27758590&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27758590).

It adds a new controller to the operator to reconcile network policies for the operands.

Depends on https://github.com/openshift/library-go/pull/1992

/cc @mpatlasov
