### PR TITLE
OCPBUGS-83306: Further cleanup lso work

### DIFF
--- a/pkg/common/provisioner_utils.go
+++ b/pkg/common/provisioner_utils.go
@@ -30,9 +30,8 @@ import (
 var ErrTryAgain = errors.New("retry provisioning")
 
 // GenerateMountMap is used to get a set of mountpoints that can be quickly looked up
-func GenerateMountMap(runtimeConfig *provCommon.RuntimeConfig) (sets.String, error) {
-	type empty struct{}
-	mountPointMap := sets.NewString()
+func GenerateMountMap(runtimeConfig *provCommon.RuntimeConfig) (sets.Set[string], error) {
+	mountPointMap := sets.New[string]()
 	// Retrieve list of mount points to iterate through discovered paths (aka files) below
 	mountPoints, err := runtimeConfig.Mounter.List()
 	if err != nil {
@@ -50,7 +49,7 @@ type CreateLocalPVArgs struct {
 	LocalVolumeLikeObject runtime.Object
 	RuntimeConfig         *provCommon.RuntimeConfig
 	StorageClass          storagev1.StorageClass
-	MountPointMap         sets.String
+	MountPointMap         sets.Set[string]
 	Client                client.Client
 	// symlinkPath points to path on /mnt/local-storage
 	SymLinkPath      string

--- a/pkg/common/provisioner_utils.go
+++ b/pkg/common/provisioner_utils.go
@@ -60,10 +60,6 @@ type CreateLocalPVArgs struct {
 	// skipping cache
 	ClientReader client.Reader
 
-	// CurrentSymlink points to source to which SymLinkPath points to.
-	// it could be a path in /dev/disk/by-id or could be simply
-	// /dev/sda etc if nothing exists
-	CurrentSymlink string
 	// BlockDevice is the block device backing this PV.
 	BlockDevice internal.BlockDevice
 	// CacheWriter enables write-through updates to the LVDL in-memory cache.
@@ -139,7 +135,7 @@ func CreateLocalPV(ctx context.Context, args CreateLocalPVArgs) error {
 	effectiveCurrentSource, err := internal.Readlink(symLinkPath)
 	if err != nil {
 		currentPreferredLink, _ := args.BlockDevice.GetPathByID()
-		klog.ErrorS(err, "could not read symlink", "symlink", symLinkPath, "currentSymlink", args.CurrentSymlink, "preferredCurrent", currentPreferredLink)
+		klog.ErrorS(err, "could not read symlink", "symlink", symLinkPath, "preferredCurrent", currentPreferredLink)
 		return fmt.Errorf("unable to resolve symlink %s: %v", symLinkPath, err)
 	}
 
@@ -290,7 +286,7 @@ func CreateLocalPV(ctx context.Context, args CreateLocalPVArgs) error {
 	// ApplyStatus creates/updates the LVDL after the PV exists. Skip it when
 	// RecreateSymlinkIfNeeded already updated the LVDL status above.
 	if !requiresSymlinkRecreation {
-		if _, err := deviceHandler.ApplyStatus(ctx, pvName, namespace, args.BlockDevice, obj, args.CurrentSymlink); err != nil {
+		if _, err := deviceHandler.ApplyStatus(ctx, pvName, namespace, args.BlockDevice, obj, effectiveCurrentSource); err != nil {
 			return fmt.Errorf("error applying device link status: %w", err)
 		}
 	}

--- a/pkg/common/pv_link_cache.go
+++ b/pkg/common/pv_link_cache.go
@@ -143,8 +143,10 @@ func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
 		return err
 	}
 
-	l.watchForEvents(informer)
-
+	_, err = l.watchForEvents(informer)
+	if err != nil {
+		return err
+	}
 	// Wait for the LVDL informer to complete its initial list.
 	if !l.mgr.GetCache().WaitForCacheSync(ctx) {
 		return fmt.Errorf("cache sync failed for LocalVolumeDeviceLink")
@@ -162,15 +164,15 @@ func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
 
 	// Signal that the cache is ready for use by reconcilers.
 	close(l.synced)
-	klog.InfoS("LVDL cache synced", "entries", len(l.localDeviceInfos))
+	klog.InfoS("LVDL cache synced")
 
 	<-ctx.Done()
 	return nil
 }
 
-func (l *LocalVolumeDeviceLinkCache) watchForEvents(informer cache.Informer) {
+func (l *LocalVolumeDeviceLinkCache) watchForEvents(informer cache.Informer) (k8scache.ResourceEventHandlerRegistration, error) {
 	// Watch for subsequent changes.
-	informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+	return informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			if lvdl, ok := obj.(*v1.LocalVolumeDeviceLink); ok {
 				l.addOrUpdateLVDL(lvdl)

--- a/pkg/common/pv_link_cache.go
+++ b/pkg/common/pv_link_cache.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -142,6 +143,8 @@ func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
 		return err
 	}
 
+	l.watchForEvents(informer)
+
 	// Wait for the LVDL informer to complete its initial list.
 	if !l.mgr.GetCache().WaitForCacheSync(ctx) {
 		return fmt.Errorf("cache sync failed for LocalVolumeDeviceLink")
@@ -157,6 +160,15 @@ func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
 		l.addOrUpdateLVDL(&lvdlList.Items[i])
 	}
 
+	// Signal that the cache is ready for use by reconcilers.
+	close(l.synced)
+	klog.InfoS("LVDL cache synced", "entries", len(l.localDeviceInfos))
+
+	<-ctx.Done()
+	return nil
+}
+
+func (l *LocalVolumeDeviceLinkCache) watchForEvents(informer cache.Informer) {
 	// Watch for subsequent changes.
 	informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
@@ -178,13 +190,6 @@ func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
 			}
 		},
 	})
-
-	// Signal that the cache is ready for use by reconcilers.
-	close(l.synced)
-	klog.InfoS("LVDL cache synced", "entries", len(l.localDeviceInfos))
-
-	<-ctx.Done()
-	return nil
 }
 
 func (l *LocalVolumeDeviceLinkCache) FindStalePVs(symlink string, blockDevice internal.BlockDevice) (CurrentBlockDeviceInfo, bool, error) {

--- a/pkg/diskmaker/controllers/lv/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lv/create_pv_test.go
@@ -38,7 +38,7 @@ func TestCreatePV(t *testing.T) {
 		desiredVolMode  string
 		deviceName      string
 		deviceCapacity  int64
-		mountPoints     sets.String
+		mountPoints     sets.Set[string]
 		extraDirEntries []*provUtil.FakeDirEntry
 	}{
 		{
@@ -63,7 +63,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeBlock),
 			desiredVolMode: string(localv1.PersistentVolumeBlock),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -91,7 +91,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeBlock),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -118,7 +118,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeBlock),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -145,7 +145,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString("/mnt/local-storage/storageclass-a/device-a"),
+			mountPoints:    sets.New[string]("/mnt/local-storage/storageclass-a/device-a"),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -173,7 +173,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString("a", "b"), // device not present
+			mountPoints:    sets.New[string]("a", "b"), // device not present
 			symlinkpath:    "/mnt/local-storage/storageclass-b/device-b",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-b",
@@ -368,7 +368,7 @@ func TestCreateLocalPV_DeviceLinkArgOrder(t *testing.T) {
 		LocalVolumeLikeObject: &lv,
 		RuntimeConfig:         r.runtimeConfig,
 		StorageClass:          sc,
-		MountPointMap:         sets.NewString(),
+		MountPointMap:         sets.New[string](),
 		Client:                r.Client,
 		ClientReader:          r.ClientReader,
 		SymLinkPath:           symLinkPath,
@@ -546,7 +546,7 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 				LocalVolumeLikeObject: &lv,
 				RuntimeConfig:         r.runtimeConfig,
 				StorageClass:          sc,
-				MountPointMap:         sets.NewString(),
+				MountPointMap:         sets.New[string](),
 				Client:                r.Client,
 				ClientReader:          r.ClientReader,
 				SymLinkPath:           symLinkPath,

--- a/pkg/diskmaker/controllers/lv/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lv/create_pv_test.go
@@ -11,6 +11,7 @@ import (
 
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	"github.com/openshift/local-storage-operator/pkg/common"
+	"github.com/openshift/local-storage-operator/pkg/diskmaker/diskmakertest"
 	"github.com/openshift/local-storage-operator/pkg/internal"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -19,37 +20,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilexec "k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 )
-
-// fakeBlkidExecutor returns a FakeExec where blkid emits uuid only when the
-// last argument matches devicePath. When any other path is passed the output is
-// empty, which is what the real blkid returns when it cannot find a UUID.
-func fakeBlkidExecutor(devicePath, uuid string) *testingexec.FakeExec {
-	blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-		out := ""
-		if cmd == "blkid" && len(args) > 0 && args[len(args)-1] == devicePath {
-			out = uuid
-		}
-		return &testingexec.FakeCmd{
-			CombinedOutputScript: []testingexec.FakeAction{
-				func() ([]byte, []byte, error) {
-					return []byte(out), nil, nil
-				},
-			},
-		}
-	}
-	commandScript := make([]testingexec.FakeCommandAction, 0, 16)
-	for i := 0; i < 16; i++ {
-		commandScript = append(commandScript, blkidAction)
-	}
-	return &testingexec.FakeExec{
-		CommandScript: commandScript,
-	}
-}
 
 func TestCreatePV(t *testing.T) {
 	reclaimPolicyDelete := corev1.PersistentVolumeReclaimDelete
@@ -376,43 +349,20 @@ func TestCreateLocalPV_DeviceLinkArgOrder(t *testing.T) {
 		},
 	})
 
-	// Override package-level globals for the duration of this test.
-	origGlob := internal.FilePathGlob
-	origEval := internal.FilePathEvalSymLinks
-	origExec := internal.CmdExecutor
-	t.Cleanup(func() {
-		internal.FilePathGlob = origGlob
-		internal.FilePathEvalSymLinks = origEval
-		internal.CmdExecutor = origExec
-	})
-	oldReadLink := internal.Readlink
-	defer func() {
-		internal.Readlink = oldReadLink
-	}()
-	internal.Readlink = func(symlinkPath string) (string, error) {
-		return "/dev/disk/by-id/wwn-null", nil
-	}
-
-	// FilePathGlob returns our fake by-id link.
-	internal.FilePathGlob = func(pattern string) ([]string, error) {
-		return []string{fakeByIDLink}, nil
-	}
-
-	// FilePathEvalSymLinks resolves the by-id link to a path whose base is
-	// kName ("sda").  If KName and DevicePath were swapped the matcher would
-	// call this with a path that still resolves correctly (because
-	// filepath.Base("/dev/sda") == "sda"), so we record which target was
-	// actually resolved to make the test stricter.
 	var resolvedTarget string
-	internal.FilePathEvalSymLinks = func(path string) (string, error) {
-		resolvedTarget = path
-		// Return a path whose base is kName so the symlink appears valid.
-		return "/dev/" + kName, nil
-	}
-
-	// blkid returns fakeUUID only when called with devPath.
-	// If the caller passes kName instead, the UUID will be empty.
-	internal.CmdExecutor = fakeBlkidExecutor(devPath, fakeUUID)
+	diskmakertest.WithInternalMocks(t, func() {
+		internal.Readlink = func(symlinkPath string) (string, error) {
+			return "/dev/disk/by-id/wwn-null", nil
+		}
+		internal.FilePathGlob = func(pattern string) ([]string, error) {
+			return []string{fakeByIDLink}, nil
+		}
+		internal.FilePathEvalSymLinks = func(path string) (string, error) {
+			resolvedTarget = path
+			return "/dev/" + kName, nil
+		}
+		internal.CmdExecutor = diskmakertest.BlkidForDevicePathFakeExec(devPath, fakeUUID)
+	})
 
 	err := common.CreateLocalPV(t.Context(), common.CreateLocalPVArgs{
 		LocalVolumeLikeObject: &lv,
@@ -507,9 +457,7 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir, err := os.MkdirTemp("", "create-local-pv-lifecycle-")
-			assert.NoError(t, err)
-			defer os.RemoveAll(tmpDir)
+			tmpDir := diskmakertest.TempDir(t, "create-local-pv-lifecycle-")
 
 			lv := localv1.LocalVolume{
 				TypeMeta: metav1.TypeMeta{
@@ -543,14 +491,6 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 			assert.NoError(t, os.Symlink("/dev/null", currentTarget))
 			assert.NoError(t, os.Symlink("/dev/null", preferredTarget))
 
-			oldReadLink := internal.Readlink
-			defer func() {
-				internal.Readlink = oldReadLink
-			}()
-			internal.Readlink = func(symlinkPath string) (string, error) {
-				return "/dev/disk/by-id/wwn-null", nil
-			}
-
 			objs := []runtime.Object{&lv, &node, &sc}
 			if tc.existingLVDLFactory != nil {
 				objs = append(objs, tc.existingLVDLFactory(pvName, lv.Namespace, currentTarget, preferredTarget))
@@ -583,30 +523,26 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 			// CreateLocalPV, which the stub returns as fakeByIDLink.
 			expectedCurrentSymlink := fakeByIDLink
 
-			origGlob := internal.FilePathGlob
-			origEval := internal.FilePathEvalSymLinks
-			origExec := internal.CmdExecutor
-			t.Cleanup(func() {
-				internal.FilePathGlob = origGlob
-				internal.FilePathEvalSymLinks = origEval
-				internal.CmdExecutor = origExec
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.Readlink = func(symlinkPath string) (string, error) {
+					return "/dev/disk/by-id/wwn-null", nil
+				}
+				internal.FilePathGlob = func(pattern string) ([]string, error) {
+					if pattern == filepath.Join(internal.DiskByIDDir, "*") {
+						return []string{fakeByIDLink}, nil
+					}
+					return filepath.Glob(pattern)
+				}
+				internal.FilePathEvalSymLinks = func(path string) (string, error) {
+					if path == fakeByIDLink {
+						return "/dev/null", nil
+					}
+					return filepath.EvalSymlinks(path)
+				}
+				internal.CmdExecutor = diskmakertest.BlkidForDevicePathFakeExec("/dev/null", "uuid-lifecycle")
 			})
 
-			internal.FilePathGlob = func(pattern string) ([]string, error) {
-				if pattern == filepath.Join(internal.DiskByIDDir, "*") {
-					return []string{fakeByIDLink}, nil
-				}
-				return filepath.Glob(pattern)
-			}
-			internal.FilePathEvalSymLinks = func(path string) (string, error) {
-				if path == fakeByIDLink {
-					return "/dev/null", nil
-				}
-				return filepath.EvalSymlinks(path)
-			}
-			internal.CmdExecutor = fakeBlkidExecutor("/dev/null", "uuid-lifecycle")
-
-			err = common.CreateLocalPV(t.Context(), common.CreateLocalPVArgs{
+			err := common.CreateLocalPV(t.Context(), common.CreateLocalPVArgs{
 				LocalVolumeLikeObject: &lv,
 				RuntimeConfig:         r.runtimeConfig,
 				StorageClass:          sc,

--- a/pkg/diskmaker/controllers/lv/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lv/create_pv_test.go
@@ -570,18 +570,18 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 			})
 
 			var expectedPreferredSymlink string
-			var expectedCurrentSymlink string
 
 			// triggerRelink case triggers change of symlink to new preferredLinkTarget.
 			// RecreateSymlinkIfNeeded uses blockDevice.GetPathByID() which returns
 			// fakeByIDLink, so both current and preferred become fakeByIDLink after relink.
 			if tc.triggerRelink {
 				assert.NoError(t, os.Symlink(currentTarget, symLinkPath))
-				expectedCurrentSymlink = fakeByIDLink
 				expectedPreferredSymlink = fakeByIDLink
-			} else {
-				expectedCurrentSymlink = currentTarget
 			}
+
+			// effectiveCurrentSource is always resolved via internal.Readlink inside
+			// CreateLocalPV, which the stub returns as fakeByIDLink.
+			expectedCurrentSymlink := fakeByIDLink
 
 			origGlob := internal.FilePathGlob
 			origEval := internal.FilePathEvalSymLinks
@@ -621,7 +621,6 @@ func TestCreateLocalPV_DeviceLinkLifecycle(t *testing.T) {
 				},
 				CacheWriter:      r.pvLinkCache,
 				ExtraLabelsForPV: map[string]string{},
-				CurrentSymlink:   currentTarget,
 			})
 			assert.NoError(t, err)
 

--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -617,7 +617,6 @@ func (r *LocalVolumeReconciler) provisionPV(ctx context.Context, scName string, 
 		ClientReader:          r.ClientReader,
 		SymLinkPath:           deviceNameLocation.SymlinkPath,
 		ExtraLabelsForPV:      lvOwnerLabels,
-		CurrentSymlink:        deviceNameLocation.SymlinkSource,
 		BlockDevice:           deviceNameLocation.BlockDevice,
 		CacheWriter:           r.pvLinkCache,
 	}

--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -384,7 +384,7 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 	return ctrl.Result{Requeue: true, RequeueAfter: r.effectiveRequeueTime}, nil
 }
 
-func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDevices []internal.BlockDevice, diskConfig *DiskConfig, mountPointMap sets.String) {
+func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDevices []internal.BlockDevice, diskConfig *DiskConfig, mountPointMap sets.Set[string]) {
 	for storageClass, disks := range diskConfig.Disks {
 		var totalProvisionedPVs int
 		var blockDeviceList []internal.BlockDevice
@@ -480,7 +480,7 @@ func (r *LocalVolumeReconciler) resolveValidDeviceLocation(devicePath string, fo
 	return deviceLocation, true, nil
 }
 
-func (r *LocalVolumeReconciler) provisionValidDevice(ctx context.Context, storageClass, symLinkDirPath, devicePath string, deviceLocation *internal.DiskLocation, mountPointMap sets.String) bool {
+func (r *LocalVolumeReconciler) provisionValidDevice(ctx context.Context, storageClass, symLinkDirPath, devicePath string, deviceLocation *internal.DiskLocation, mountPointMap sets.Set[string]) bool {
 	existingSymlink, err := common.GetSymlinkedForCurrentSC(symLinkDirPath, deviceLocation.BlockDevice.KName)
 	if err != nil {
 		r.reportSymlinkLookupError(symLinkDirPath, devicePath, err)
@@ -538,7 +538,7 @@ func (r *LocalVolumeReconciler) reportProvisioningError(devicePath string, err e
 	klog.Error(msg)
 }
 
-func (r *LocalVolumeReconciler) processNewSymlink(ctx context.Context, scName string, diskLocation *internal.DiskLocation, mountPointMap sets.String) (bool, error) {
+func (r *LocalVolumeReconciler) processNewSymlink(ctx context.Context, scName string, diskLocation *internal.DiskLocation, mountPointMap sets.Set[string]) (bool, error) {
 	symLinkDirPath := path.Join(r.symlinkLocation, scName)
 	source, target, idExists, err := getSymlinkSourceAndTarget(diskLocation, symLinkDirPath)
 	if err != nil {
@@ -581,7 +581,7 @@ func (r *LocalVolumeReconciler) processExistingSymlink(
 	scName string,
 	symlinkPath string,
 	diskLocation *internal.DiskLocation,
-	mountPointMap sets.String) error {
+	mountPointMap sets.Set[string]) error {
 
 	klog.V(4).Infof("in processExistingSymlink symlink %s", symlinkPath)
 
@@ -596,7 +596,7 @@ func (r *LocalVolumeReconciler) processExistingSymlink(
 	return r.provisionPV(ctx, scName, diskLocation, mountPointMap)
 }
 
-func (r *LocalVolumeReconciler) provisionPV(ctx context.Context, scName string, deviceNameLocation *internal.DiskLocation, mountPointMap sets.String) error {
+func (r *LocalVolumeReconciler) provisionPV(ctx context.Context, scName string, deviceNameLocation *internal.DiskLocation, mountPointMap sets.Set[string]) error {
 	storageClass := &storagev1.StorageClass{}
 	err := r.Client.Get(ctx, types.NamespacedName{Name: scName}, storageClass)
 	if err != nil {

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -13,9 +13,6 @@ import (
 	"testing"
 	"time"
 
-	utilexec "k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
-
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	localv1alpha1 "github.com/openshift/local-storage-operator/api/v1alpha1"
@@ -147,8 +144,7 @@ func TestResolveValidDeviceLocation(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
-	tempDir := createTmpDir(t, "", "diskmaker")
-	defer os.RemoveAll(tempDir)
+	tempDir := diskmakertest.TempDir(t, "diskmaker")
 	diskConfig := &DiskConfig{
 		Disks: map[string]*Disks{
 			"foo": {
@@ -198,8 +194,7 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestProcessExistingSymlink_UsesFullSymlinkPath(t *testing.T) {
-	tmpRoot := createTmpDir(t, "", "existing-symlink")
-	defer os.RemoveAll(tmpRoot)
+	tmpRoot := diskmakertest.TempDir(t, "existing-symlink")
 
 	reclaimPolicyDelete := corev1.PersistentVolumeReclaimDelete
 	lv := &localv1.LocalVolume{
@@ -247,17 +242,12 @@ func TestProcessExistingSymlink_UsesFullSymlinkPath(t *testing.T) {
 		},
 	})
 
-	origGlob := internal.FilePathGlob
-	origExec := internal.CmdExecutor
-	t.Cleanup(func() {
-		internal.FilePathGlob = origGlob
-		internal.CmdExecutor = origExec
+	diskmakertest.WithInternalMocks(t, func() {
+		internal.FilePathGlob = func(string) ([]string, error) {
+			return nil, nil
+		}
+		internal.CmdExecutor = diskmakertest.BlkidForDevicePathFakeExec(filepath.Join("/dev", deviceName), "")
 	})
-
-	internal.FilePathGlob = func(string) ([]string, error) {
-		return nil, nil
-	}
-	internal.CmdExecutor = fakeBlkidExecutor(filepath.Join("/dev", deviceName), "")
 
 	diskLocation := &internal.DiskLocation{
 		DiskNamePath: deviceTarget,
@@ -352,8 +342,7 @@ func TestProvisionValidDevice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpRoot := createTmpDir(t, "", "provision-valid-device")
-			defer os.RemoveAll(tmpRoot)
+			tmpRoot := diskmakertest.TempDir(t, "provision-valid-device")
 
 			lv := &localv1.LocalVolume{
 				TypeMeta: metav1.TypeMeta{
@@ -410,28 +399,21 @@ func TestProvisionValidDevice(t *testing.T) {
 				assert.NoError(t, os.Symlink("/dev/null", filepath.Join(symLinkDir, "claimed")))
 			}
 
-			origGlob := internal.FilePathGlob
-			origEval := internal.FilePathEvalSymLinks
-			origExec := internal.CmdExecutor
-			t.Cleanup(func() {
-				internal.FilePathGlob = origGlob
-				internal.FilePathEvalSymLinks = origEval
-				internal.CmdExecutor = origExec
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.FilePathGlob = func(pattern string) ([]string, error) {
+					if pattern == filepath.Join(internal.DiskByIDDir, "*") {
+						return []string{fakeByIDLink}, nil
+					}
+					return filepath.Glob(pattern)
+				}
+				internal.FilePathEvalSymLinks = func(path string) (string, error) {
+					if path == fakeByIDLink {
+						return "/dev/null", nil
+					}
+					return filepath.EvalSymlinks(path)
+				}
+				internal.CmdExecutor = diskmakertest.BlkidForDevicePathFakeExec("/dev/null", "")
 			})
-
-			internal.FilePathGlob = func(pattern string) ([]string, error) {
-				if pattern == filepath.Join(internal.DiskByIDDir, "*") {
-					return []string{fakeByIDLink}, nil
-				}
-				return filepath.Glob(pattern)
-			}
-			internal.FilePathEvalSymLinks = func(path string) (string, error) {
-				if path == fakeByIDLink {
-					return "/dev/null", nil
-				}
-				return filepath.EvalSymlinks(path)
-			}
-			internal.CmdExecutor = fakeBlkidExecutor("/dev/null", "")
 
 			diskLocation := &internal.DiskLocation{
 				UserProvidedPath: "/dev/null",
@@ -459,8 +441,7 @@ func TestProcessValidDevices(t *testing.T) {
 	reclaimPolicyDelete := corev1.PersistentVolumeReclaimDelete
 	fakeByIDLink := "/dev/disk/by-id/wwn-null"
 
-	tmpRoot := createTmpDir(t, "", "process-valid-devices")
-	defer os.RemoveAll(tmpRoot)
+	tmpRoot := diskmakertest.TempDir(t, "process-valid-devices")
 
 	lv := &localv1.LocalVolume{
 		TypeMeta: metav1.TypeMeta{
@@ -504,28 +485,21 @@ func TestProcessValidDevices(t *testing.T) {
 		},
 	})
 
-	origGlob := internal.FilePathGlob
-	origEval := internal.FilePathEvalSymLinks
-	origExec := internal.CmdExecutor
-	t.Cleanup(func() {
-		internal.FilePathGlob = origGlob
-		internal.FilePathEvalSymLinks = origEval
-		internal.CmdExecutor = origExec
+	diskmakertest.WithInternalMocks(t, func() {
+		internal.FilePathGlob = func(pattern string) ([]string, error) {
+			if pattern == filepath.Join(internal.DiskByIDDir, "*") {
+				return []string{fakeByIDLink}, nil
+			}
+			return filepath.Glob(pattern)
+		}
+		internal.FilePathEvalSymLinks = func(path string) (string, error) {
+			if path == fakeByIDLink {
+				return "/dev/null", nil
+			}
+			return filepath.EvalSymlinks(path)
+		}
+		internal.CmdExecutor = diskmakertest.BlkidForDevicePathFakeExec("/dev/null", "")
 	})
-
-	internal.FilePathGlob = func(pattern string) ([]string, error) {
-		if pattern == filepath.Join(internal.DiskByIDDir, "*") {
-			return []string{fakeByIDLink}, nil
-		}
-		return filepath.Glob(pattern)
-	}
-	internal.FilePathEvalSymLinks = func(path string) (string, error) {
-		if path == fakeByIDLink {
-			return "/dev/null", nil
-		}
-		return filepath.EvalSymlinks(path)
-	}
-	internal.CmdExecutor = fakeBlkidExecutor("/dev/null", "")
 
 	diskConfig := &DiskConfig{
 		Disks: map[string]*Disks{
@@ -557,10 +531,9 @@ func TestProcessValidDevices(t *testing.T) {
 }
 
 func TestCreateSymLinkByDeviceID(t *testing.T) {
-	tmpSymLinkTargetDir := createTmpDir(t, "", "target")
+	tmpSymLinkTargetDir := diskmakertest.TempDir(t, "target")
 	fakeDisk := createTmpFile(t, "", "diskName", emptyFile)
 	fakeDiskByID := createTmpFile(t, "", "diskID", emptyFile)
-	defer os.RemoveAll(tmpSymLinkTargetDir)
 	defer os.Remove(fakeDisk.Name())
 	defer os.Remove(fakeDiskByID.Name())
 
@@ -629,12 +602,11 @@ func TestWipeDeviceWhenCreateSymLinkByDeviceName(t *testing.T) {
 		test := tests[i]
 		volHelper := util.NewVolumeHelper()
 		t.Run(test.name, func(t *testing.T) {
-			tmpSymLinkTargetDir := createTmpDir(t, "", "target")
+			tmpSymLinkTargetDir := diskmakertest.TempDir(t, "target")
 			fakeDisk := createTmpFile(t, "", "diskName", tinyFile)
 			fname := fakeDisk.Name()
 			volHelper.FormatAsExt4(t, fname)
 			defer os.Remove(fname)
-			defer os.RemoveAll(tmpSymLinkTargetDir)
 
 			lv := &localv1.LocalVolume{
 				TypeMeta: metav1.TypeMeta{
@@ -751,8 +723,7 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpRoot := createTmpDir(t, "", "rejected-devices")
-			defer os.RemoveAll(tmpRoot)
+			tmpRoot := diskmakertest.TempDir(t, "rejected-devices")
 
 			symLinkDir := filepath.Join(tmpRoot, storageClassName)
 			err := os.MkdirAll(symLinkDir, 0755)
@@ -795,62 +766,33 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 			r.runtimeConfig.Namespace = testNamespace
 			r.fsInterface = FakeFileSystemInterface{}
 
-			origGlob := internal.FilePathGlob
-			origEval := internal.FilePathEvalSymLinks
-			origExec := internal.CmdExecutor
-			defer func() {
-				internal.FilePathGlob = origGlob
-				internal.FilePathEvalSymLinks = origEval
-				internal.CmdExecutor = origExec
-			}()
-
-			internal.FilePathGlob = func(pattern string) ([]string, error) {
-				if strings.HasPrefix(pattern, internal.DiskByIDDir) {
-					if tc.byIDGlobErr != nil {
-						return nil, tc.byIDGlobErr
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.FilePathGlob = func(pattern string) ([]string, error) {
+					if strings.HasPrefix(pattern, internal.DiskByIDDir) {
+						if tc.byIDGlobErr != nil {
+							return nil, tc.byIDGlobErr
+						}
+						return []string{preferredByID, secondaryByID}, nil
 					}
-					return []string{preferredByID, secondaryByID}, nil
+					return filepath.Glob(pattern)
 				}
-				return filepath.Glob(pattern)
-			}
 
-			internal.FilePathEvalSymLinks = func(p string) (string, error) {
-				switch p {
-				case preferredByID, secondaryByID:
-					// Simulate by-id links resolving to this block device.
-					return filepath.Join("/dev", blockDevKName), nil
-				default:
-					return filepath.EvalSymlinks(p)
-				}
-			}
-
-			if tc.execCommandErr {
-				blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-					return &testingexec.FakeCmd{
-						CombinedOutputScript: []testingexec.FakeAction{
-							func() ([]byte, []byte, error) {
-								return nil, nil, fmt.Errorf("exit status 1")
-							},
-						},
+				internal.FilePathEvalSymLinks = func(p string) (string, error) {
+					switch p {
+					case preferredByID, secondaryByID:
+						// Simulate by-id links resolving to this block device.
+						return filepath.Join("/dev", blockDevKName), nil
+					default:
+						return filepath.EvalSymlinks(p)
 					}
 				}
-				internal.CmdExecutor = &testingexec.FakeExec{
-					CommandScript: []testingexec.FakeCommandAction{blkidAction},
+
+				if tc.execCommandErr {
+					internal.CmdExecutor = diskmakertest.BlkidAlwaysFakeExec("", fmt.Errorf("exit status 1"))
+				} else {
+					internal.CmdExecutor = diskmakertest.BlkidAlwaysFakeExec(filesystemUUID, nil)
 				}
-			} else {
-				blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-					return &testingexec.FakeCmd{
-						CombinedOutputScript: []testingexec.FakeAction{
-							func() ([]byte, []byte, error) {
-								return []byte(filesystemUUID), nil, nil
-							},
-						},
-					}
-				}
-				internal.CmdExecutor = &testingexec.FakeExec{
-					CommandScript: []testingexec.FakeCommandAction{blkidAction},
-				}
-			}
+			})
 
 			kname := blockDevKName
 			if tc.useEmptyKName {
@@ -911,8 +853,7 @@ func TestIgnoredDevicesProcessedWhenNoValidDevices(t *testing.T) {
 		filesystemUUID = "uuid-test-1234"
 	)
 
-	tmpRoot := createTmpDir(t, "", "ignored-devices")
-	defer os.RemoveAll(tmpRoot)
+	tmpRoot := diskmakertest.TempDir(t, "ignored-devices")
 
 	symLinkDir := filepath.Join(tmpRoot, storageClassName)
 	err := os.MkdirAll(symLinkDir, 0755)
@@ -949,41 +890,23 @@ func TestIgnoredDevicesProcessedWhenNoValidDevices(t *testing.T) {
 	r.runtimeConfig.Namespace = testNamespace
 	r.fsInterface = FakeFileSystemInterface{}
 
-	origGlob := internal.FilePathGlob
-	origEval := internal.FilePathEvalSymLinks
-	origExec := internal.CmdExecutor
-	defer func() {
-		internal.FilePathGlob = origGlob
-		internal.FilePathEvalSymLinks = origEval
-		internal.CmdExecutor = origExec
-	}()
-
-	internal.FilePathGlob = func(pattern string) ([]string, error) {
-		if strings.HasPrefix(pattern, internal.DiskByIDDir) {
-			return []string{preferredByID, secondaryByID}, nil
+	diskmakertest.WithInternalMocks(t, func() {
+		internal.FilePathGlob = func(pattern string) ([]string, error) {
+			if strings.HasPrefix(pattern, internal.DiskByIDDir) {
+				return []string{preferredByID, secondaryByID}, nil
+			}
+			return filepath.Glob(pattern)
 		}
-		return filepath.Glob(pattern)
-	}
-	internal.FilePathEvalSymLinks = func(p string) (string, error) {
-		switch p {
-		case preferredByID, secondaryByID:
-			return filepath.Join("/dev", blockDevKName), nil
-		default:
-			return filepath.EvalSymlinks(p)
+		internal.FilePathEvalSymLinks = func(p string) (string, error) {
+			switch p {
+			case preferredByID, secondaryByID:
+				return filepath.Join("/dev", blockDevKName), nil
+			default:
+				return filepath.EvalSymlinks(p)
+			}
 		}
-	}
-	blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-		return &testingexec.FakeCmd{
-			CombinedOutputScript: []testingexec.FakeAction{
-				func() ([]byte, []byte, error) {
-					return []byte(filesystemUUID), nil, nil
-				},
-			},
-		}
-	}
-	internal.CmdExecutor = &testingexec.FakeExec{
-		CommandScript: []testingexec.FakeCommandAction{blkidAction},
-	}
+		internal.CmdExecutor = diskmakertest.BlkidAlwaysFakeExec(filesystemUUID, nil)
+	})
 
 	diskConfig := &DiskConfig{
 		Disks: map[string]*Disks{
@@ -1149,14 +1072,6 @@ func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Obje
 	)
 
 	return lvReconciler, tc
-}
-
-func createTmpDir(t *testing.T, dir, prefix string) string {
-	tmpDir, err := os.MkdirTemp(dir, prefix)
-	if err != nil {
-		t.Fatalf("error creating temp directory : %v", err)
-	}
-	return tmpDir
 }
 
 func createTmpFile(t *testing.T, dir, pattern string, size int64) *os.File {
@@ -1437,7 +1352,7 @@ func TestDeleteReconcile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpSymLinkTargetDir := createTmpDir(t, "", "target")
+			tmpSymLinkTargetDir := diskmakertest.TempDir(t, "target")
 
 			cmBytes, err := f.ReadFile("testfiles/provisioner_conf.yaml")
 			if err != nil {

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -944,72 +944,110 @@ func TestIgnoredDevicesProcessedWhenNoValidDevices(t *testing.T) {
 //     symlink does not match in GetSymlinkedForCurrentSC, so provisionValidDevice
 //     calls processNewSymlink after resolving DiskID to wwn-new
 //  5. FindStalePVs falls back to sibling lookup, finds the LVDL via scsi-sibling
-//  6. GetSymlinkTargetPath warns (wwn-new not in ValidLinkTargets) but returns path
-//  7. CreateLocalPV recreates the symlink and updates the PV / LVDL
+//  6. With PreferredLinkTarget policy, GetSymlinkTargetPath warns (wwn-new not in
+//     ValidLinkTargets) but returns path; CreateLocalPV recreates the symlink and
+//     updates the PV / LVDL. With policy None, GetSymlinkTargetPath returns an error
+//     and processNewSymlink surfaces it (no symlink fix).
 func TestProcessNewSymlink_SiblingFallback(t *testing.T) {
-	fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
-	cfg := fixture.Config
-
-	lv := &localv1.LocalVolume{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: localv1.GroupVersion.String(),
-			Kind:       "LocalVolume",
+	testCases := []struct {
+		name      string
+		policy    localv1.DeviceLinkPolicy
+		expectErr string
+	}{
+		{
+			name:   "PreferredLinkTarget policy resolves sibling fallback",
+			policy: localv1.DeviceLinkPolicyPreferredLinkTarget,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "lv-relink",
-			Namespace: cfg.TestNamespace,
-		},
-	}
-
-	objs := append([]runtime.Object{lv}, fixture.RuntimeObjects()...)
-	r, tc := getFakeDiskMaker(t, fixture.TmpRoot, objs...)
-	r.localVolume = lv
-	r.runtimeConfig.Node = &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   cfg.TestNodeName,
-			Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+		{
+			name:      "policy None cannot fix stale symlink via sibling fallback",
+			policy:    localv1.DeviceLinkPolicyNone,
+			expectErr: "found stale symlink link",
 		},
 	}
-	r.runtimeConfig.Name = common.GetProvisionedByValue(*r.runtimeConfig.Node)
-	r.runtimeConfig.Namespace = cfg.TestNamespace
-	r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
-		VolumeMode: string(corev1.PersistentVolumeBlock),
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
+			cfg := fixture.Config
+
+			lv := &localv1.LocalVolume{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: localv1.GroupVersion.String(),
+					Kind:       "LocalVolume",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lv-relink",
+					Namespace: cfg.TestNamespace,
+				},
+			}
+
+			lvdl := fixture.LocalVolumeDeviceLink()
+			lvdl.Spec.Policy = tt.policy
+
+			objs := []runtime.Object{lv, fixture.PersistentVolume(), lvdl, fixture.StorageClass()}
+			r, testCtx := getFakeDiskMaker(t, fixture.TmpRoot, objs...)
+			r.localVolume = lv
+			r.runtimeConfig.Node = &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   cfg.TestNodeName,
+					Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+				},
+			}
+			r.runtimeConfig.Name = common.GetProvisionedByValue(*r.runtimeConfig.Node)
+			r.runtimeConfig.Namespace = cfg.TestNamespace
+			r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
+				VolumeMode: string(corev1.PersistentVolumeBlock),
+			}
+			r.fsInterface = FakeFileSystemInterface{}
+
+			r.pvLinkCache.SeedForTests(lvdl)
+
+			fixture.AddFakeVolumeDirEntries(testCtx.fakeVolUtil)
+
+			validDevices := []internal.BlockDevice{
+				{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName},
+			}
+			devicePath := filepath.Join("/dev", cfg.BlockDevKName)
+			deviceLocation, matched, err := r.resolveValidDeviceLocation(devicePath, false, validDevices)
+			assert.NoError(t, err)
+			assert.True(t, matched)
+			if deviceLocation.DiskID == "" {
+				matchedDeviceID, err := deviceLocation.BlockDevice.GetUncachedPathID()
+				assert.NoError(t, err)
+				deviceLocation.DiskID = matchedDeviceID
+			}
+
+			provisioned, err := r.processNewSymlink(context.TODO(), cfg.SCName, deviceLocation, sets.NewString())
+			if tt.expectErr != "" {
+				assert.ErrorContains(t, err, tt.expectErr)
+				assert.False(t, provisioned)
+				gotLinkTarget, rerr := os.Readlink(fixture.SymlinkPath)
+				assert.NoError(t, rerr)
+				assert.Equal(t, cfg.OldByID, gotLinkTarget)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.True(t, provisioned)
+
+			gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
+			assert.NoError(t, err)
+			assert.Equal(t, cfg.NewByID, gotLinkTarget,
+				"symlink under local-storage should be updated to the current preferred by-id path")
+
+			pv := &corev1.PersistentVolume{}
+			err = testCtx.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
+			assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
+			assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
+				"PV local path should be preserved from the original symlink name")
+			gotLVDL := &localv1.LocalVolumeDeviceLink{}
+			err = testCtx.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
+			assert.NoError(t, err)
+			assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
+			assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
+			assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
+		})
 	}
-	r.fsInterface = FakeFileSystemInterface{}
-
-	r.pvLinkCache.SeedForTests(fixture.LocalVolumeDeviceLink())
-
-	fixture.AddFakeVolumeDirEntries(tc.fakeVolUtil)
-
-	diskConfig := &DiskConfig{
-		Disks: map[string]*Disks{
-			cfg.SCName: {
-				DevicePaths: []string{filepath.Join("/dev", cfg.BlockDevKName)},
-			},
-		},
-	}
-	validDevices := []internal.BlockDevice{
-		{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName},
-	}
-
-	r.processValidDevices(context.TODO(), validDevices, diskConfig, sets.NewString())
-
-	gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
-	assert.NoError(t, err)
-	assert.Equal(t, cfg.NewByID, gotLinkTarget,
-		"symlink under local-storage should be updated to the current preferred by-id path")
-
-	pv := &corev1.PersistentVolume{}
-	err = tc.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
-	assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
-	assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
-		"PV local path should be preserved from the original symlink name")
-	gotLVDL := &localv1.LocalVolumeDeviceLink{}
-	err = tc.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
-	assert.NoError(t, err)
-	assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
-	assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
-	assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
 }
 
 func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Object) (*LocalVolumeReconciler, *testContext) {

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -20,6 +20,7 @@ import (
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	localv1alpha1 "github.com/openshift/local-storage-operator/api/v1alpha1"
 	"github.com/openshift/local-storage-operator/pkg/common"
+	"github.com/openshift/local-storage-operator/pkg/diskmaker/diskmakertest"
 	"github.com/openshift/local-storage-operator/pkg/internal"
 	test "github.com/openshift/local-storage-operator/test/framework"
 	"github.com/openshift/local-storage-operator/test/framework/util"
@@ -1005,6 +1006,87 @@ func TestIgnoredDevicesProcessedWhenNoValidDevices(t *testing.T) {
 	assert.Equal(t, preferredByID, gotLVDL.Status.PreferredLinkTarget)
 	assert.Equal(t, filesystemUUID, gotLVDL.Status.FilesystemUUID)
 	assert.ElementsMatch(t, []string{preferredByID, secondaryByID}, gotLVDL.Status.ValidLinkTargets)
+}
+
+// TestProcessNewSymlink_SiblingFallback verifies that when a device's preferred
+// /dev/disk/by-id symlink changes while diskmaker is not running (e.g. OS upgrade),
+// the reconciler can still find the stale PV via a sibling by-id symlink that
+// remains in the LVDL's ValidLinkTargets.
+//
+// Scenario:
+//  1. PV was provisioned with /dev/disk/by-id/wwn-old as CurrentLinkTarget
+//  2. Node reboots, wwn-old disappears, wwn-new appears (same device)
+//  3. scsi-sibling still exists and is recorded in LVDL's ValidLinkTargets
+//  4. Diskmaker reconciles via processValidDevices (device path /dev/sdb); dangling
+//     symlink does not match in GetSymlinkedForCurrentSC, so provisionValidDevice
+//     calls processNewSymlink after resolving DiskID to wwn-new
+//  5. FindStalePVs falls back to sibling lookup, finds the LVDL via scsi-sibling
+//  6. GetSymlinkTargetPath warns (wwn-new not in ValidLinkTargets) but returns path
+//  7. CreateLocalPV recreates the symlink and updates the PV / LVDL
+func TestProcessNewSymlink_SiblingFallback(t *testing.T) {
+	fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
+	cfg := fixture.Config
+
+	lv := &localv1.LocalVolume{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: localv1.GroupVersion.String(),
+			Kind:       "LocalVolume",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lv-relink",
+			Namespace: cfg.TestNamespace,
+		},
+	}
+
+	objs := append([]runtime.Object{lv}, fixture.RuntimeObjects()...)
+	r, tc := getFakeDiskMaker(t, fixture.TmpRoot, objs...)
+	r.localVolume = lv
+	r.runtimeConfig.Node = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   cfg.TestNodeName,
+			Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+		},
+	}
+	r.runtimeConfig.Name = common.GetProvisionedByValue(*r.runtimeConfig.Node)
+	r.runtimeConfig.Namespace = cfg.TestNamespace
+	r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
+		VolumeMode: string(corev1.PersistentVolumeBlock),
+	}
+	r.fsInterface = FakeFileSystemInterface{}
+
+	r.pvLinkCache.SeedForTests(fixture.LocalVolumeDeviceLink())
+
+	fixture.AddFakeVolumeDirEntries(tc.fakeVolUtil)
+
+	diskConfig := &DiskConfig{
+		Disks: map[string]*Disks{
+			cfg.SCName: {
+				DevicePaths: []string{filepath.Join("/dev", cfg.BlockDevKName)},
+			},
+		},
+	}
+	validDevices := []internal.BlockDevice{
+		{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName},
+	}
+
+	r.processValidDevices(context.TODO(), validDevices, diskConfig, sets.NewString())
+
+	gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.NewByID, gotLinkTarget,
+		"symlink under local-storage should be updated to the current preferred by-id path")
+
+	pv := &corev1.PersistentVolume{}
+	err = tc.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
+	assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
+	assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
+		"PV local path should be preserved from the original symlink name")
+	gotLVDL := &localv1.LocalVolumeDeviceLink{}
+	err = tc.fakeClient.Get(context.TODO(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
+	assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
+	assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
 }
 
 func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Object) (*LocalVolumeReconciler, *testContext) {

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -257,7 +257,7 @@ func TestProcessExistingSymlink_UsesFullSymlinkPath(t *testing.T) {
 		},
 	}
 
-	err := d.processExistingSymlink(context.TODO(), sc.Name, symlinkPath, diskLocation, sets.NewString())
+	err := d.processExistingSymlink(context.TODO(), sc.Name, symlinkPath, diskLocation, sets.New[string]())
 	assert.NoError(t, err)
 	assert.Equal(t, symlinkPath, diskLocation.SymlinkPath)
 	assert.Equal(t, deviceTarget, diskLocation.SymlinkSource)
@@ -424,7 +424,7 @@ func TestProvisionValidDevice(t *testing.T) {
 				},
 			}
 
-			provisioned := d.provisionValidDevice(t.Context(), storageClassName, symLinkDir, "/dev/null", diskLocation, sets.NewString())
+			provisioned := d.provisionValidDevice(t.Context(), storageClassName, symLinkDir, "/dev/null", diskLocation, sets.New[string]())
 			assert.Equal(t, tc.expectProvisioned, provisioned)
 			assert.Equal(t, tc.expectRequeue, d.effectiveRequeueTime)
 
@@ -515,7 +515,7 @@ func TestProcessValidDevices(t *testing.T) {
 		t.Context(),
 		[]internal.BlockDevice{{Name: "null", KName: "null", PathByID: fakeByIDLink}},
 		diskConfig,
-		sets.NewString(),
+		sets.New[string](),
 	)
 
 	pvName := common.GeneratePVName(filepath.Base(fakeByIDLink), node.Name, storageClassName)
@@ -1017,7 +1017,7 @@ func TestProcessNewSymlink_SiblingFallback(t *testing.T) {
 				deviceLocation.DiskID = matchedDeviceID
 			}
 
-			provisioned, err := r.processNewSymlink(context.TODO(), cfg.SCName, deviceLocation, sets.NewString())
+			provisioned, err := r.processNewSymlink(context.TODO(), cfg.SCName, deviceLocation, sets.New[string]())
 			if tt.expectErr != "" {
 				assert.ErrorContains(t, err, tt.expectErr)
 				assert.False(t, provisioned)

--- a/pkg/diskmaker/controllers/lvset/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lvset/create_pv_test.go
@@ -37,7 +37,7 @@ func TestCreatePV(t *testing.T) {
 		desiredVolMode  string
 		deviceName      string
 		deviceCapacity  int64
-		mountPoints     sets.String
+		mountPoints     sets.Set[string]
 		extraDirEntries []*provUtil.FakeDirEntry
 	}{
 		{
@@ -64,7 +64,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeBlock),
 			desiredVolMode: string(localv1.PersistentVolumeBlock),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -95,7 +95,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeBlock),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -125,7 +125,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeBlock),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString(),
+			mountPoints:    sets.New[string](),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -155,7 +155,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString("/mnt/local-storage/storageclass-a/device-a"),
+			mountPoints:    sets.New[string]("/mnt/local-storage/storageclass-a/device-a"),
 			symlinkpath:    "/mnt/local-storage/storageclass-a/device-a",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-a",
@@ -186,7 +186,7 @@ func TestCreatePV(t *testing.T) {
 			},
 			actualVolMode:  string(localv1.PersistentVolumeFilesystem),
 			desiredVolMode: string(localv1.PersistentVolumeFilesystem),
-			mountPoints:    sets.NewString("a", "b"), // device not present
+			mountPoints:    sets.New[string]("a", "b"), // device not present
 			symlinkpath:    "/mnt/local-storage/storageclass-b/device-b",
 			deviceCapacity: 10 * common.GiB,
 			deviceName:     "device-b",
@@ -363,7 +363,7 @@ func TestCreatePV_SetsLVDLOwnerRefToLocalVolumeSet(t *testing.T) {
 		LocalVolumeLikeObject: &lvset,
 		RuntimeConfig:         r.runtimeConfig,
 		StorageClass:          sc,
-		MountPointMap:         sets.NewString(),
+		MountPointMap:         sets.New[string](),
 		Client:                r.Client,
 		ClientReader:          r.ClientReader,
 		SymLinkPath:           symLinkPath,

--- a/pkg/diskmaker/controllers/lvset/create_pv_test.go
+++ b/pkg/diskmaker/controllers/lvset/create_pv_test.go
@@ -11,6 +11,7 @@ import (
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	localv1alpha1 "github.com/openshift/local-storage-operator/api/v1alpha1"
 	"github.com/openshift/local-storage-operator/pkg/common"
+	"github.com/openshift/local-storage-operator/pkg/diskmaker/diskmakertest"
 	"github.com/openshift/local-storage-operator/pkg/internal"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -18,8 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilexec "k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 )
@@ -210,13 +209,11 @@ func TestCreatePV(t *testing.T) {
 			testConfig.runtimeConfig.Name = common.GetProvisionedByValue(tc.node)
 			testConfig.runtimeConfig.DiscoveryMap[tc.sc.Name] = provCommon.MountConfig{VolumeMode: tc.desiredVolMode}
 
-			oldReadLink := internal.Readlink
-			defer func() {
-				internal.Readlink = oldReadLink
-			}()
-			internal.Readlink = func(symlinkPath string) (string, error) {
-				return "/dev/disk/by-id/wwn-null", nil
-			}
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.Readlink = func(symlinkPath string) (string, error) {
+					return "/dev/disk/by-id/wwn-null", nil
+				}
+			})
 
 			fakeMap := map[string]string{
 				string(corev1.PersistentVolumeFilesystem): provUtil.FakeEntryFile,
@@ -349,40 +346,18 @@ func TestCreatePV_SetsLVDLOwnerRefToLocalVolumeSet(t *testing.T) {
 		},
 	})
 
-	origGlob := internal.FilePathGlob
-	origEval := internal.FilePathEvalSymLinks
-	origExec := internal.CmdExecutor
-	t.Cleanup(func() {
-		internal.FilePathGlob = origGlob
-		internal.FilePathEvalSymLinks = origEval
-		internal.CmdExecutor = origExec
-	})
-	internal.FilePathGlob = func(pattern string) ([]string, error) {
-		return []string{"/dev/disk/by-id/wwn-ownerref"}, nil
-	}
-	internal.FilePathEvalSymLinks = func(path string) (string, error) {
-		return "/dev/device-ownerref", nil
-	}
-	blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-		return &testingexec.FakeCmd{
-			CombinedOutputScript: []testingexec.FakeAction{
-				func() ([]byte, []byte, error) {
-					return []byte("uuid-ownerref"), nil, nil
-				},
-			},
+	diskmakertest.WithInternalMocks(t, func() {
+		internal.FilePathGlob = func(pattern string) ([]string, error) {
+			return []string{"/dev/disk/by-id/wwn-ownerref"}, nil
 		}
-	}
-	internal.CmdExecutor = &testingexec.FakeExec{
-		CommandScript: []testingexec.FakeCommandAction{blkidAction},
-	}
-	oldReadLink := internal.Readlink
-	t.Cleanup(func() {
-		internal.Readlink = oldReadLink
+		internal.FilePathEvalSymLinks = func(path string) (string, error) {
+			return "/dev/device-ownerref", nil
+		}
+		internal.CmdExecutor = diskmakertest.BlkidAlwaysFakeExec("uuid-ownerref", nil)
+		internal.Readlink = func(symlinkPath string) (string, error) {
+			return "/dev/disk/by-id/wwn-null", nil
+		}
 	})
-
-	internal.Readlink = func(symlinkPath string) (string, error) {
-		return "/dev/disk/by-id/wwn-null", nil
-	}
 
 	err := common.CreateLocalPV(t.Context(), common.CreateLocalPVArgs{
 		LocalVolumeLikeObject: &lvset,

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -560,7 +560,7 @@ func (r *LocalVolumeSetReconciler) processNewSymlink(
 		symlinkPath, err = currentDevice.GetSymlinkTargetPath(ctx, symLinkDir, symlinkSourcePath, r.Client)
 		if err != nil {
 			r.reportProvisioningFailure(lvset, blockDevice.KName, err)
-			return result, nil
+			return result, err
 		}
 		err = r.provisionFromExistingPV(ctx, lvset, blockDevice, storageClass, mountPointMap, symlinkPath)
 		if err == common.ErrTryAgain {

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -516,7 +516,7 @@ func (r *LocalVolumeSetReconciler) processNewSymlink(
 	blockDevice internal.BlockDevice,
 	blockDevices []internal.BlockDevice,
 	storageClass storagev1.StorageClass,
-	mountPointMap sets.String,
+	mountPointMap sets.Set[string],
 	symLinkDir string,
 ) (*processNewSymlinkResult, error) {
 	result := &processNewSymlinkResult{}
@@ -598,7 +598,7 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 	obj *localv1alpha1.LocalVolumeSet,
 	dev internal.BlockDevice,
 	storageClass storagev1.StorageClass,
-	mountPointMap sets.String,
+	mountPointMap sets.Set[string],
 	symlinkSourcePath string,
 	symlinkPath string,
 ) error {
@@ -690,7 +690,7 @@ func (r *LocalVolumeSetReconciler) provisionFromExistingPV(
 	obj *localv1alpha1.LocalVolumeSet,
 	blockDevice internal.BlockDevice,
 	storageClass storagev1.StorageClass,
-	mountPointMap sets.String,
+	mountPointMap sets.Set[string],
 	symlinkPath string) error {
 	createLocalPVArgs := common.CreateLocalPVArgs{
 		LocalVolumeLikeObject: obj,

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -640,7 +640,6 @@ func (r *LocalVolumeSetReconciler) provisionPV(
 		ClientReader:          r.ClientReader,
 		SymLinkPath:           symlinkPath,
 		ExtraLabelsForPV:      map[string]string{},
-		CurrentSymlink:        symlinkSourcePath,
 		BlockDevice:           dev,
 		CacheWriter:           r.pvLinkCache,
 	}
@@ -694,12 +693,6 @@ func (r *LocalVolumeSetReconciler) provisionFromExistingPV(
 	storageClass storagev1.StorageClass,
 	mountPointMap sets.String,
 	symlinkPath string) error {
-	// read the current source to which symlink in /mnt/local-storage points to
-	effectiveCurrentSource, err := internal.Readlink(symlinkPath)
-	if err != nil {
-		klog.ErrorS(err, "error evaluating symlink", "symlink", symlinkPath)
-	}
-
 	createLocalPVArgs := common.CreateLocalPVArgs{
 		LocalVolumeLikeObject: obj,
 		RuntimeConfig:         r.runtimeConfig,
@@ -709,7 +702,6 @@ func (r *LocalVolumeSetReconciler) provisionFromExistingPV(
 		ClientReader:          r.ClientReader,
 		SymLinkPath:           symlinkPath,
 		ExtraLabelsForPV:      map[string]string{},
-		CurrentSymlink:        effectiveCurrentSource,
 		BlockDevice:           blockDevice,
 		CacheWriter:           r.pvLinkCache,
 	}

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -34,7 +34,6 @@ import (
 const (
 	// ComponentName for lvset symlinker
 	ComponentName      = "localvolumeset-symlink-controller"
-	pvOwnerKey         = "pvOwner"
 	defaultRequeueTime = time.Minute
 	fastRequeueTime    = 5 * time.Second
 )

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -560,7 +560,7 @@ func (r *LocalVolumeSetReconciler) processNewSymlink(
 		symlinkPath, err = currentDevice.GetSymlinkTargetPath(ctx, symLinkDir, symlinkSourcePath, r.Client)
 		if err != nil {
 			r.reportProvisioningFailure(lvset, blockDevice.KName, err)
-			return result, err
+			return result, nil
 		}
 		err = r.provisionFromExistingPV(ctx, lvset, blockDevice, storageClass, mountPointMap, symlinkPath)
 		if err == common.ErrTryAgain {

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -267,7 +267,7 @@ func TestProcessNewSymlink(t *testing.T) {
 				device,
 				[]internal.BlockDevice{device},
 				*sc,
-				sets.NewString(),
+				sets.New[string](),
 				symLinkDirPath,
 			)
 
@@ -380,7 +380,7 @@ func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
 				device,
 				[]internal.BlockDevice{device},
 				*sc,
-				sets.NewString(),
+				sets.New[string](),
 				fixture.SymLinkDir,
 			)
 			assert.NotNil(t, result)
@@ -514,7 +514,7 @@ func TestProvisionFromExistingPV(t *testing.T) {
 				lvset,
 				internal.BlockDevice{Name: "null", KName: "null"},
 				*sc,
-				sets.NewString(),
+				sets.New[string](),
 				symlinkPath,
 			)
 

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -312,21 +312,22 @@ func TestProcessNewSymlink(t *testing.T) {
 // Exercises FindStalePVs → provisionFromExistingPV → CreateLocalPV with a LocalVolumeSet owner.
 func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
 	testCases := []struct {
-		name      string
-		lvsetName string
-		policy    v1api.DeviceLinkPolicy
-		expectErr string
+		name          string
+		lvsetName     string
+		policy        v1api.DeviceLinkPolicy
+		expectUpdated bool
 	}{
 		{
-			name:      "PreferredLinkTarget policy resolves sibling fallback",
-			lvsetName: "lvset-sibling-fallback",
-			policy:    v1api.DeviceLinkPolicyPreferredLinkTarget,
+			name:          "PreferredLinkTarget policy resolves sibling fallback",
+			lvsetName:     "lvset-sibling-fallback",
+			policy:        v1api.DeviceLinkPolicyPreferredLinkTarget,
+			expectUpdated: true,
 		},
 		{
-			name:      "policy None cannot fix stale symlink via sibling fallback",
-			lvsetName: "lvset-sibling-fallback-none",
-			policy:    v1api.DeviceLinkPolicyNone,
-			expectErr: "found stale symlink link",
+			name:          "policy None cannot fix stale symlink via sibling fallback",
+			lvsetName:     "lvset-sibling-fallback-none",
+			policy:        v1api.DeviceLinkPolicyNone,
+			expectUpdated: false,
 		},
 	}
 
@@ -384,15 +385,16 @@ func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
 				fixture.SymLinkDir,
 			)
 			assert.NotNil(t, result)
-			if tc.expectErr != "" {
-				assert.ErrorContains(t, err, tc.expectErr)
-				return
-			}
-
 			assert.NoError(t, err)
 
 			gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
 			assert.NoError(t, err)
+			if !tc.expectUpdated {
+				assert.Equal(t, cfg.OldByID, gotLinkTarget,
+					"symlink should remain unchanged when sibling fallback is not allowed to repair it")
+				return
+			}
+
 			assert.Equal(t, cfg.NewByID, gotLinkTarget,
 				"symlink under local-storage should be updated to the current preferred by-id path")
 

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -311,75 +311,106 @@ func TestProcessNewSymlink(t *testing.T) {
 // scenario: stale dangling symlink and LVDL valid targets include a sibling by-id path.
 // Exercises FindStalePVs → provisionFromExistingPV → CreateLocalPV with a LocalVolumeSet owner.
 func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
-	fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
-	cfg := fixture.Config
-
-	lvset := &v1alphav1api.LocalVolumeSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alphav1api.LocalVolumeSetKind,
-			APIVersion: v1alphav1api.GroupVersion.String(),
+	testCases := []struct {
+		name      string
+		lvsetName string
+		policy    v1api.DeviceLinkPolicy
+		expectErr string
+	}{
+		{
+			name:      "PreferredLinkTarget policy resolves sibling fallback",
+			lvsetName: "lvset-sibling-fallback",
+			policy:    v1api.DeviceLinkPolicyPreferredLinkTarget,
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "lvset-sibling-fallback",
-			Namespace: cfg.TestNamespace,
-		},
-		Spec: v1alphav1api.LocalVolumeSetSpec{
-			StorageClassName: cfg.SCName,
-		},
-	}
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   cfg.TestNodeName,
-			Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+		{
+			name:      "policy None cannot fix stale symlink via sibling fallback",
+			lvsetName: "lvset-sibling-fallback-none",
+			policy:    v1api.DeviceLinkPolicyNone,
+			expectErr: "found stale symlink link",
 		},
 	}
 
-	objs := append([]runtime.Object{lvset, node}, fixture.RuntimeObjects()...)
-	r, tc := newFakeLocalVolumeSetReconciler(t, objs...)
-	r.pvLinkCache.SeedForTests(fixture.LocalVolumeDeviceLink())
-	r.nodeName = node.Name
-	r.runtimeConfig.Node = node
-	r.runtimeConfig.Name = common.GetProvisionedByValue(*node)
-	r.runtimeConfig.Namespace = cfg.TestNamespace
-	r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
-		VolumeMode: string(corev1.PersistentVolumeBlock),
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
+			cfg := fixture.Config
+
+			lvset := &v1alphav1api.LocalVolumeSet{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       v1alphav1api.LocalVolumeSetKind,
+					APIVersion: v1alphav1api.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tc.lvsetName,
+					Namespace: cfg.TestNamespace,
+				},
+				Spec: v1alphav1api.LocalVolumeSetSpec{
+					StorageClassName: cfg.SCName,
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   cfg.TestNodeName,
+					Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+				},
+			}
+
+			lvdl := fixture.LocalVolumeDeviceLink()
+			lvdl.Spec.Policy = tc.policy
+
+			objs := []runtime.Object{lvset, node, fixture.PersistentVolume(), lvdl, fixture.StorageClass()}
+			r, testCtx := newFakeLocalVolumeSetReconciler(t, objs...)
+			r.pvLinkCache.SeedForTests(lvdl)
+			r.nodeName = node.Name
+			r.runtimeConfig.Node = node
+			r.runtimeConfig.Name = common.GetProvisionedByValue(*node)
+			r.runtimeConfig.Namespace = cfg.TestNamespace
+			r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
+				VolumeMode: string(corev1.PersistentVolumeBlock),
+			}
+
+			fixture.AddFakeVolumeDirEntries(testCtx.fakeVolUtil)
+
+			sc := fixture.StorageClass()
+			device := internal.BlockDevice{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName}
+
+			result, err := r.processNewSymlink(
+				context.Background(),
+				lvset,
+				device,
+				[]internal.BlockDevice{device},
+				*sc,
+				sets.NewString(),
+				fixture.SymLinkDir,
+			)
+			assert.NotNil(t, result)
+			if tc.expectErr != "" {
+				assert.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
+			assert.NoError(t, err)
+			assert.Equal(t, cfg.NewByID, gotLinkTarget,
+				"symlink under local-storage should be updated to the current preferred by-id path")
+
+			pv := &corev1.PersistentVolume{}
+			err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
+			assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
+			assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
+				"PV local path should be preserved from the original symlink name")
+			assert.Equal(t, v1api.LocalVolumeSetKind, pv.Labels[common.PVOwnerKindLabel])
+
+			gotLVDL := &v1api.LocalVolumeDeviceLink{}
+			err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
+			assert.NoError(t, err)
+			assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
+			assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
+			assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
+		})
 	}
-
-	fixture.AddFakeVolumeDirEntries(tc.fakeVolUtil)
-
-	sc := fixture.StorageClass()
-	device := internal.BlockDevice{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName}
-
-	result, err := r.processNewSymlink(
-		context.Background(),
-		lvset,
-		device,
-		[]internal.BlockDevice{device},
-		*sc,
-		sets.NewString(),
-		fixture.SymLinkDir,
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, result)
-
-	gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
-	assert.NoError(t, err)
-	assert.Equal(t, cfg.NewByID, gotLinkTarget,
-		"symlink under local-storage should be updated to the current preferred by-id path")
-
-	pv := &corev1.PersistentVolume{}
-	err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
-	assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
-	assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
-		"PV local path should be preserved from the original symlink name")
-	assert.Equal(t, v1api.LocalVolumeSetKind, pv.Labels[common.PVOwnerKindLabel])
-
-	gotLVDL := &v1api.LocalVolumeDeviceLink{}
-	err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
-	assert.NoError(t, err)
-	assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
-	assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
-	assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
 }
 
 func TestProvisionFromExistingPV(t *testing.T) {

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -2,7 +2,6 @@ package lvset
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,8 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
 	"k8s.io/utils/mount"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -118,54 +115,8 @@ func newFakeLocalVolumeSetReconciler(t *testing.T, objs ...runtime.Object) (*Loc
 	return lvsReconciler, tc
 }
 
-func createTempDir(t *testing.T, prefix string) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", prefix)
-	assert.NoError(t, err)
-	return dir
-}
-
-func fakeCommandExecutor(findOutput, blkidOutput string, blkidErr error) *testingexec.FakeExec {
-	action := func(cmd string, args ...string) exec.Cmd {
-		switch cmd {
-		case "find":
-			return &testingexec.FakeCmd{
-				CombinedOutputScript: []testingexec.FakeAction{
-					func() ([]byte, []byte, error) {
-						return []byte(findOutput), nil, nil
-					},
-				},
-			}
-		case "blkid":
-			return &testingexec.FakeCmd{
-				CombinedOutputScript: []testingexec.FakeAction{
-					func() ([]byte, []byte, error) {
-						return []byte(blkidOutput), nil, blkidErr
-					},
-				},
-			}
-		default:
-			return &testingexec.FakeCmd{
-				CombinedOutputScript: []testingexec.FakeAction{
-					func() ([]byte, []byte, error) {
-						return nil, nil, fmt.Errorf("unexpected command %s", cmd)
-					},
-				},
-			}
-		}
-	}
-	commandScript := make([]testingexec.FakeCommandAction, 0, 16)
-	for i := 0; i < 16; i++ {
-		commandScript = append(commandScript, action)
-	}
-	return &testingexec.FakeExec{
-		CommandScript: commandScript,
-	}
-}
-
 func TestGetAlreadySymlinked(t *testing.T) {
-	tmpDir := createTempDir(t, "already-symlinked-")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := diskmakertest.TempDir(t, "already-symlinked-")
 
 	matching := filepath.Join(tmpDir, "matching")
 	nonMatching := filepath.Join(tmpDir, "other")
@@ -225,8 +176,7 @@ func TestProcessNewSymlink(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := createTempDir(t, "process-new-symlink-")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := diskmakertest.TempDir(t, "process-new-symlink-")
 
 			lvset := &v1alphav1api.LocalVolumeSet{
 				TypeMeta: metav1.TypeMeta{
@@ -295,28 +245,21 @@ func TestProcessNewSymlink(t *testing.T) {
 				assert.NoError(t, os.Symlink("/dev/null", filepath.Join(symLinkDirPath, "claimed")))
 			}
 
-			origEval := internal.FilePathEvalSymLinks
-			origGlob := internal.FilePathGlob
-			origExec := internal.CmdExecutor
-			t.Cleanup(func() {
-				internal.FilePathEvalSymLinks = origEval
-				internal.FilePathGlob = origGlob
-				internal.CmdExecutor = origExec
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.FilePathEvalSymLinks = func(path string) (string, error) {
+					if path == device.PathByID {
+						return "/dev/null", nil
+					}
+					return filepath.EvalSymlinks(path)
+				}
+				internal.FilePathGlob = func(pattern string) ([]string, error) {
+					if pattern == filepath.Join(internal.DiskByIDDir, "*") {
+						return []string{fakeIDPath}, nil
+					}
+					return filepath.Glob(pattern)
+				}
+				internal.CmdExecutor = diskmakertest.FindAndBlkidFakeExec("", "", nil)
 			})
-
-			internal.FilePathEvalSymLinks = func(path string) (string, error) {
-				if path == device.PathByID {
-					return "/dev/null", nil
-				}
-				return filepath.EvalSymlinks(path)
-			}
-			internal.FilePathGlob = func(pattern string) ([]string, error) {
-				if pattern == filepath.Join(internal.DiskByIDDir, "*") {
-					return []string{fakeIDPath}, nil
-				}
-				return filepath.Glob(pattern)
-			}
-			internal.CmdExecutor = fakeCommandExecutor("", "", nil)
 
 			result, err := r.processNewSymlink(
 				t.Context(),
@@ -473,8 +416,7 @@ func TestProvisionFromExistingPV(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := createTempDir(t, "existing-pv-")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := diskmakertest.TempDir(t, "existing-pv-")
 
 			lvset := &v1alphav1api.LocalVolumeSet{
 				TypeMeta: metav1.TypeMeta{
@@ -520,24 +462,21 @@ func TestProvisionFromExistingPV(t *testing.T) {
 				},
 			})
 
-			origExec := internal.CmdExecutor
-			origReadlink := internal.Readlink
-			t.Cleanup(func() {
-				internal.CmdExecutor = origExec
-				internal.Readlink = origReadlink
-			})
-			internal.CmdExecutor = fakeCommandExecutor("", "", nil)
-			if tc.mockReadlink {
-				internal.Readlink = func(path string) (string, error) {
-					if path == symlinkPath {
-						if tc.removeSymlink {
-							return "", os.ErrNotExist
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.CmdExecutor = diskmakertest.FindAndBlkidFakeExec("", "", nil)
+				if tc.mockReadlink {
+					baseReadlink := internal.Readlink
+					internal.Readlink = func(path string) (string, error) {
+						if path == symlinkPath {
+							if tc.removeSymlink {
+								return "", os.ErrNotExist
+							}
+							return tc.symlinkTarget, nil
 						}
-						return tc.symlinkTarget, nil
+						return baseReadlink(path)
 					}
-					return origReadlink(path)
 				}
-			}
+			})
 
 			err := r.provisionFromExistingPV(
 				t.Context(),
@@ -638,8 +577,7 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmpDir := createTempDir(t, "rejected-lvset-")
-			defer os.RemoveAll(tmpDir)
+			tmpDir := diskmakertest.TempDir(t, "rejected-lvset-")
 
 			lvset := &v1alphav1api.LocalVolumeSet{
 				TypeMeta: metav1.TypeMeta{
@@ -713,31 +651,24 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 				r.pvLinkCache.SeedForTests(lvdl)
 			}
 
-			origGlob := internal.FilePathGlob
-			origEval := internal.FilePathEvalSymLinks
-			origExec := internal.CmdExecutor
-			t.Cleanup(func() {
-				internal.FilePathGlob = origGlob
-				internal.FilePathEvalSymLinks = origEval
-				internal.CmdExecutor = origExec
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.FilePathGlob = func(pattern string) ([]string, error) {
+					if pattern == filepath.Join(internal.DiskByIDDir, "*") {
+						return []string{"/dev/disk/by-id/wwn-null"}, nil
+					}
+					return filepath.Glob(pattern)
+				}
+				internal.FilePathEvalSymLinks = func(path string) (string, error) {
+					if path == "/dev/disk/by-id/wwn-null" {
+						return "/dev/null", nil
+					}
+					if tc.danglingSymlink && path == symlinkPath {
+						return "", os.ErrNotExist
+					}
+					return filepath.EvalSymlinks(path)
+				}
+				internal.CmdExecutor = diskmakertest.FindAndBlkidFakeExec("", "uuid-null", nil)
 			})
-
-			internal.FilePathGlob = func(pattern string) ([]string, error) {
-				if pattern == filepath.Join(internal.DiskByIDDir, "*") {
-					return []string{"/dev/disk/by-id/wwn-null"}, nil
-				}
-				return filepath.Glob(pattern)
-			}
-			internal.FilePathEvalSymLinks = func(path string) (string, error) {
-				if path == "/dev/disk/by-id/wwn-null" {
-					return "/dev/null", nil
-				}
-				if tc.danglingSymlink && path == symlinkPath {
-					return "", os.ErrNotExist
-				}
-				return filepath.EvalSymlinks(path)
-			}
-			internal.CmdExecutor = fakeCommandExecutor("", "uuid-null", nil)
 
 			r.processRejectedDevicesForDeviceLinks(
 				t.Context(),

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -1,6 +1,7 @@
 package lvset
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	v1api "github.com/openshift/local-storage-operator/api/v1"
 	v1alphav1api "github.com/openshift/local-storage-operator/api/v1alpha1"
 	"github.com/openshift/local-storage-operator/pkg/common"
+	"github.com/openshift/local-storage-operator/pkg/diskmaker/diskmakertest"
 	"github.com/openshift/local-storage-operator/pkg/internal"
 	test "github.com/openshift/local-storage-operator/test/framework"
 	"github.com/stretchr/testify/assert"
@@ -360,6 +362,81 @@ func TestProcessNewSymlink(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProcessNewSymlink_SiblingFallback_LVSet mirrors the LocalVolume sibling-fallback
+// scenario: stale dangling symlink and LVDL valid targets include a sibling by-id path.
+// Exercises FindStalePVs → provisionFromExistingPV → CreateLocalPV with a LocalVolumeSet owner.
+func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
+	fixture := diskmakertest.SetupSiblingFallback(t, diskmakertest.DefaultSiblingFallbackConfig())
+	cfg := fixture.Config
+
+	lvset := &v1alphav1api.LocalVolumeSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alphav1api.LocalVolumeSetKind,
+			APIVersion: v1alphav1api.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lvset-sibling-fallback",
+			Namespace: cfg.TestNamespace,
+		},
+		Spec: v1alphav1api.LocalVolumeSetSpec{
+			StorageClassName: cfg.SCName,
+		},
+	}
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   cfg.TestNodeName,
+			Labels: map[string]string{corev1.LabelHostname: cfg.TestNodeName},
+		},
+	}
+
+	objs := append([]runtime.Object{lvset, node}, fixture.RuntimeObjects()...)
+	r, tc := newFakeLocalVolumeSetReconciler(t, objs...)
+	r.pvLinkCache.SeedForTests(fixture.LocalVolumeDeviceLink())
+	r.nodeName = node.Name
+	r.runtimeConfig.Node = node
+	r.runtimeConfig.Name = common.GetProvisionedByValue(*node)
+	r.runtimeConfig.Namespace = cfg.TestNamespace
+	r.runtimeConfig.DiscoveryMap[cfg.SCName] = provCommon.MountConfig{
+		VolumeMode: string(corev1.PersistentVolumeBlock),
+	}
+
+	fixture.AddFakeVolumeDirEntries(tc.fakeVolUtil)
+
+	sc := fixture.StorageClass()
+	device := internal.BlockDevice{Name: cfg.BlockDevKName, KName: cfg.BlockDevKName}
+
+	result, err := r.processNewSymlink(
+		context.Background(),
+		lvset,
+		device,
+		[]internal.BlockDevice{device},
+		*sc,
+		sets.NewString(),
+		fixture.SymLinkDir,
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+
+	gotLinkTarget, err := os.Readlink(fixture.SymlinkPath)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.NewByID, gotLinkTarget,
+		"symlink under local-storage should be updated to the current preferred by-id path")
+
+	pv := &corev1.PersistentVolume{}
+	err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName}, pv)
+	assert.NoError(t, err, "provisioned PV should exist after sibling fallback")
+	assert.Equal(t, fixture.SymlinkPath, pv.Spec.Local.Path,
+		"PV local path should be preserved from the original symlink name")
+	assert.Equal(t, v1api.LocalVolumeSetKind, pv.Labels[common.PVOwnerKindLabel])
+
+	gotLVDL := &v1api.LocalVolumeDeviceLink{}
+	err = r.Client.Get(context.Background(), types.NamespacedName{Name: fixture.ExpectedPVName, Namespace: cfg.TestNamespace}, gotLVDL)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.NewByID, gotLVDL.Status.CurrentLinkTarget)
+	assert.Equal(t, cfg.NewByID, gotLVDL.Status.PreferredLinkTarget)
+	assert.ElementsMatch(t, []string{cfg.NewByID, cfg.SiblingByID}, gotLVDL.Status.ValidLinkTargets)
 }
 
 func TestProvisionFromExistingPV(t *testing.T) {

--- a/pkg/diskmaker/diskmakertest/fake_exec.go
+++ b/pkg/diskmaker/diskmakertest/fake_exec.go
@@ -1,0 +1,88 @@
+package diskmakertest
+
+import (
+	"fmt"
+
+	utilexec "k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
+)
+
+const fakeExecScriptRepeats = 16
+
+// BlkidAlwaysFakeExec returns a FakeExec where every invocation behaves like blkid returning
+// output (and blkidErr) regardless of arguments. Matches sibling-fallback style stubs.
+func BlkidAlwaysFakeExec(output string, blkidErr error) *testingexec.FakeExec {
+	action := func(cmd string, args ...string) utilexec.Cmd {
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) {
+					return []byte(output), nil, blkidErr
+				},
+			},
+		}
+	}
+	return repeatedFakeExec(action)
+}
+
+// BlkidForDevicePathFakeExec returns a FakeExec where blkid emits output only when the last
+// argument equals devicePath (same semantics as the former lv fakeBlkidExecutor).
+func BlkidForDevicePathFakeExec(devicePath, outputWhenMatch string) *testingexec.FakeExec {
+	action := func(cmd string, args ...string) utilexec.Cmd {
+		out := ""
+		if cmd == "blkid" && len(args) > 0 && args[len(args)-1] == devicePath {
+			out = outputWhenMatch
+		}
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) {
+					return []byte(out), nil, nil
+				},
+			},
+		}
+	}
+	return repeatedFakeExec(action)
+}
+
+// FindAndBlkidFakeExec returns a FakeExec that handles find and blkid like the former
+// lvset fakeCommandExecutor (other commands error).
+func FindAndBlkidFakeExec(findOutput, blkidOutput string, blkidErr error) *testingexec.FakeExec {
+	action := func(cmd string, args ...string) utilexec.Cmd {
+		switch cmd {
+		case "find":
+			return &testingexec.FakeCmd{
+				CombinedOutputScript: []testingexec.FakeAction{
+					func() ([]byte, []byte, error) {
+						return []byte(findOutput), nil, nil
+					},
+				},
+			}
+		case "blkid":
+			return &testingexec.FakeCmd{
+				CombinedOutputScript: []testingexec.FakeAction{
+					func() ([]byte, []byte, error) {
+						return []byte(blkidOutput), nil, blkidErr
+					},
+				},
+			}
+		default:
+			return &testingexec.FakeCmd{
+				CombinedOutputScript: []testingexec.FakeAction{
+					func() ([]byte, []byte, error) {
+						return nil, nil, fmt.Errorf("unexpected command %s", cmd)
+					},
+				},
+			}
+		}
+	}
+	return repeatedFakeExec(action)
+}
+
+func repeatedFakeExec(action testingexec.FakeCommandAction) *testingexec.FakeExec {
+	commandScript := make([]testingexec.FakeCommandAction, 0, fakeExecScriptRepeats)
+	for i := 0; i < fakeExecScriptRepeats; i++ {
+		commandScript = append(commandScript, action)
+	}
+	return &testingexec.FakeExec{
+		CommandScript: commandScript,
+	}
+}

--- a/pkg/diskmaker/diskmakertest/harness.go
+++ b/pkg/diskmaker/diskmakertest/harness.go
@@ -1,0 +1,41 @@
+package diskmakertest
+
+import (
+	"os"
+	"testing"
+
+	"github.com/openshift/local-storage-operator/pkg/internal"
+)
+
+// TempDir creates a temporary directory with the given prefix and registers t.Cleanup
+// to remove it. Use instead of ad-hoc createTmpDir/createTempDir in controller tests.
+func TempDir(t *testing.T, prefix string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", prefix)
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	return dir
+}
+
+// WithInternalMocks snapshots internal.FilePathGlob, FilePathEvalSymLinks, CmdExecutor, and
+// Readlink, runs setup (which should assign test doubles), then registers t.Cleanup to
+// restore originals. Do not nest overlapping calls in the same subtest without restoring
+// between them.
+func WithInternalMocks(t *testing.T, setup func()) {
+	t.Helper()
+	origGlob := internal.FilePathGlob
+	origEval := internal.FilePathEvalSymLinks
+	origExec := internal.CmdExecutor
+	origReadlink := internal.Readlink
+	t.Cleanup(func() {
+		internal.FilePathGlob = origGlob
+		internal.FilePathEvalSymLinks = origEval
+		internal.CmdExecutor = origExec
+		internal.Readlink = origReadlink
+	})
+	setup()
+}

--- a/pkg/diskmaker/diskmakertest/sibling_fallback.go
+++ b/pkg/diskmaker/diskmakertest/sibling_fallback.go
@@ -1,0 +1,232 @@
+// Package diskmakertest holds shared test fixtures for diskmaker controller tests.
+package diskmakertest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	localv1 "github.com/openshift/local-storage-operator/api/v1"
+	"github.com/openshift/local-storage-operator/pkg/common"
+	"github.com/openshift/local-storage-operator/pkg/internal"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilexec "k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
+
+	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
+)
+
+// SiblingFallbackConfig configures the stale by-id / sibling LVDL scenario.
+type SiblingFallbackConfig struct {
+	TestNodeName    string
+	TestNamespace   string
+	SCName          string
+	OldByID         string
+	NewByID         string
+	SiblingByID     string
+	BlockDevKName   string
+	SymlinkBaseName string
+	BlkidUUID       string
+	TempDirPrefix   string
+}
+
+// DefaultSiblingFallbackConfig returns the standard values used across LV and LVSet tests.
+func DefaultSiblingFallbackConfig() SiblingFallbackConfig {
+	return SiblingFallbackConfig{
+		TestNodeName:    "node-relink",
+		TestNamespace:   "default",
+		SCName:          "local-sc",
+		OldByID:         "/dev/disk/by-id/wwn-old",
+		NewByID:         "/dev/disk/by-id/wwn-new",
+		SiblingByID:     "/dev/disk/by-id/scsi-sibling",
+		BlockDevKName:   "sdb",
+		SymlinkBaseName: "old-symlink-name",
+		BlkidUUID:       "uuid-relink-1234",
+		TempDirPrefix:   "sibling-fallback",
+	}
+}
+
+// SiblingFallbackFixture is the on-disk layout plus derived PV name for sibling fallback tests.
+type SiblingFallbackFixture struct {
+	Config         SiblingFallbackConfig
+	TmpRoot        string
+	SymLinkDir     string
+	SymlinkPath    string
+	ExpectedPVName string
+}
+
+// mergeSiblingFallbackConfig fills zero fields from defaults.
+func mergeSiblingFallbackConfig(cfg SiblingFallbackConfig) SiblingFallbackConfig {
+	def := DefaultSiblingFallbackConfig()
+	if cfg.TestNodeName == "" {
+		cfg.TestNodeName = def.TestNodeName
+	}
+	if cfg.TestNamespace == "" {
+		cfg.TestNamespace = def.TestNamespace
+	}
+	if cfg.SCName == "" {
+		cfg.SCName = def.SCName
+	}
+	if cfg.OldByID == "" {
+		cfg.OldByID = def.OldByID
+	}
+	if cfg.NewByID == "" {
+		cfg.NewByID = def.NewByID
+	}
+	if cfg.SiblingByID == "" {
+		cfg.SiblingByID = def.SiblingByID
+	}
+	if cfg.BlockDevKName == "" {
+		cfg.BlockDevKName = def.BlockDevKName
+	}
+	if cfg.SymlinkBaseName == "" {
+		cfg.SymlinkBaseName = def.SymlinkBaseName
+	}
+	if cfg.BlkidUUID == "" {
+		cfg.BlkidUUID = def.BlkidUUID
+	}
+	if cfg.TempDirPrefix == "" {
+		cfg.TempDirPrefix = def.TempDirPrefix
+	}
+	return cfg
+}
+
+// SetupSiblingFallback creates temp dirs, a dangling symlink to OldByID, installs internal
+// mocks (by-id glob/eval, blkid), and registers t.Cleanup to restore globals and remove tmpdir.
+func SetupSiblingFallback(t *testing.T, cfg SiblingFallbackConfig) *SiblingFallbackFixture {
+	t.Helper()
+	cfg = mergeSiblingFallbackConfig(cfg)
+
+	tmpRoot, err := os.MkdirTemp("", cfg.TempDirPrefix)
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpRoot) })
+	symLinkDir := filepath.Join(tmpRoot, cfg.SCName)
+	if err := os.MkdirAll(symLinkDir, 0o755); err != nil {
+		t.Fatalf("mkdir symLinkDir: %v", err)
+	}
+	symlinkPath := filepath.Join(symLinkDir, cfg.SymlinkBaseName)
+	if err := os.Symlink(cfg.OldByID, symlinkPath); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	expectedPVName := common.GeneratePVName(cfg.SymlinkBaseName, cfg.TestNodeName, cfg.SCName)
+
+	f := &SiblingFallbackFixture{
+		Config:         cfg,
+		TmpRoot:        tmpRoot,
+		SymLinkDir:     symLinkDir,
+		SymlinkPath:    symlinkPath,
+		ExpectedPVName: expectedPVName,
+	}
+
+	origGlob := internal.FilePathGlob
+	origEval := internal.FilePathEvalSymLinks
+	origExec := internal.CmdExecutor
+	t.Cleanup(func() {
+		internal.FilePathGlob = origGlob
+		internal.FilePathEvalSymLinks = origEval
+		internal.CmdExecutor = origExec
+	})
+
+	internal.FilePathGlob = func(pattern string) ([]string, error) {
+		if strings.HasPrefix(pattern, internal.DiskByIDDir) {
+			return []string{cfg.NewByID, cfg.SiblingByID}, nil
+		}
+		return filepath.Glob(pattern)
+	}
+	internal.FilePathEvalSymLinks = func(p string) (string, error) {
+		switch p {
+		case cfg.NewByID, cfg.SiblingByID:
+			return filepath.Join("/dev", cfg.BlockDevKName), nil
+		case cfg.OldByID:
+			return "", os.ErrNotExist
+		default:
+			if p == symlinkPath {
+				return filepath.Join("/dev", cfg.BlockDevKName), nil
+			}
+			return filepath.EvalSymlinks(p)
+		}
+	}
+
+	blkidAction := func(cmd string, args ...string) utilexec.Cmd {
+		return &testingexec.FakeCmd{
+			CombinedOutputScript: []testingexec.FakeAction{
+				func() ([]byte, []byte, error) {
+					return []byte(cfg.BlkidUUID), nil, nil
+				},
+			},
+		}
+	}
+	internal.CmdExecutor = &testingexec.FakeExec{
+		CommandScript: []testingexec.FakeCommandAction{blkidAction},
+	}
+
+	return f
+}
+
+// PersistentVolume returns a PV pointing at the local-storage symlink path.
+func (f *SiblingFallbackFixture) PersistentVolume() *corev1.PersistentVolume {
+	reclaimDelete := corev1.PersistentVolumeReclaimDelete
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: f.ExpectedPVName},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: reclaimDelete,
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				Local: &corev1.LocalVolumeSource{Path: f.SymlinkPath},
+			},
+			StorageClassName: f.Config.SCName,
+		},
+	}
+}
+
+// LocalVolumeDeviceLink returns an LVDL with PreferredLinkTarget policy and stale by-id status.
+func (f *SiblingFallbackFixture) LocalVolumeDeviceLink() *localv1.LocalVolumeDeviceLink {
+	return &localv1.LocalVolumeDeviceLink{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f.ExpectedPVName,
+			Namespace: f.Config.TestNamespace,
+		},
+		Spec: localv1.LocalVolumeDeviceLinkSpec{
+			PersistentVolumeName: f.ExpectedPVName,
+			Policy:               localv1.DeviceLinkPolicyPreferredLinkTarget,
+		},
+		Status: localv1.LocalVolumeDeviceLinkStatus{
+			CurrentLinkTarget: f.Config.OldByID,
+			ValidLinkTargets:  []string{f.Config.OldByID, f.Config.SiblingByID},
+		},
+	}
+}
+
+// StorageClass returns a no-provisioner storage class matching the fixture.
+func (f *SiblingFallbackFixture) StorageClass() *storagev1.StorageClass {
+	reclaimDelete := corev1.PersistentVolumeReclaimDelete
+	return &storagev1.StorageClass{
+		ObjectMeta:    metav1.ObjectMeta{Name: f.Config.SCName},
+		ReclaimPolicy: &reclaimDelete,
+		Provisioner:   "kubernetes.io/no-provisioner",
+	}
+}
+
+// RuntimeObjects returns PV, LVDL, and StorageClass for a fake client.
+func (f *SiblingFallbackFixture) RuntimeObjects() []runtime.Object {
+	return []runtime.Object{
+		f.PersistentVolume(),
+		f.LocalVolumeDeviceLink(),
+		f.StorageClass(),
+	}
+}
+
+// AddFakeVolumeDirEntries registers the symlink basename as a block entry under TmpRoot for FakeVolumeUtil.
+func (f *SiblingFallbackFixture) AddFakeVolumeDirEntries(volUtil *provUtil.FakeVolumeUtil) {
+	volUtil.AddNewDirEntries(f.TmpRoot, map[string][]*provUtil.FakeDirEntry{
+		f.Config.SCName: {
+			{Name: f.Config.SymlinkBaseName, Capacity: 10 * common.GiB, VolumeType: provUtil.FakeEntryBlock},
+		},
+	})
+}

--- a/pkg/diskmaker/diskmakertest/sibling_fallback.go
+++ b/pkg/diskmaker/diskmakertest/sibling_fallback.go
@@ -14,8 +14,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilexec "k8s.io/utils/exec"
-	testingexec "k8s.io/utils/exec/testing"
 
 	provUtil "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/util"
 )
@@ -101,11 +99,7 @@ func SetupSiblingFallback(t *testing.T, cfg SiblingFallbackConfig) *SiblingFallb
 	t.Helper()
 	cfg = mergeSiblingFallbackConfig(cfg)
 
-	tmpRoot, err := os.MkdirTemp("", cfg.TempDirPrefix)
-	if err != nil {
-		t.Fatalf("mkdir temp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(tmpRoot) })
+	tmpRoot := TempDir(t, cfg.TempDirPrefix)
 	symLinkDir := filepath.Join(tmpRoot, cfg.SCName)
 	if err := os.MkdirAll(symLinkDir, 0o755); err != nil {
 		t.Fatalf("mkdir symLinkDir: %v", err)
@@ -125,47 +119,28 @@ func SetupSiblingFallback(t *testing.T, cfg SiblingFallbackConfig) *SiblingFallb
 		ExpectedPVName: expectedPVName,
 	}
 
-	origGlob := internal.FilePathGlob
-	origEval := internal.FilePathEvalSymLinks
-	origExec := internal.CmdExecutor
-	t.Cleanup(func() {
-		internal.FilePathGlob = origGlob
-		internal.FilePathEvalSymLinks = origEval
-		internal.CmdExecutor = origExec
-	})
-
-	internal.FilePathGlob = func(pattern string) ([]string, error) {
-		if strings.HasPrefix(pattern, internal.DiskByIDDir) {
-			return []string{cfg.NewByID, cfg.SiblingByID}, nil
-		}
-		return filepath.Glob(pattern)
-	}
-	internal.FilePathEvalSymLinks = func(p string) (string, error) {
-		switch p {
-		case cfg.NewByID, cfg.SiblingByID:
-			return filepath.Join("/dev", cfg.BlockDevKName), nil
-		case cfg.OldByID:
-			return "", os.ErrNotExist
-		default:
-			if p == symlinkPath {
-				return filepath.Join("/dev", cfg.BlockDevKName), nil
+	WithInternalMocks(t, func() {
+		internal.FilePathGlob = func(pattern string) ([]string, error) {
+			if strings.HasPrefix(pattern, internal.DiskByIDDir) {
+				return []string{cfg.NewByID, cfg.SiblingByID}, nil
 			}
-			return filepath.EvalSymlinks(p)
+			return filepath.Glob(pattern)
 		}
-	}
-
-	blkidAction := func(cmd string, args ...string) utilexec.Cmd {
-		return &testingexec.FakeCmd{
-			CombinedOutputScript: []testingexec.FakeAction{
-				func() ([]byte, []byte, error) {
-					return []byte(cfg.BlkidUUID), nil, nil
-				},
-			},
+		internal.FilePathEvalSymLinks = func(p string) (string, error) {
+			switch p {
+			case cfg.NewByID, cfg.SiblingByID:
+				return filepath.Join("/dev", cfg.BlockDevKName), nil
+			case cfg.OldByID:
+				return "", os.ErrNotExist
+			default:
+				if p == symlinkPath {
+					return filepath.Join("/dev", cfg.BlockDevKName), nil
+				}
+				return filepath.EvalSymlinks(p)
+			}
 		}
-	}
-	internal.CmdExecutor = &testingexec.FakeExec{
-		CommandScript: []testingexec.FakeCommandAction{blkidAction},
-	}
+		internal.CmdExecutor = BlkidAlwaysFakeExec(cfg.BlkidUUID, nil)
+	})
 
 	return f
 }


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-83306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added sibling-fallback tests, new reusable fixtures, and centralized test utilities (scoped mocks, temp-dir helpers, deterministic fake command executors).

* **Refactor**
  * Modernized internal collection handling and reorganized event-watcher/cache startup so readiness is signaled after initial sync and population.

* **Bug Fixes**
  * Improved symlink handling and provisioning status updates; removed reliance on stale symlink arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->