### PR TITLE
OCPBUGS-82545: Fire metric for missing symlink on LocalVolume.

### DIFF
--- a/assets/templates/localmetrics/prometheus-rule.yaml
+++ b/assets/templates/localmetrics/prometheus-rule.yaml
@@ -70,3 +70,19 @@ spec:
             Local Storage operator has observed that pv {{ $labels.persistent_volume }} is using a symlink
             that is not optimum for stability between reboots and OS upgrades. Consider updating
             LocalVolumeDeviceLink policy to preferredSymlink to allow LSO to manage the symlink.
+    - name: lso_lv_missing_device_path
+      rules:
+      - alert: LSOLocalVolumeMissingDevicePath
+        expr: min_over_time(lso_lv_missing_device_path_count[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "LocalVolume references a device path that does not exist on the node"
+          description: |
+            Local Storage Operator cannot find {{ $value }} device path(s) listed in a LocalVolume
+            for storage class {{ $labels.storageClass }} on node {{ $labels.nodeName }}.
+            This typically happens when a /dev/disk/by-id/ symlink is removed during an OS upgrade
+            (e.g. RHEL 9 to RHEL 10). The existing PersistentVolumes may still be usable, but LSO
+            cannot monitor or update their symlinks until the LocalVolume devicePaths are corrected.
+            Update the LocalVolume spec to reference a device path that currently exists on the node.

--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -371,6 +371,8 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		r.processRejectedDevicesForDeviceLinks(ctx, ignoredDevices, diskConfig)
 	}
 
+	r.updateMissingDevicePathMetrics(diskConfig)
+
 	mountPointMap, err := common.GenerateMountMap(r.runtimeConfig)
 	if err != nil {
 		klog.ErrorS(err, "failed to generate mountPointMap")
@@ -422,6 +424,18 @@ func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDe
 
 		// update metrics for orphaned symlink devices
 		localmetrics.SetLVOrphanedSymlinksMetric(nodeName, storageClass, len(orphanSymlinkDevices))
+	}
+}
+
+func (r *LocalVolumeReconciler) updateMissingDevicePathMetrics(diskConfig *DiskConfig) {
+	for storageClass, disks := range diskConfig.Disks {
+		missing := 0
+		for _, devicePath := range disks.DevicePaths {
+			if _, err := r.fsInterface.evalSymlink(devicePath); err != nil {
+				missing++
+			}
+		}
+		localmetrics.SetLVMissingDevicePathMetric(nodeName, storageClass, missing)
 	}
 }
 

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -19,8 +19,10 @@ import (
 	"github.com/openshift/local-storage-operator/pkg/common"
 	"github.com/openshift/local-storage-operator/pkg/diskmaker/diskmakertest"
 	"github.com/openshift/local-storage-operator/pkg/internal"
+	"github.com/openshift/local-storage-operator/pkg/localmetrics"
 	test "github.com/openshift/local-storage-operator/test/framework"
 	"github.com/openshift/local-storage-operator/test/framework/util"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1551,4 +1553,92 @@ func RemoveIndex(s []corev1.PersistentVolume, index int) []corev1.PersistentVolu
 	ret := make([]corev1.PersistentVolume, 0)
 	ret = append(ret, s[:index]...)
 	return append(ret, s[index+1:]...)
+}
+
+func TestUpdateMissingDevicePathMetrics(t *testing.T) {
+	const testNodeName = "node-missing-paths"
+
+	tests := []struct {
+		name            string
+		devicePaths     []string
+		evalSymlinkFn   func(string) (string, error)
+		priorMissing    int // pre-seed the gauge to verify it resets
+		expectedMissing float64
+	}{
+		{
+			// Verifies the gauge resets: seed a non-zero value then confirm it goes back to 0.
+			name:        "metric resets to zero when previously-missing path is recovered",
+			devicePaths: []string{"/dev/sda"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return path, nil
+			},
+			priorMissing:    3,
+			expectedMissing: 0,
+		},
+		{
+			name:        "by-id symlink disappeared after OS upgrade",
+			devicePaths: []string{"/dev/disk/by-id/scsi-removed"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return "", fmt.Errorf("lstat %s: no such file or directory", path)
+			},
+			expectedMissing: 1,
+		},
+		{
+			name:        "one path missing, one resolves",
+			devicePaths: []string{"/dev/sda", "/dev/disk/by-id/scsi-gone"},
+			evalSymlinkFn: func(path string) (string, error) {
+				if strings.HasSuffix(path, "scsi-gone") {
+					return "", fmt.Errorf("lstat %s: no such file or directory", path)
+				}
+				return path, nil
+			},
+			expectedMissing: 1,
+		},
+		{
+			name:        "all paths missing, metric matches count",
+			devicePaths: []string{"/dev/disk/by-id/scsi-gone-1", "/dev/disk/by-id/scsi-gone-2"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return "", fmt.Errorf("lstat %s: no such file or directory", path)
+			},
+			expectedMissing: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpRoot := diskmakertest.TempDir(t, "missing-paths")
+
+			lv := &localv1.LocalVolume{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       localv1.LocalVolumeKind,
+					APIVersion: localv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "lv-missing", Namespace: "default"},
+			}
+
+			d, _ := getFakeDiskMaker(t, tmpRoot)
+			d.localVolume = lv
+			d.fsInterface = stubFileSystemInterface{evalFunc: tc.evalSymlinkFn}
+
+			diskConfig := &DiskConfig{
+				Disks: map[string]*Disks{
+					storageClassName: {DevicePaths: tc.devicePaths},
+				},
+			}
+
+			origNodeName := nodeName
+			nodeName = testNodeName
+			t.Cleanup(func() { nodeName = origNodeName })
+
+			if tc.priorMissing > 0 {
+				localmetrics.SetLVMissingDevicePathMetric(testNodeName, storageClassName, tc.priorMissing)
+			}
+
+			d.updateMissingDevicePathMetrics(diskConfig)
+
+			pb := &dto.Metric{}
+			assert.NoError(t, localmetrics.LVMissingDevicePathGauge(testNodeName, storageClassName).Write(pb))
+			assert.Equal(t, tc.expectedMissing, pb.GetGauge().GetValue())
+		})
+	}
 }

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -43,6 +43,11 @@ var (
 		Help: "Total symlinks that became orphan after updating the devicePaths in LocalVolume CR",
 	}, []string{"nodeName", "storageClass"})
 
+	metricLocalVolumeMissingDevicePaths = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lso_lv_missing_device_path_count",
+		Help: "Total device paths in LocalVolume spec that cannot be resolved on the node (e.g. symlink removed after OS upgrade)",
+	}, []string{"nodeName", "storageClass"})
+
 	LVDMetricsList = []prometheus.Collector{
 		metricDiscoveredDevicesByLocalVolumeDiscovery,
 	}
@@ -54,6 +59,7 @@ var (
 		metricLocalVolumeSetDeletionTimestamp,
 		metricLocalVolumeProvisionedPVs,
 		metricLocalVolumeOrphanedSymlinks,
+		metricLocalVolumeMissingDevicePaths,
 	}
 )
 
@@ -102,4 +108,16 @@ func SetLVOrphanedSymlinksMetric(nodeName, storageClassName string, count int) {
 	metricLocalVolumeOrphanedSymlinks.
 		With(prometheus.Labels{"nodeName": nodeName, "storageClass": storageClassName}).
 		Set(float64(count))
+}
+
+func SetLVMissingDevicePathMetric(nodeName, storageClassName string, count int) {
+	metricLocalVolumeMissingDevicePaths.
+		With(prometheus.Labels{"nodeName": nodeName, "storageClass": storageClassName}).
+		Set(float64(count))
+}
+
+func LVMissingDevicePathGauge(nodeName, storageClassName string) prometheus.Gauge {
+	return metricLocalVolumeMissingDevicePaths.With(prometheus.Labels{
+		"nodeName": nodeName, "storageClass": storageClassName,
+	})
 }


### PR DESCRIPTION
I have added a user-specified `SpecifiedLinkTarget` field to our api so we know when to fire the metric when the path is invalid due to changes such as an OS reinstall.

This was tested on GCP cluster with 2 scenarios.

1. Create localvolume -> Change symlink to invalid one -> see metric firing -> update back to symlink -> metric back to 0 occurences
2. Create localvolume -> change symlink to invalid one -> metric shows problems ->remove localvolume and pv -> metric back to 0 occurences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status reporting for device link resolution on disk-identification lookup failures with a best-effort status update to keep device link state accurate.
* **New Features**
  * Added a public block-device resolution utility that resolves by-id symlinks and returns device details including the by-id path.
* **Tests**
  * Added unit tests covering successful and failing device-resolution and status-update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->