### PR TITLE
OCPBUGS-83413: Add node name to lvdl

### DIFF
--- a/api/v1/localvolumedevicelink_types.go
+++ b/api/v1/localvolumedevicelink_types.go
@@ -52,12 +52,12 @@ type LocalVolumeDeviceLinkSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	PersistentVolumeName string `json:"persistentVolumeName"`
 
-	// nodeName is the name of the Openshift node on which this
+	// nodeName is the name of the OpenShift node on which this
 	// LocalVolumeDeviceLink object exists
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	NodeName string `json:"nodeName"`
+	NodeName string `json:"nodeName,omitempty"`
 
 	// policy expresses how to manage symlinks for the device.
 	// "None" means no policy has been chosen, and will generate an alert if

--- a/api/v1/localvolumedevicelink_types.go
+++ b/api/v1/localvolumedevicelink_types.go
@@ -52,6 +52,13 @@ type LocalVolumeDeviceLinkSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	PersistentVolumeName string `json:"persistentVolumeName"`
 
+	// nodeName is the name of the Openshift node on which this
+	// LocalVolumeDeviceLink object exists
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
+	NodeName string `json:"nodeName"`
+
 	// policy expresses how to manage symlinks for the device.
 	// "None" means no policy has been chosen, and will generate an alert if
 	// there is a mismatch between .status.currentLinkTarget and

--- a/cmd/diskmaker-manager/manager.go
+++ b/cmd/diskmaker-manager/manager.go
@@ -86,6 +86,12 @@ func startManager(cmd *cobra.Command, args []string) error {
 		klog.ErrorS(err, "failed to get watch namespace")
 		return err
 	}
+	localNodeName := common.GetNodeNameEnvVar()
+	if localNodeName == "" {
+		err = errors.New("MY_NODE_NAME must be set for diskmaker-manager to scope LocalVolumeDeviceLink cache to the local node")
+		klog.ErrorS(err, "failed to determine local node name")
+		return err
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Cache: cache.Options{
@@ -103,7 +109,7 @@ func startManager(cmd *cobra.Command, args []string) error {
 	// Create the shared LVDL cache and register it as a manager.Runnable.
 	// The manager will call Start(ctx) after its own caches are started,
 	// and the cache waits for LVDL informer sync before processing events.
-	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(mgr.GetClient(), mgr)
+	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(mgr.GetClient(), mgr, localNodeName)
 	if err := mgr.Add(pvLinkCache); err != nil {
 		klog.ErrorS(err, "failed to add pvLinkCache runnable")
 		return err

--- a/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
+++ b/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
@@ -44,7 +44,7 @@ spec:
             properties:
               nodeName:
                 description: |-
-                  nodeName is the name of the Openshift node on which this
+                  nodeName is the name of the OpenShift node on which this
                   LocalVolumeDeviceLink object exists
                 maxLength: 253
                 minLength: 1

--- a/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
+++ b/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
@@ -42,6 +42,13 @@ spec:
           spec:
             description: spec holds user settable values for the device link
             properties:
+              nodeName:
+                description: |-
+                  nodeName is the name of the Openshift node on which this
+                  LocalVolumeDeviceLink object exists
+                maxLength: 253
+                minLength: 1
+                type: string
               persistentVolumeName:
                 description: persistentVolumeName is the name of the persistent volume
                   linked to the device
@@ -66,6 +73,7 @@ spec:
                 - PreferredLinkTarget
                 type: string
             required:
+            - nodeName
             - persistentVolumeName
             type: object
           status:

--- a/pkg/common/device_link_handler.go
+++ b/pkg/common/device_link_handler.go
@@ -37,14 +37,16 @@ type DeviceLinkHandler struct {
 	clientReader client.Reader
 	recorder     record.EventRecorder
 	cacheWriter  *LocalVolumeDeviceLinkCache
+	nodeName     string
 }
 
-func NewDeviceLinkHandler(client client.Client, clientReader client.Reader, recorder record.EventRecorder, cacheWriter *LocalVolumeDeviceLinkCache) *DeviceLinkHandler {
+func NewDeviceLinkHandler(client client.Client, clientReader client.Reader, recorder record.EventRecorder, cacheWriter *LocalVolumeDeviceLinkCache, nodeName string) *DeviceLinkHandler {
 	return &DeviceLinkHandler{
 		client:       client,
 		clientReader: clientReader,
 		recorder:     recorder,
 		cacheWriter:  cacheWriter,
+		nodeName:     nodeName,
 	}
 }
 
@@ -65,6 +67,9 @@ func (dl *DeviceLinkHandler) generateLVDLObj(pvName, namespace string, ownerObj 
 	if err != nil {
 		return nil, err
 	}
+	if dl.nodeName == "" {
+		return nil, fmt.Errorf("node name is required for LocalVolumeDeviceLink %s", pvName)
+	}
 
 	requiredLocalDeviceLink := &v1.LocalVolumeDeviceLink{
 		ObjectMeta: metav1.ObjectMeta{
@@ -74,6 +79,7 @@ func (dl *DeviceLinkHandler) generateLVDLObj(pvName, namespace string, ownerObj 
 		},
 		Spec: v1.LocalVolumeDeviceLinkSpec{
 			PersistentVolumeName: pvName,
+			NodeName:             dl.nodeName,
 			Policy:               v1.DeviceLinkPolicyNone,
 		},
 	}

--- a/pkg/common/device_link_handler_test.go
+++ b/pkg/common/device_link_handler_test.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const testNodeName = "worker-a"
+
 // createTempFile creates an empty regular file at path (for use as a fake device).
 func createTempFile(t *testing.T, path string) error {
 	t.Helper()
@@ -71,6 +73,7 @@ func newLVDL(name, namespace, pvName string) *v1.LocalVolumeDeviceLink {
 		},
 		Spec: v1.LocalVolumeDeviceLinkSpec{
 			PersistentVolumeName: pvName,
+			NodeName:             testNodeName,
 			Policy:               v1.DeviceLinkPolicyNone,
 		},
 	}
@@ -151,7 +154,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			filesystemUUID: "550e8400-e29b-41d4-a716-446655440000",
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-statustest", Namespace: "default"},
-				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-statustest"},
+				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-statustest", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
 					CurrentLinkTarget:   "/dev/disk/by-id/wwn-current",
 					PreferredLinkTarget: "/dev/disk/by-id/wwn-preferred",
@@ -171,7 +174,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			existingPV:     newPV("local-pv-nolinks"),
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-nolinks", Namespace: "default"},
-				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-nolinks"},
+				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-nolinks", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
 					CurrentLinkTarget:   "/dev/sdb",
 					PreferredLinkTarget: "",
@@ -192,7 +195,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			globLinks:      []string{"/dev/disk/by-id/wwn-preferred"},
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-fullflow", Namespace: "openshift-local-storage"},
-				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-fullflow"},
+				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-fullflow", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
 					CurrentLinkTarget:   "/dev/disk/by-id/scsi-current",
 					PreferredLinkTarget: "/dev/disk/by-id/wwn-preferred",
@@ -222,6 +225,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-lvdl-missing", Namespace: "default"},
 				Spec: v1.LocalVolumeDeviceLinkSpec{
 					PersistentVolumeName: "local-pv-lvdl-missing",
+					NodeName:             testNodeName,
 					Policy:               v1.DeviceLinkPolicyNone,
 				},
 				Status: v1.LocalVolumeDeviceLinkStatus{
@@ -246,8 +250,8 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			}
 
 			fakeClient := newFakeDeviceLinkClient(t, runtimeObjects...).Build()
-			pvCache := NewLocalVolumeDeviceLinkCache(nil, nil)
-			handler := NewDeviceLinkHandler(fakeClient, fakeClient, record.NewFakeRecorder(10), pvCache)
+			pvCache := NewLocalVolumeDeviceLinkCache(nil, nil, testNodeName)
+			handler := NewDeviceLinkHandler(fakeClient, fakeClient, record.NewFakeRecorder(10), pvCache, testNodeName)
 
 			origGlob := internal.FilePathGlob
 			origEval := internal.FilePathEvalSymLinks
@@ -283,6 +287,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			assert.Equal(t, tc.expectedLVDL.Name, updated.Name)
 			assert.Equal(t, tc.expectedLVDL.Namespace, updated.Namespace)
 			assert.Equal(t, tc.expectedLVDL.Spec.PersistentVolumeName, updated.Spec.PersistentVolumeName)
+			assert.Equal(t, tc.expectedLVDL.Spec.NodeName, updated.Spec.NodeName)
 			assert.Equal(t, tc.expectedLVDL.Status.CurrentLinkTarget, updated.Status.CurrentLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.PreferredLinkTarget, updated.Status.PreferredLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.FilesystemUUID, updated.Status.FilesystemUUID)
@@ -295,6 +300,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			assert.Equal(t, tc.expectedLVDL.Name, fetched.Name)
 			assert.Equal(t, tc.expectedLVDL.Namespace, fetched.Namespace)
 			assert.Equal(t, tc.expectedLVDL.Spec.PersistentVolumeName, fetched.Spec.PersistentVolumeName)
+			assert.Equal(t, tc.expectedLVDL.Spec.NodeName, fetched.Spec.NodeName)
 			assert.Equal(t, tc.expectedLVDL.Status.CurrentLinkTarget, fetched.Status.CurrentLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.PreferredLinkTarget, fetched.Status.PreferredLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.FilesystemUUID, fetched.Status.FilesystemUUID)
@@ -332,6 +338,7 @@ func newLVDLWithPolicy(name, namespace string, policy v1.DeviceLinkPolicy, curre
 		},
 		Spec: v1.LocalVolumeDeviceLinkSpec{
 			PersistentVolumeName: name,
+			NodeName:             testNodeName,
 			Policy:               policy,
 		},
 		Status: v1.LocalVolumeDeviceLinkStatus{
@@ -696,9 +703,9 @@ func TestRecreateSymlinkIfNeeded(t *testing.T) {
 			}
 
 			fakeClient := newFakeDeviceLinkClient(t, lvdl).Build()
-			pvCache := NewLocalVolumeDeviceLinkCache(nil, nil)
+			pvCache := NewLocalVolumeDeviceLinkCache(nil, nil, testNodeName)
 			pvCache.MarkSyncedForTests()
-			handler := NewDeviceLinkHandler(fakeClient, fakeClient, record.NewFakeRecorder(10), pvCache)
+			handler := NewDeviceLinkHandler(fakeClient, fakeClient, record.NewFakeRecorder(10), pvCache, testNodeName)
 
 			if tc.configureEval != nil {
 				internal.FilePathEvalSymLinks = tc.configureEval(env)

--- a/pkg/common/provisioner_utils.go
+++ b/pkg/common/provisioner_utils.go
@@ -113,7 +113,7 @@ func CreateLocalPV(ctx context.Context, args CreateLocalPVArgs) error {
 		return fmt.Errorf("name: %q, namespace: %q, or  kind: %q is empty for obj: %+v", name, namespace, kind, obj)
 	}
 
-	deviceHandler := NewDeviceLinkHandler(client, args.ClientReader, args.RuntimeConfig.Recorder, args.CacheWriter)
+	deviceHandler := NewDeviceLinkHandler(client, args.ClientReader, args.RuntimeConfig.Recorder, args.CacheWriter, args.RuntimeConfig.Node.Name)
 	klog.V(4).Infof("finding lvdl %s %s", pvName, namespace)
 	lvdl, err := deviceHandler.FindLVDL(ctx, pvName, namespace)
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/common/pv_link_cache.go
+++ b/pkg/common/pv_link_cache.go
@@ -29,7 +29,8 @@ type LocalVolumeDeviceLinkCache struct {
 	client client.Client
 	mgr    manager.Manager
 
-	synced chan struct{}
+	synced        chan struct{}
+	localNodeName string
 	// map of symlinkName in /dev/disk/byid and CurrentBlockDeviceInfo
 	localDeviceInfos map[string]CurrentBlockDeviceInfo
 }
@@ -113,11 +114,12 @@ func (c CurrentBlockDeviceInfo) getLVDLAndPV(ctx context.Context, client client.
 	return lvdl, pv, nil
 }
 
-func NewLocalVolumeDeviceLinkCache(client client.Client, mgr manager.Manager) *LocalVolumeDeviceLinkCache {
+func NewLocalVolumeDeviceLinkCache(client client.Client, mgr manager.Manager, localNodeName string) *LocalVolumeDeviceLinkCache {
 	return &LocalVolumeDeviceLinkCache{
 		client:           client,
 		mgr:              mgr,
 		synced:           make(chan struct{}),
+		localNodeName:    localNodeName,
 		localDeviceInfos: map[string]CurrentBlockDeviceInfo{},
 	}
 }
@@ -138,6 +140,10 @@ func (l *LocalVolumeDeviceLinkCache) IsSynced() bool {
 // caches are started, but we still need to wait for the LVDL informer
 // (which may have been dynamically added) to complete its initial sync.
 func (l *LocalVolumeDeviceLinkCache) Start(ctx context.Context) error {
+	if l.localNodeName == "" {
+		return fmt.Errorf("LocalVolumeDeviceLink cache requires a local node name")
+	}
+
 	informer, err := l.mgr.GetCache().GetInformer(ctx, &v1.LocalVolumeDeviceLink{})
 	if err != nil {
 		return err
@@ -250,6 +256,10 @@ func (l *LocalVolumeDeviceLinkCache) MarkSyncedForTests() {
 }
 
 func (l *LocalVolumeDeviceLinkCache) addOrUpdateLVDL(lvdl *v1.LocalVolumeDeviceLink) {
+	if !l.shouldIndexLVDL(lvdl) {
+		return
+	}
+
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -287,6 +297,13 @@ func (l *LocalVolumeDeviceLinkCache) addOrUpdateLVDL(lvdl *v1.LocalVolumeDeviceL
 		deviceInfo.lvdls[lvdl.Name] = lvdl
 		l.localDeviceInfos[linkTarget] = deviceInfo
 	}
+}
+
+func (l *LocalVolumeDeviceLinkCache) shouldIndexLVDL(lvdl *v1.LocalVolumeDeviceLink) bool {
+	if lvdl == nil {
+		return false
+	}
+	return lvdl.Spec.NodeName == l.localNodeName
 }
 
 func (l *LocalVolumeDeviceLinkCache) removeLVDL(lvdl *v1.LocalVolumeDeviceLink) {

--- a/pkg/common/pv_link_cache_test.go
+++ b/pkg/common/pv_link_cache_test.go
@@ -17,6 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const (
+	cacheLocalNode = "worker-a"
+	cacheOtherNode = "worker-b"
+)
+
 func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 	const (
 		symlinkDir = "/mnt/local-storage/sc-a"
@@ -33,8 +38,8 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "errors when more than one LVDL maps source",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl1 := newCacheLVDL("pv-a", "/tmp/current-a", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
-				lvdl2 := newCacheLVDL("pv-b", "/tmp/current-b", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl1 := newCacheLVDL("pv-a", cacheLocalNode, "/tmp/current-a", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl2 := newCacheLVDL("pv-b", cacheLocalNode, "/tmp/current-b", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
 				c.addOrUpdateLVDL(lvdl1)
 				c.addOrUpdateLVDL(lvdl2)
 				info := c.localDeviceInfos[sourcePath]
@@ -45,7 +50,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "errors when lvdl set is unexpectedly empty",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl := newCacheLVDL("pv-empty", "/tmp/current-empty", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl := newCacheLVDL("pv-empty", cacheLocalNode, "/tmp/current-empty", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
 				c.addOrUpdateLVDL(lvdl)
 				info := c.localDeviceInfos[sourcePath]
 				c.removeLVDL(lvdl)
@@ -56,7 +61,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "errors when policy is not preferred link target",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl := newCacheLVDL("pv-none", "/tmp/current-none", v1api.DeviceLinkPolicyNone, sourcePath)
+				lvdl := newCacheLVDL("pv-none", cacheLocalNode, "/tmp/current-none", v1api.DeviceLinkPolicyNone, sourcePath)
 				c.addOrUpdateLVDL(lvdl)
 				info := c.localDeviceInfos[sourcePath]
 				return info, sourcePath
@@ -66,7 +71,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "errors when current link still resolves",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl := newCacheLVDL("pv-resolves", "/tmp/current-resolves", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl := newCacheLVDL("pv-resolves", cacheLocalNode, "/tmp/current-resolves", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
 				c.addOrUpdateLVDL(lvdl)
 				info := c.localDeviceInfos[sourcePath]
 				return info, sourcePath
@@ -82,7 +87,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "returns recomputed symlink path when preferred policy and unresolved current",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl := newCacheLVDL("pv-success", "/dev/disk/by-id/yyy", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl := newCacheLVDL("pv-success", cacheLocalNode, "/dev/disk/by-id/yyy", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
 				c.addOrUpdateLVDL(lvdl)
 				info := c.localDeviceInfos[sourcePath]
 				return info, sourcePath
@@ -97,7 +102,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		{
 			name: "returns symlink path with warning when source is not in validLinkTargets",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
-				lvdl := newCacheLVDL("pv-invalid-target", "/tmp/current-invalid", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/wwn-other")
+				lvdl := newCacheLVDL("pv-invalid-target", cacheLocalNode, "/tmp/current-invalid", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/wwn-other")
 				c.addOrUpdateLVDL(lvdl)
 				return c.localDeviceInfos["/dev/disk/by-id/wwn-other"], sourcePath
 			},
@@ -123,7 +128,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 				}
 			}
 
-			cache := NewLocalVolumeDeviceLinkCache(nil, nil)
+			cache := NewLocalVolumeDeviceLinkCache(nil, nil, cacheLocalNode)
 			info, source := tc.setup(t, cache)
 			fakeClient := fakeClientForInfo(t, info)
 
@@ -149,7 +154,8 @@ func TestFindStalePVs(t *testing.T) {
 	)
 
 	tests := []struct {
-		name string
+		name          string
+		localNodeName string
 		// symlink is the primary key passed to FindStalePVs
 		symlink string
 		// seededLVDLs are pre-populated into the cache
@@ -169,9 +175,10 @@ func TestFindStalePVs(t *testing.T) {
 			name:    "direct match by symlink name",
 			symlink: directSymlink,
 			seededLVDLs: []*v1api.LocalVolumeDeviceLink{
-				newCacheLVDL("pv-direct", "/dev/disk/by-id/old-gone", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
+				newCacheLVDL("pv-direct", cacheLocalNode, "/dev/disk/by-id/old-gone", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
 			},
-			blockDevice: internal.BlockDevice{Name: "sda", KName: "sda"},
+			localNodeName: cacheLocalNode,
+			blockDevice:   internal.BlockDevice{Name: "sda", KName: "sda"},
 			// No glob/eval needed — direct match short-circuits
 			wantFound:     true,
 			wantLVDLNames: []string{"pv-direct"},
@@ -181,9 +188,10 @@ func TestFindStalePVs(t *testing.T) {
 			symlink: unknownSymlink,
 			seededLVDLs: []*v1api.LocalVolumeDeviceLink{
 				// LVDL was recorded with siblingSymlink, not unknownSymlink
-				newCacheLVDL("pv-sibling", "/dev/disk/by-id/old-gone", v1api.DeviceLinkPolicyPreferredLinkTarget, siblingSymlink),
+				newCacheLVDL("pv-sibling", cacheLocalNode, "/dev/disk/by-id/old-gone", v1api.DeviceLinkPolicyPreferredLinkTarget, siblingSymlink),
 			},
-			blockDevice: internal.BlockDevice{Name: "sdb", KName: "sdb"},
+			localNodeName: cacheLocalNode,
+			blockDevice:   internal.BlockDevice{Name: "sdb", KName: "sdb"},
 			filePathGlob: func(pattern string) ([]string, error) {
 				return []string{unknownSymlink, siblingSymlink}, nil
 			},
@@ -198,9 +206,10 @@ func TestFindStalePVs(t *testing.T) {
 			wantLVDLNames: []string{"pv-sibling"},
 		},
 		{
-			name:        "no match when device has no cached LVDL",
-			symlink:     unknownSymlink,
-			blockDevice: internal.BlockDevice{Name: "sdc", KName: "sdc"},
+			name:          "no match when device has no cached LVDL",
+			symlink:       unknownSymlink,
+			localNodeName: cacheLocalNode,
+			blockDevice:   internal.BlockDevice{Name: "sdc", KName: "sdc"},
 			filePathGlob: func(pattern string) ([]string, error) {
 				return []string{unknownSymlink}, nil
 			},
@@ -213,9 +222,10 @@ func TestFindStalePVs(t *testing.T) {
 			wantFound: false,
 		},
 		{
-			name:        "error when GetValidByIDSymlinks fails",
-			symlink:     unknownSymlink,
-			blockDevice: internal.BlockDevice{Name: "sdd", KName: "sdd"},
+			name:          "error when GetValidByIDSymlinks fails",
+			symlink:       unknownSymlink,
+			localNodeName: cacheLocalNode,
+			blockDevice:   internal.BlockDevice{Name: "sdd", KName: "sdd"},
 			filePathGlob: func(pattern string) ([]string, error) {
 				return nil, fmt.Errorf("permission denied")
 			},
@@ -225,10 +235,11 @@ func TestFindStalePVs(t *testing.T) {
 			name:    "merges LVDLs from multiple sibling symlinks",
 			symlink: unknownSymlink,
 			seededLVDLs: []*v1api.LocalVolumeDeviceLink{
-				newCacheLVDL("pv-link-a", "/dev/disk/by-id/old-a", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
-				newCacheLVDL("pv-link-b", "/dev/disk/by-id/old-b", v1api.DeviceLinkPolicyPreferredLinkTarget, siblingSymlink),
+				newCacheLVDL("pv-link-a", cacheLocalNode, "/dev/disk/by-id/old-a", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
+				newCacheLVDL("pv-link-b", cacheLocalNode, "/dev/disk/by-id/old-b", v1api.DeviceLinkPolicyPreferredLinkTarget, siblingSymlink),
 			},
-			blockDevice: internal.BlockDevice{Name: "sde", KName: "sde"},
+			localNodeName: cacheLocalNode,
+			blockDevice:   internal.BlockDevice{Name: "sde", KName: "sde"},
 			filePathGlob: func(pattern string) ([]string, error) {
 				return []string{directSymlink, siblingSymlink, unknownSymlink}, nil
 			},
@@ -238,6 +249,35 @@ func TestFindStalePVs(t *testing.T) {
 			},
 			wantFound:     true,
 			wantLVDLNames: []string{"pv-link-a", "pv-link-b"},
+		},
+		{
+			name:          "ignores direct match from different node",
+			symlink:       directSymlink,
+			localNodeName: cacheLocalNode,
+			seededLVDLs: []*v1api.LocalVolumeDeviceLink{
+				newCacheLVDL("pv-remote", cacheOtherNode, "/dev/disk/by-id/old-gone", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
+			},
+			blockDevice: internal.BlockDevice{Name: "sdf", KName: "sdf"},
+			wantFound:   false,
+		},
+		{
+			name:          "merges only local node lvdl entries when sibling targets overlap",
+			symlink:       unknownSymlink,
+			localNodeName: cacheLocalNode,
+			seededLVDLs: []*v1api.LocalVolumeDeviceLink{
+				newCacheLVDL("pv-local-a", cacheLocalNode, "/dev/disk/by-id/old-a", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink),
+				newCacheLVDL("pv-local-b", cacheLocalNode, "/dev/disk/by-id/old-b", v1api.DeviceLinkPolicyPreferredLinkTarget, siblingSymlink),
+				newCacheLVDL("pv-remote", cacheOtherNode, "/dev/disk/by-id/old-remote", v1api.DeviceLinkPolicyPreferredLinkTarget, directSymlink, siblingSymlink),
+			},
+			blockDevice: internal.BlockDevice{Name: "sdg", KName: "sdg"},
+			filePathGlob: func(pattern string) ([]string, error) {
+				return []string{directSymlink, siblingSymlink, unknownSymlink}, nil
+			},
+			filePathEvalSymLinks: func(path string) (string, error) {
+				return "/dev/sdg", nil
+			},
+			wantFound:     true,
+			wantLVDLNames: []string{"pv-local-a", "pv-local-b"},
 		},
 	}
 
@@ -257,7 +297,7 @@ func TestFindStalePVs(t *testing.T) {
 				internal.FilePathEvalSymLinks = tc.filePathEvalSymLinks
 			}
 
-			c := NewLocalVolumeDeviceLinkCache(nil, nil)
+			c := NewLocalVolumeDeviceLinkCache(nil, nil, tc.localNodeName)
 			for _, lvdl := range tc.seededLVDLs {
 				c.addOrUpdateLVDL(lvdl)
 			}
@@ -287,10 +327,10 @@ func TestFindStalePVs(t *testing.T) {
 }
 
 func TestAddOrUpdateLVDL_RemovesStaleTargets(t *testing.T) {
-	c := NewLocalVolumeDeviceLinkCache(nil, nil)
+	c := NewLocalVolumeDeviceLinkCache(nil, nil, cacheLocalNode)
 
 	// Seed with targets A and B.
-	lvdl := newCacheLVDL("pv-1", "/old", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/A", "/dev/disk/by-id/B")
+	lvdl := newCacheLVDL("pv-1", cacheLocalNode, "/old", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/A", "/dev/disk/by-id/B")
 	c.addOrUpdateLVDL(lvdl)
 
 	// Verify both entries exist.
@@ -300,7 +340,7 @@ func TestAddOrUpdateLVDL_RemovesStaleTargets(t *testing.T) {
 	assert.True(t, okB, "expected entry for target B")
 
 	// Update the same LVDL so ValidLinkTargets changes from [A, B] to [A, C].
-	lvdlUpdated := newCacheLVDL("pv-1", "/new", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/A", "/dev/disk/by-id/C")
+	lvdlUpdated := newCacheLVDL("pv-1", cacheLocalNode, "/new", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/A", "/dev/disk/by-id/C")
 	c.addOrUpdateLVDL(lvdlUpdated)
 
 	// A should still exist, B should be gone, C should be added.
@@ -315,13 +355,24 @@ func TestAddOrUpdateLVDL_RemovesStaleTargets(t *testing.T) {
 	assert.Equal(t, "/new", c.localDeviceInfos["/dev/disk/by-id/A"].lvdls["pv-1"].Status.CurrentLinkTarget)
 }
 
-func newCacheLVDL(name, current string, policy v1api.DeviceLinkPolicy, validTargets ...string) *v1api.LocalVolumeDeviceLink {
+func TestAddOrUpdateLVDL_IgnoresDifferentNodes(t *testing.T) {
+	c := NewLocalVolumeDeviceLinkCache(nil, nil, cacheLocalNode)
+
+	c.addOrUpdateLVDL(newCacheLVDL("pv-remote", cacheOtherNode, "/remote", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/remote"))
+	assert.Empty(t, c.localDeviceInfos, "expected foreign-node LVDL to be ignored")
+
+	c.addOrUpdateLVDL(newCacheLVDL("pv-local", cacheLocalNode, "/local", v1api.DeviceLinkPolicyPreferredLinkTarget, "/dev/disk/by-id/local"))
+	assert.Contains(t, c.localDeviceInfos, "/dev/disk/by-id/local")
+}
+
+func newCacheLVDL(name, nodeName, current string, policy v1api.DeviceLinkPolicy, validTargets ...string) *v1api.LocalVolumeDeviceLink {
 	return &v1api.LocalVolumeDeviceLink{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
 		Spec: v1api.LocalVolumeDeviceLinkSpec{
 			PersistentVolumeName: name,
+			NodeName:             nodeName,
 			Policy:               policy,
 		},
 		Status: v1api.LocalVolumeDeviceLinkStatus{

--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -663,7 +663,7 @@ func (r *LocalVolumeReconciler) processRejectedDevicesForDeviceLinks(ctx context
 			existingSymlinkName := filepath.Base(symlinkPath)
 
 			lvdlName := common.GeneratePVName(existingSymlinkName, r.runtimeConfig.Node.Name, storageClassName)
-			deviceHandler := common.NewDeviceLinkHandler(r.Client, r.ClientReader, r.runtimeConfig.Recorder, r.pvLinkCache)
+			deviceHandler := common.NewDeviceLinkHandler(r.Client, r.ClientReader, r.runtimeConfig.Recorder, r.pvLinkCache, r.runtimeConfig.Node.Name)
 
 			lvdl, err := deviceHandler.FindLVDL(ctx, lvdlName, r.runtimeConfig.Namespace)
 			if err != nil && !apierrors.IsNotFound(err) {

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -756,6 +756,7 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 					},
 					Spec: localv1.LocalVolumeDeviceLinkSpec{
 						PersistentVolumeName: pvName,
+						NodeName:             testNodeName,
 						Policy:               localv1.DeviceLinkPolicyNone,
 					},
 				})
@@ -880,6 +881,7 @@ func TestIgnoredDevicesProcessedWhenNoValidDevices(t *testing.T) {
 			},
 			Spec: localv1.LocalVolumeDeviceLinkSpec{
 				PersistentVolumeName: pvName,
+				NodeName:             testNodeName,
 				Policy:               localv1.DeviceLinkPolicyNone,
 			},
 		},
@@ -983,6 +985,7 @@ func TestProcessNewSymlink_SiblingFallback(t *testing.T) {
 
 			lvdl := fixture.LocalVolumeDeviceLink()
 			lvdl.Spec.Policy = tt.policy
+			lvdl.Spec.NodeName = cfg.TestNodeName
 
 			objs := []runtime.Object{lv, fixture.PersistentVolume(), lvdl, fixture.StorageClass()}
 			r, testCtx := getFakeDiskMaker(t, fixture.TmpRoot, objs...)
@@ -999,6 +1002,8 @@ func TestProcessNewSymlink_SiblingFallback(t *testing.T) {
 				VolumeMode: string(corev1.PersistentVolumeBlock),
 			}
 			r.fsInterface = FakeFileSystemInterface{}
+			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil, cfg.TestNodeName)
+			r.pvLinkCache.MarkSyncedForTests()
 
 			r.pvLinkCache.SeedForTests(lvdl)
 
@@ -1096,7 +1101,7 @@ func getFakeDiskMaker(t *testing.T, symlinkLocation string, objs ...runtime.Obje
 		fakeVolUtil:   fakeVolUtil,
 	}
 
-	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(fakeClient, nil)
+	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(fakeClient, nil, "test-node")
 	pvLinkCache.MarkSyncedForTests()
 
 	lvReconciler := NewLocalVolumeReconciler(

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -2,6 +2,7 @@ package lvset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -341,7 +342,9 @@ func (r *LocalVolumeSetReconciler) processRejectedDevicesForDeviceLinks(ctx cont
 	for _, blockDevice := range rejectedDevices {
 		symlinkPath, err := common.HasExistingLocalVolumes(ctx, r.Client, symLinkDir, blockDevice, r.pvLinkCache)
 		if err != nil {
-			klog.ErrorS(err, "failed to check for existing symlink for device", "volume", blockDevice.Name)
+			if !errors.As(err, &internal.IDPathNotFoundError{}) {
+				klog.ErrorS(err, "failed to check for existing symlink for device", "volume", blockDevice.Name)
+			}
 			continue
 		}
 
@@ -353,7 +356,7 @@ func (r *LocalVolumeSetReconciler) processRejectedDevicesForDeviceLinks(ctx cont
 		targetBaseSymlinkName := filepath.Base(symlinkPath)
 
 		lvdlName := common.GeneratePVName(targetBaseSymlinkName, r.runtimeConfig.Node.Name, storageClassName)
-		deviceHandler := common.NewDeviceLinkHandler(r.Client, r.ClientReader, r.runtimeConfig.Recorder, r.pvLinkCache)
+		deviceHandler := common.NewDeviceLinkHandler(r.Client, r.ClientReader, r.runtimeConfig.Recorder, r.pvLinkCache, r.runtimeConfig.Node.Name)
 
 		lvdl, err := deviceHandler.FindLVDL(ctx, lvdlName, r.runtimeConfig.Namespace)
 		if err != nil && !kerrors.IsNotFound(err) {

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -99,7 +99,7 @@ func newFakeLocalVolumeSetReconciler(t *testing.T, objs ...runtime.Object) (*Loc
 		fakeVolUtil:   fakeVolUtil,
 	}
 
-	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(fakeClient, nil)
+	pvLinkCache := common.NewLocalVolumeDeviceLinkCache(fakeClient, nil, "test-node")
 	pvLinkCache.MarkSyncedForTests()
 
 	lvsReconciler := NewLocalVolumeSetReconciler(
@@ -227,7 +227,7 @@ func TestProcessNewSymlink(t *testing.T) {
 			}
 
 			r, ctx := newFakeLocalVolumeSetReconciler(t, objs...)
-			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil)
+			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil, node.Name)
 			r.nodeName = node.Name
 			r.runtimeConfig.Node = node
 			r.runtimeConfig.Name = common.GetProvisionedByValue(*node)
@@ -358,9 +358,12 @@ func TestProcessNewSymlink_SiblingFallback_LVSet(t *testing.T) {
 
 			lvdl := fixture.LocalVolumeDeviceLink()
 			lvdl.Spec.Policy = tc.policy
+			lvdl.Spec.NodeName = node.Name
 
 			objs := []runtime.Object{lvset, node, fixture.PersistentVolume(), lvdl, fixture.StorageClass()}
 			r, testCtx := newFakeLocalVolumeSetReconciler(t, objs...)
+			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil, node.Name)
+			r.pvLinkCache.MarkSyncedForTests()
 			r.pvLinkCache.SeedForTests(lvdl)
 			r.nodeName = node.Name
 			r.runtimeConfig.Node = node
@@ -637,6 +640,7 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 				},
 				Spec: v1api.LocalVolumeDeviceLinkSpec{
 					PersistentVolumeName: pvName,
+					NodeName:             node.Name,
 					Policy:               tc.initialPolicy,
 				},
 				Status: v1api.LocalVolumeDeviceLinkStatus{
@@ -664,7 +668,7 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 				},
 				lvdl,
 			)
-			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil)
+			r.pvLinkCache = common.NewLocalVolumeDeviceLinkCache(r.Client, nil, node.Name)
 			r.nodeName = node.Name
 			r.runtimeConfig.Node = node
 			r.runtimeConfig.Namespace = testNamespace

--- a/pkg/diskmaker/diskmakertest/sibling_fallback.go
+++ b/pkg/diskmaker/diskmakertest/sibling_fallback.go
@@ -169,6 +169,7 @@ func (f *SiblingFallbackFixture) LocalVolumeDeviceLink() *localv1.LocalVolumeDev
 		},
 		Spec: localv1.LocalVolumeDeviceLinkSpec{
 			PersistentVolumeName: f.ExpectedPVName,
+			NodeName:             f.Config.TestNodeName,
 			Policy:               localv1.DeviceLinkPolicyPreferredLinkTarget,
 		},
 		Status: localv1.LocalVolumeDeviceLinkStatus{

--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -89,43 +89,30 @@ func eventuallyDelete(t *testing.T, removeFinalizers bool, objs ...client.Object
 // using eventuallyDelete is inherently racy
 // this function compares if PV was recreated with a different UID
 // then PV must be deleted.
-func eventuallyDeletePV(t *testing.T, objs ...client.Object) {
+func eventuallyDeletePV(t *testing.T, pv *corev1.PersistentVolume) {
 	f := framework.Global
 	matcher := gomega.NewWithT(t)
-	for _, obj := range objs {
-		accessor, err := meta.Accessor(obj)
-		if err != nil {
-			t.Fatalf("deletion failed, cannot get accessor for object: %+v, obj: %+v", err, obj)
+	oldUID := pv.UID
+	matcher.Eventually(func() error {
+		t.Logf("deleting obj %q with kind %q in ns %q", pv.Name, pv.Kind, pv.Namespace)
+		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: pv.Name, Namespace: pv.Namespace}, pv)
+		if errors.IsNotFound(err) || errors.IsGone(err) {
+			t.Logf("object already deleted: %s", err)
+			return nil
 		}
-		kind := obj.GetObjectKind().GroupVersionKind().Kind
-		name := accessor.GetName()
-		namespace := accessor.GetNamespace()
-		oldUID := accessor.GetUID()
-		matcher.Eventually(func() error {
-			t.Logf("deleting obj %q with kind %q in ns %q", name, kind, namespace)
-			err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
-			if errors.IsNotFound(err) || errors.IsGone(err) {
-				t.Logf("object already deleted: %s", err)
-				return nil
-			}
-			accessor, err = meta.Accessor(obj)
-			if err != nil {
-				t.Fatalf("deletion failed, cannot get accessor for object: %+v, obj: %+v", err, obj)
-			}
-			newUID := accessor.GetUID()
-			if newUID != oldUID {
-				t.Logf("object %s has been deleted and recreated", name)
-				return nil
-			}
+		newUID := pv.GetUID()
+		if newUID != oldUID {
+			t.Logf("object %s has been deleted and recreated", pv.Name)
+			return nil
+		}
 
-			err = f.Client.Delete(context.TODO(), obj)
-			if errors.IsNotFound(err) || errors.IsGone(err) {
-				t.Logf("object already deleted: %s", err)
-				return nil
-			}
-			return err
-		}, time.Minute*5, time.Second*5).ShouldNot(gomega.HaveOccurred(), "deleting %q", name)
-	}
+		err = f.Client.Delete(context.TODO(), pv)
+		if errors.IsNotFound(err) || errors.IsGone(err) {
+			t.Logf("object already deleted: %s", err)
+			return nil
+		}
+		return err
+	}, time.Minute*5, time.Second*5).ShouldNot(gomega.HaveOccurred(), "deleting %q", pv.Name)
 }
 
 func eventuallyFindPVs(t *testing.T, f *framework.Framework, storageClassName string, expectedPVs int) []corev1.PersistentVolume {
@@ -133,7 +120,7 @@ func eventuallyFindPVs(t *testing.T, f *framework.Framework, storageClassName st
 	matcher := gomega.NewWithT(t)
 	matcher.Eventually(func() []corev1.PersistentVolume {
 		pvList := &corev1.PersistentVolumeList{}
-		t.Log(fmt.Sprintf("waiting for %d PVs to be created with StorageClass: %q", expectedPVs, storageClassName))
+		t.Logf("waiting for %d PVs to be created with StorageClass: %q", expectedPVs, storageClassName)
 		matcher.Eventually(func() error {
 			return f.Client.List(context.TODO(), pvList)
 		}).ShouldNot(gomega.HaveOccurred())

--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -85,6 +85,49 @@ func eventuallyDelete(t *testing.T, removeFinalizers bool, objs ...client.Object
 
 }
 
+// PVs rapidly get deleted and recreated if diskmaker is running
+// using eventuallyDelete is inherently racy
+// this function compares if PV was recreated with a different UID
+// then PV must be deleted.
+func eventuallyDeletePV(t *testing.T, objs ...client.Object) {
+	f := framework.Global
+	matcher := gomega.NewWithT(t)
+	for _, obj := range objs {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			t.Fatalf("deletion failed, cannot get accessor for object: %+v, obj: %+v", err, obj)
+		}
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		name := accessor.GetName()
+		namespace := accessor.GetNamespace()
+		oldUID := accessor.GetUID()
+		matcher.Eventually(func() error {
+			t.Logf("deleting obj %q with kind %q in ns %q", name, kind, namespace)
+			err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, obj)
+			if errors.IsNotFound(err) || errors.IsGone(err) {
+				t.Logf("object already deleted: %s", err)
+				return nil
+			}
+			accessor, err = meta.Accessor(obj)
+			if err != nil {
+				t.Fatalf("deletion failed, cannot get accessor for object: %+v, obj: %+v", err, obj)
+			}
+			newUID := accessor.GetUID()
+			if newUID != oldUID {
+				t.Logf("object %s has been deleted and recreated", name)
+				return nil
+			}
+
+			err = f.Client.Delete(context.TODO(), obj)
+			if errors.IsNotFound(err) || errors.IsGone(err) {
+				t.Logf("object already deleted: %s", err)
+				return nil
+			}
+			return err
+		}, time.Minute*5, time.Second*5).ShouldNot(gomega.HaveOccurred(), "deleting %q", name)
+	}
+}
+
 func eventuallyFindPVs(t *testing.T, f *framework.Framework, storageClassName string, expectedPVs int) []corev1.PersistentVolume {
 	var matchedPVs []corev1.PersistentVolume
 	matcher := gomega.NewWithT(t)
@@ -305,4 +348,17 @@ func consumePV(t *testing.T, ctx *framework.Context, pv corev1.PersistentVolume)
 
 	matchingPod.TypeMeta.Kind = "Pod"
 	return pvc, job, &matchingPod
+}
+
+func assertLVDLsContainTargetAndNodes(t *testing.T, lvdls []localv1.LocalVolumeDeviceLink, expectedTarget string, expectedNodeNames []string) {
+	matcher := gomega.NewWithT(t)
+	foundNodeNames := sets.New[string]()
+	for _, lvdl := range lvdls {
+		matcher.Expect(lvdl.Status.ValidLinkTargets).To(gomega.ContainElement(expectedTarget),
+			"expected ValidLinkTargets for LVDL %q to contain %q", lvdl.Name, expectedTarget)
+		matcher.Expect(lvdl.Spec.NodeName).ToNot(gomega.BeEmpty(), "expected NodeName for LVDL %q", lvdl.Name)
+		foundNodeNames.Insert(lvdl.Spec.NodeName)
+	}
+	matcher.Expect(foundNodeNames.UnsortedList()).To(gomega.ConsistOf(expectedNodeNames),
+		"expected LVDL node names for target %q", expectedTarget)
 }

--- a/test/e2e/hostudev.go
+++ b/test/e2e/hostudev.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -9,6 +10,13 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+const sharedScsi8Link = "/dev/disk/by-id/scsi-8-local-storage-e2e-shared"
+
+type sharedByIDSymlinkTarget struct {
+	nodeHostname string
+	currentLink  string
+}
 
 // addNewUdevSymlink adds a new udev symlink on the node. The link will point to the same device as the currentLink.
 func addNewUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string, currentLink, newLink string) {
@@ -26,6 +34,16 @@ func addNewUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string
 	symlinkJob.TypeMeta.Kind = "Job"
 	eventuallyDelete(t, false, symlinkJob)
 	t.Logf("added udev symlink %s -> %s on node %s", currentLink, newLink, nodeHostname)
+}
+
+func addSharedUdevSymlink(t *testing.T, ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn, targets []sharedByIDSymlinkTarget, newLink string) {
+	for _, target := range targets {
+		addNewUdevSymlink(t, ctx, target.nodeHostname, target.currentLink, newLink)
+		addToCleanupFuncs(cleanupFuncs, fmt.Sprintf("removeUdevSymlink-%s-%s", target.nodeHostname, filepath.Base(newLink)), func(t *testing.T) error {
+			removeUdevSymlink(t, ctx, target.nodeHostname, newLink)
+			return nil
+		})
+	}
 }
 
 // removeUdevSymlink removes a udev symlink on the node. It literally calls `rm -f $linkPattern` (in the root directory),

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -110,6 +110,85 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 
 		selectedDisk := nodeEnv[0].disks[0]
 		matcher.Expect(selectedDisk.path).ShouldNot(gomega.BeZero(), "device path should not be empty")
+		sharedSelectedDisk := nodeEnv[0].disks[1]
+		matcher.Expect(sharedSelectedDisk.path).ShouldNot(gomega.BeZero(), "shared selected device path should not be empty")
+		sharedAliasDisk := nodeEnv[1].disks[1]
+		matcher.Expect(sharedAliasDisk.path).ShouldNot(gomega.BeZero(), "shared alias device path should not be empty")
+
+		t.Log("TEST: duplicate by-id cache reproducer for LocalVolume using shared scsi-8 alias")
+		addSharedUdevSymlink(t, ctx, cleanupFuncs, []sharedByIDSymlinkTarget{
+			{
+				nodeHostname: nodeEnv[0].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(sharedSelectedDisk),
+			},
+			{
+				nodeHostname: nodeEnv[1].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(sharedAliasDisk),
+			},
+		}, sharedScsi8Link)
+
+		sharedLocalVolume := getLocalVolume(selectedNode, sharedScsi8Link, namespace)
+		sharedLocalVolume.Name = "test-local-disk-shared-byid"
+		sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName = "test-local-sc-shared-byid"
+
+		matcher.Eventually(func() error {
+			t.Log("creating shared localvolume reproducer")
+			return f.Client.Create(goctx.TODO(), sharedLocalVolume, &framework.CleanupOptions{TestContext: ctx})
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "creating shared localvolume reproducer")
+
+		err = waitForDaemonSet(t, f.KubeClient, namespace, nodedaemon.DiskMakerName, retryInterval, timeout)
+		if err != nil {
+			t.Fatalf("error waiting for diskmaker daemonset for shared localvolume reproducer: %v", err)
+		}
+		err = verifyLocalVolume(t, sharedLocalVolume, f.Client)
+		if err != nil {
+			t.Fatalf("error verifying shared localvolume reproducer: %v", err)
+		}
+		err = checkLocalVolumeStatus(t, sharedLocalVolume)
+		if err != nil {
+			t.Fatalf("error checking shared localvolume reproducer condition: %v", err)
+		}
+
+		sharedPVs := eventuallyFindPVs(t, f, sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName, 1)
+		matcher.Expect(filepath.Base(sharedPVs[0].Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+		sharedPVNames := []string{sharedPVs[0].Name}
+		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name})
+
+		matcher.Eventually(func() error {
+			t.Log("expanding shared localvolume reproducer to a second node")
+			key := types.NamespacedName{Name: sharedLocalVolume.Name, Namespace: sharedLocalVolume.Namespace}
+			if err := f.Client.Get(goctx.TODO(), key, sharedLocalVolume); err != nil {
+				return err
+			}
+			matchFields := sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms[0].MatchFields
+			if len(matchFields) == 0 {
+				return fmt.Errorf("shared localvolume reproducer node selector is missing matchFields")
+			}
+			secondNodeTerm := sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms[0]
+			secondNodeTerm.MatchFields = append([]v1.NodeSelectorRequirement(nil), matchFields...)
+			secondNodeTerm.MatchFields[0].Values = []string{nodeEnv[1].node.Name}
+			sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms = append(
+				sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms,
+				secondNodeTerm,
+			)
+			return f.Client.Update(goctx.TODO(), sharedLocalVolume)
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "updating shared localvolume reproducer")
+
+		sharedPVs = eventuallyFindPVs(t, f, sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName, 2)
+		sharedPVNames = make([]string, 0, len(sharedPVs))
+		for _, pv := range sharedPVs {
+			matcher.Expect(filepath.Base(pv.Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+			sharedPVNames = append(sharedPVNames, pv.Name)
+		}
+		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name, nodeEnv[1].node.Name})
+
+		t.Log("cleaning up LocalVolume duplicate by-id reproducer before continuing with standard test flow")
+		cleanupLVAndWaitForOwnedPVsToDisappear(t, f, sharedLocalVolume)
+
+		removeUdevSymlink(t, ctx, nodeEnv[0].node.Labels[corev1.LabelHostname], sharedScsi8Link)
+		removeUdevSymlink(t, ctx, nodeEnv[1].node.Labels[corev1.LabelHostname], sharedScsi8Link)
 
 		localVolume := getLocalVolume(selectedNode, selectedDisk.path, namespace)
 
@@ -195,6 +274,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 			"/dev/disk/by-id/wwn-local-storage-e2e-step3",
 			"/dev/disk/by-id/scsi-3-local-storage-e2e-step2",
 		)
+
 		pvs = []corev1.PersistentVolume{selectedPV}
 
 		// consume pvs
@@ -272,7 +352,6 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		symLinkPath := path.Join(common.GetLocalDiskLocationPath(), lvStorageClassName)
 		checkForSymlinks(t, ctx, nodeEnv, symLinkPath)
 	}
-
 }
 
 func verifyLVDLFilesystemUUIDForPVs(t *testing.T, f *framework.Framework, namespace string, pvNames []string) {
@@ -356,28 +435,76 @@ func verifyProvisionerAnnotation(t *testing.T, pvs []corev1.PersistentVolume, no
 
 }
 
+func waitForLocalVolumeAndOwnedPVsToDisappear(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) {
+	matcher := gomega.NewWithT(t)
+
+	matcher.Eventually(func() error {
+		key := types.NamespacedName{Name: localVolume.Name, Namespace: localVolume.Namespace}
+		currentLocalVolume := &localv1.LocalVolume{}
+		err := f.Client.Get(context.TODO(), key, currentLocalVolume)
+		if err != nil {
+			if !errors.IsNotFound(err) && !errors.IsGone(err) {
+				return err
+			}
+		} else {
+			return fmt.Errorf("localvolume %q still exists with finalizers: %+v", currentLocalVolume.Name, currentLocalVolume.Finalizers)
+		}
+
+		pvList := &corev1.PersistentVolumeList{}
+		err = f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+			common.PVOwnerKindLabel:      localv1.LocalVolumeKind,
+			common.PVOwnerNamespaceLabel: localVolume.Namespace,
+			common.PVOwnerNameLabel:      localVolume.Name,
+		})
+		if err != nil {
+			return err
+		}
+		if len(pvList.Items) > 0 {
+			pvNames := make([]string, 0, len(pvList.Items))
+			for _, pv := range pvList.Items {
+				pvNames = append(pvNames, pv.Name)
+			}
+			return fmt.Errorf("waiting for owned PVs to disappear for localvolume %q: %+v", localVolume.Name, pvNames)
+		}
+
+		return nil
+	}, time.Minute*8, time.Second*5).ShouldNot(gomega.HaveOccurred(), "waiting for localvolume %q and owned PVs to be deleted", localVolume.Name)
+}
+
+func cleanupLVAndWaitForOwnedPVsToDisappear(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) {
+	eventuallyDelete(t, false, localVolume)
+	waitForLocalVolumeAndOwnedPVsToDisappear(t, f, localVolume)
+}
+
 func cleanupLVResources(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) error {
-	// cleanup lv force-removing the finalizer if necessary
+	// first mark lv for deletion without removing finalizer
+	eventuallyDelete(t, false, localVolume)
+	pvList := &corev1.PersistentVolumeList{}
+	matcher := gomega.NewWithT(t)
+	matcher.Eventually(func() error {
+		err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+			common.PVOwnerKindLabel:      localv1.LocalVolumeKind,
+			common.PVOwnerNamespaceLabel: localVolume.Namespace,
+			common.PVOwnerNameLabel:      localVolume.Name,
+		})
+		if err != nil {
+			return err
+		}
+		t.Logf("Deleting %d PVs", len(pvList.Items))
+		for _, pv := range pvList.Items {
+			eventuallyDelete(t, false, &pv)
+		}
+		return nil
+	}, time.Minute*3, time.Second*2).ShouldNot(gomega.HaveOccurred(), "cleaning up pvs for lv: %q", localVolume.GetName())
+
+	// Delete the owning resources after their PVs are fully gone so the
+	// diskmaker cleanup path can remove PV finalizers first.
 	eventuallyDelete(t, true, localVolume)
 	sc := &storagev1.StorageClass{
 		TypeMeta:   metav1.TypeMeta{Kind: localv1.LocalVolumeKind},
 		ObjectMeta: metav1.ObjectMeta{Name: localVolume.Spec.StorageClassDevices[0].StorageClassName},
 	}
 	eventuallyDelete(t, false, sc)
-	pvList := &corev1.PersistentVolumeList{}
-	matcher := gomega.NewWithT(t)
-	matcher.Eventually(func() error {
-		err := f.Client.List(context.TODO(), pvList)
-		if err != nil {
-			return err
-		}
-		t.Logf("Deleting %d PVs", len(pvList.Items))
-		for _, pv := range pvList.Items {
-			// pv.TypeMeta.Kind = kind
-			eventuallyDelete(t, false, &pv)
-		}
-		return nil
-	}, time.Minute*3, time.Second*2).ShouldNot(gomega.HaveOccurred(), "cleaning up pvs for lv: %q", localVolume.GetName())
 
 	return nil
 

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -112,7 +112,6 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		thirtyGi := resource.MustParse("30G")
 		fiftyGi := resource.MustParse("50G")
 		hundredTi := resource.MustParse("100Ti")
-		one := int32(1)
 		two := int32(2)
 		three := int32(3)
 
@@ -172,7 +171,6 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 			},
 			Spec: localv1alpha1.LocalVolumeSetSpec{
 				StorageClassName: "shared-byid-10g",
-				MaxDeviceCount:   &one,
 				VolumeMode:       localv1.PersistentVolumeBlock,
 				NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
 					{
@@ -209,7 +207,6 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 			if err := f.Client.Get(context.TODO(), key, sharedLVSet); err != nil {
 				return err
 			}
-			sharedLVSet.Spec.MaxDeviceCount = &two
 			sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values = append(
 				sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values,
 				nodeEnv[1].node.ObjectMeta.Labels[corev1.LabelHostname],

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -5,6 +5,7 @@ import (
 	goctx "context"
 	"fmt"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -111,6 +112,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		thirtyGi := resource.MustParse("30G")
 		fiftyGi := resource.MustParse("50G")
 		hundredTi := resource.MustParse("100Ti")
+		one := int32(1)
 		two := int32(2)
 		three := int32(3)
 
@@ -150,6 +152,85 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		t.Log("creating and attaching disks")
 		createAndAttachAWSVolumes(t, ec2Client, ctx, namespace, nodeEnv)
 		nodeEnv = populateDeviceInfo(t, ctx, nodeEnv)
+
+		t.Log("TEST: duplicate by-id cache reproducer for LocalVolumeSet using shared scsi-8 alias")
+		addSharedUdevSymlink(t, ctx, cleanupFuncs, []sharedByIDSymlinkTarget{
+			{
+				nodeHostname: nodeEnv[0].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(nodeEnv[0].disks[0]),
+			},
+			{
+				nodeHostname: nodeEnv[1].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(nodeEnv[1].disks[0]),
+			},
+		}, sharedScsi8Link)
+
+		sharedLVSet := &localv1alpha1.LocalVolumeSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-byid-10g",
+				Namespace: namespace,
+			},
+			Spec: localv1alpha1.LocalVolumeSetSpec{
+				StorageClassName: "shared-byid-10g",
+				MaxDeviceCount:   &one,
+				VolumeMode:       localv1.PersistentVolumeBlock,
+				NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      corev1.LabelHostname,
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{nodeEnv[0].node.ObjectMeta.Labels[corev1.LabelHostname]},
+							},
+						},
+					},
+				}},
+				DeviceInclusionSpec: &localv1alpha1.DeviceInclusionSpec{
+					DeviceTypes: []localv1alpha1.DeviceType{localv1alpha1.RawDisk},
+					MaxSize:     &twentyGi,
+				},
+			},
+		}
+
+		t.Logf("creating localvolumeset %q", sharedLVSet.GetName())
+		err = f.Client.Create(context.TODO(), sharedLVSet, &framework.CleanupOptions{TestContext: ctx})
+		matcher.Expect(err).NotTo(gomega.HaveOccurred(), "create shared localvolumeset reproducer")
+
+		sharedPVs := eventuallyFindPVs(t, f, sharedLVSet.Spec.StorageClassName, 1)
+
+		matcher.Expect(filepath.Base(sharedPVs[0].Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+		sharedPVNames := []string{sharedPVs[0].Name}
+		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name})
+
+		matcher.Eventually(func() error {
+			t.Log("expanding shared localvolumeset reproducer to a second node")
+			key := types.NamespacedName{Name: sharedLVSet.GetName(), Namespace: sharedLVSet.GetNamespace()}
+			if err := f.Client.Get(context.TODO(), key, sharedLVSet); err != nil {
+				return err
+			}
+			sharedLVSet.Spec.MaxDeviceCount = &two
+			sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values = append(
+				sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values,
+				nodeEnv[1].node.ObjectMeta.Labels[corev1.LabelHostname],
+			)
+			return f.Client.Update(context.TODO(), sharedLVSet)
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "updating shared localvolumeset reproducer")
+
+		sharedPVs = eventuallyFindPVs(t, f, sharedLVSet.Spec.StorageClassName, 2)
+		sharedPVNames = make([]string, 0, len(sharedPVs))
+		for _, pv := range sharedPVs {
+			matcher.Expect(filepath.Base(pv.Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+			sharedPVNames = append(sharedPVNames, pv.Name)
+		}
+		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name, nodeEnv[1].node.Name})
+
+		t.Log("cleaning up LocalVolumeSet duplicate by-id reproducer before continuing with standard test flow")
+		eventuallyDelete(t, false, sharedLVSet)
+		waitForLVSetAndOwnedPVsToDisappear(t, sharedLVSet)
+		removeUdevSymlink(t, ctx, nodeEnv[0].node.Labels[corev1.LabelHostname], sharedScsi8Link)
+		removeUdevSymlink(t, ctx, nodeEnv[1].node.Labels[corev1.LabelHostname], sharedScsi8Link)
 
 		// create block and fs on two nodes parallely
 		// do cleanup job verification
@@ -265,7 +346,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		twentyToFiftyBlockPVs := eventuallyFindPVs(t, f, twentyToFifty.Spec.StorageClassName, 3)
 		// verify deletion
 		for _, pv := range twentyToFiftyBlockPVs {
-			eventuallyDelete(t, false, &pv)
+			eventuallyDeletePV(t, &pv)
 		}
 		// verify that block PVs come back after deletion
 		eventuallyFindPVs(t, f, twentyToFifty.Spec.StorageClassName, 3)
@@ -400,7 +481,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		// verify deletion
 		t.Log("verify that filesystem PVs come back after deletion")
 		for _, pv := range fsPVs {
-			eventuallyDelete(t, false, &pv)
+			eventuallyDeletePV(t, &pv)
 		}
 		fsPVs = eventuallyFindPVs(t, f, twentyToFiftyFilesystem.Spec.StorageClassName, 9)
 
@@ -504,30 +585,73 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 
 }
 
+func waitForLVSetAndOwnedPVsToDisappear(t *testing.T, lvset *localv1alpha1.LocalVolumeSet) {
+	f := framework.Global
+	matcher := gomega.NewWithT(t)
+
+	matcher.Eventually(func() error {
+		key := types.NamespacedName{Name: lvset.Name, Namespace: lvset.Namespace}
+		currentLVSet := &localv1alpha1.LocalVolumeSet{}
+		err := f.Client.Get(context.TODO(), key, currentLVSet)
+		if err != nil {
+			if !errors.IsNotFound(err) && !errors.IsGone(err) {
+				return err
+			}
+		} else {
+			return fmt.Errorf("localvolumeset %q still exists with finalizers: %+v", currentLVSet.Name, currentLVSet.Finalizers)
+		}
+
+		pvList := &corev1.PersistentVolumeList{}
+		err = f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+			common.PVOwnerKindLabel:      localv1.LocalVolumeSetKind,
+			common.PVOwnerNamespaceLabel: lvset.Namespace,
+			common.PVOwnerNameLabel:      lvset.Name,
+		})
+		if err != nil {
+			return err
+		}
+		if len(pvList.Items) > 0 {
+			pvNames := make([]string, 0, len(pvList.Items))
+			for _, pv := range pvList.Items {
+				pvNames = append(pvNames, pv.Name)
+			}
+			return fmt.Errorf("waiting for owned PVs to disappear for localvolumeset %q: %+v", lvset.Name, pvNames)
+		}
+
+		return nil
+	}, time.Minute*8, time.Second*5).ShouldNot(gomega.HaveOccurred(), "waiting for localvolumeset %q and owned PVs to be deleted", lvset.Name)
+}
+
 func cleanupLVSetResources(t *testing.T, lvsets *[]*localv1alpha1.LocalVolumeSet) error {
 	for _, lvset := range *lvsets {
 		t.Logf("cleaning up pvs and storageclasses: %q", lvset.GetName())
 		f := framework.Global
 		matcher := gomega.NewWithT(t)
-		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: lvset.Spec.StorageClassName}}
+		// delete lvset without removing finalizer, so as it doesn't
+		// automatically recreate the PVs we delete below
+		eventuallyDelete(t, false, lvset)
 
-		eventuallyDelete(t, true, lvset)
-		eventuallyDelete(t, false, sc)
 		pvList := &corev1.PersistentVolumeList{}
 		t.Logf("listing pvs for lvset: %q", lvset.GetName())
 		matcher.Eventually(func() error {
-			err := f.Client.List(context.TODO(), pvList)
+			err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+				common.PVOwnerKindLabel:      localv1.LocalVolumeSetKind,
+				common.PVOwnerNamespaceLabel: lvset.Namespace,
+				common.PVOwnerNameLabel:      lvset.Name,
+			})
 			if err != nil {
 				return err
 			}
 			t.Logf("Deleting %d PVs", len(pvList.Items))
 			for _, pv := range pvList.Items {
-				if pv.Spec.StorageClassName == lvset.Spec.StorageClassName {
-					eventuallyDelete(t, false, &pv)
-				}
+				eventuallyDelete(t, false, &pv)
 			}
 			return nil
 		}, time.Minute*3, time.Second*2).ShouldNot(gomega.HaveOccurred(), "cleaning up pvs for lvset: %q", lvset.GetName())
+
+		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: lvset.Spec.StorageClassName}}
+		eventuallyDelete(t, true, lvset)
+		eventuallyDelete(t, false, sc)
 	}
 
 	return nil

--- a/test/e2e/symlink_check.go
+++ b/test/e2e/symlink_check.go
@@ -279,7 +279,7 @@ func verifyMultiStepPreferredLinkReconciliation(
 		t.Logf("step %d: deleting PV %q and verifying recreation", i+1, pv.Name)
 		oldPVUID := pv.UID
 		oldPVPath := pv.Spec.Local.Path
-		eventuallyDelete(t, false, &pv)
+		eventuallyDeletePV(t, &pv)
 
 		// After PV deletion + symlink cleanup + recreation, the symlink filename
 		// may change (the recreated symlink uses the current preferred by-id name).
@@ -350,7 +350,7 @@ func verifySymlinkFallbackOnDisappearingLink(
 	t.Logf("fallback test: deleting PV %q and verifying recreation with fallback target", pv.Name)
 	oldPVUID := pv.UID
 	oldPVPath := pv.Spec.Local.Path
-	eventuallyDelete(t, false, &pv)
+	eventuallyDeletePV(t, &pv)
 
 	pv = waitForRecreatedPVByName(t, f, pv.Name, oldPVUID)
 	matcher.Expect(pv.Spec.Local.Path).To(gomega.Equal(oldPVPath),


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-83413

includes changes from https://github.com/openshift/local-storage-operator/pull/603


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LocalVolumeDeviceLink objects now require a nodeName field (1–253 chars) to associate links with a specific node.

* **Enhancements**
  * Device link discovery and indexing are scoped to the local node, reducing cross-node interference.
  * Manager startup now validates presence of the local node identity to ensure node-scoped behavior.

* **Tests**
  * Unit and e2e tests expanded for multi-node/shared-by-id scenarios; new e2e reproducer, cleanup helpers, and assertions added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->