### PR TITLE
Add e2e for duplicate device names

### DIFF
--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -90,7 +90,7 @@ func eventuallyFindPVs(t *testing.T, f *framework.Framework, storageClassName st
 	matcher := gomega.NewWithT(t)
 	matcher.Eventually(func() []corev1.PersistentVolume {
 		pvList := &corev1.PersistentVolumeList{}
-		t.Log(fmt.Sprintf("waiting for %d PVs to be created with StorageClass: %q", expectedPVs, storageClassName))
+		t.Logf("waiting for %d PVs to be created with StorageClass: %q", expectedPVs, storageClassName)
 		matcher.Eventually(func() error {
 			return f.Client.List(context.TODO(), pvList)
 		}).ShouldNot(gomega.HaveOccurred())
@@ -130,6 +130,16 @@ func eventuallyFindLVDLsForPVs(t *testing.T, f *framework.Framework, namespace s
 		return len(foundLVDLs) == len(pvNameSet)
 	}, time.Minute*5, time.Second*5).Should(gomega.BeTrue(), "waiting for LVDL objects with populated status for all PVs")
 	return foundLVDLs
+}
+
+func assertLVDLsContainTarget(t *testing.T, lvdls []localv1.LocalVolumeDeviceLink, expectedTarget string, expectedCount int) {
+	matcher := gomega.NewWithT(t)
+	matcher.Expect(lvdls).To(gomega.HaveLen(expectedCount),
+		"expected %d LVDLs for target %q", expectedCount, expectedTarget)
+	for _, lvdl := range lvdls {
+		matcher.Expect(lvdl.Status.ValidLinkTargets).To(gomega.ContainElement(expectedTarget),
+			"expected ValidLinkTargets for LVDL %q to contain %q", lvdl.Name, expectedTarget)
+	}
 }
 
 // waits for PVs of the same name to become available

--- a/test/e2e/hostudev.go
+++ b/test/e2e/hostudev.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/onsi/gomega"
@@ -9,6 +10,13 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
+
+const sharedScsi8Link = "/dev/disk/by-id/scsi-8-local-storage-e2e-shared"
+
+type sharedByIDSymlinkTarget struct {
+	nodeHostname string
+	currentLink  string
+}
 
 // addNewUdevSymlink adds a new udev symlink on the node. The link will point to the same device as the currentLink.
 func addNewUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string, currentLink, newLink string) {
@@ -26,6 +34,16 @@ func addNewUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string
 	symlinkJob.TypeMeta.Kind = "Job"
 	eventuallyDelete(t, false, symlinkJob)
 	t.Logf("added udev symlink %s -> %s on node %s", currentLink, newLink, nodeHostname)
+}
+
+func addSharedUdevSymlink(t *testing.T, ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn, targets []sharedByIDSymlinkTarget, newLink string) {
+	for _, target := range targets {
+		addNewUdevSymlink(t, ctx, target.nodeHostname, target.currentLink, newLink)
+		addToCleanupFuncs(cleanupFuncs, fmt.Sprintf("removeUdevSymlink-%s-%s", target.nodeHostname, filepath.Base(newLink)), func(t *testing.T) error {
+			removeUdevSymlink(t, ctx, target.nodeHostname, newLink)
+			return nil
+		})
+	}
 }
 
 // removeUdevSymlink removes a udev symlink on the node. It literally calls `rm -f $linkPattern` (in the root directory),

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -110,6 +110,84 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 
 		selectedDisk := nodeEnv[0].disks[0]
 		matcher.Expect(selectedDisk.path).ShouldNot(gomega.BeZero(), "device path should not be empty")
+		sharedAliasDisk := nodeEnv[1].disks[0]
+		matcher.Expect(sharedAliasDisk.path).ShouldNot(gomega.BeZero(), "shared alias device path should not be empty")
+
+		t.Log("TEST: duplicate by-id cache reproducer for LocalVolume using shared scsi-8 alias")
+		addSharedUdevSymlink(t, ctx, cleanupFuncs, []sharedByIDSymlinkTarget{
+			{
+				nodeHostname: nodeEnv[0].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(selectedDisk),
+			},
+			{
+				nodeHostname: nodeEnv[1].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(sharedAliasDisk),
+			},
+		}, sharedScsi8Link)
+
+		sharedLocalVolume := getLocalVolume(selectedNode, sharedScsi8Link, namespace)
+		sharedLocalVolume.Name = "test-local-disk-shared-byid"
+		sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName = "test-local-sc-shared-byid"
+
+		matcher.Eventually(func() error {
+			t.Log("creating shared localvolume reproducer")
+			return f.Client.Create(goctx.TODO(), sharedLocalVolume, &framework.CleanupOptions{TestContext: ctx})
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "creating shared localvolume reproducer")
+
+		addToCleanupFuncs(cleanupFuncs, "cleanupSharedLVResources", func(t *testing.T) error {
+			return cleanupLVResources(t, f, sharedLocalVolume)
+		})
+
+		err = waitForDaemonSet(t, f.KubeClient, namespace, nodedaemon.DiskMakerName, retryInterval, timeout)
+		if err != nil {
+			t.Fatalf("error waiting for diskmaker daemonset for shared localvolume reproducer: %v", err)
+		}
+		err = verifyLocalVolume(t, sharedLocalVolume, f.Client)
+		if err != nil {
+			t.Fatalf("error verifying shared localvolume reproducer: %v", err)
+		}
+		err = checkLocalVolumeStatus(t, sharedLocalVolume)
+		if err != nil {
+			t.Fatalf("error checking shared localvolume reproducer condition: %v", err)
+		}
+
+		sharedPVs := eventuallyFindPVs(t, f, sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName, 1)
+		matcher.Expect(filepath.Base(sharedPVs[0].Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+		sharedPVNames := []string{sharedPVs[0].Name}
+		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTarget(t, sharedLVDLs, sharedScsi8Link, 1)
+
+		matcher.Eventually(func() error {
+			t.Log("expanding shared localvolume reproducer to a second node")
+			key := types.NamespacedName{Name: sharedLocalVolume.Name, Namespace: sharedLocalVolume.Namespace}
+			if err := f.Client.Get(goctx.TODO(), key, sharedLocalVolume); err != nil {
+				return err
+			}
+			matchFields := sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms[0].MatchFields
+			if len(matchFields) == 0 {
+				return fmt.Errorf("shared localvolume reproducer node selector is missing matchFields")
+			}
+			matchFields[0].Values = append(matchFields[0].Values, nodeEnv[1].node.Name)
+			sharedLocalVolume.Spec.NodeSelector.NodeSelectorTerms[0].MatchFields = matchFields
+			return f.Client.Update(goctx.TODO(), sharedLocalVolume)
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "updating shared localvolume reproducer")
+
+		sharedPVs = eventuallyFindPVs(t, f, sharedLocalVolume.Spec.StorageClassDevices[0].StorageClassName, 2)
+		sharedPVNames = make([]string, 0, len(sharedPVs))
+		for _, pv := range sharedPVs {
+			matcher.Expect(filepath.Base(pv.Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+			sharedPVNames = append(sharedPVNames, pv.Name)
+		}
+		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTarget(t, sharedLVDLs, sharedScsi8Link, 2)
+
+		t.Log("cleaning up LocalVolume duplicate by-id reproducer before continuing with standard test flow")
+		err = cleanupLVResources(t, f, sharedLocalVolume)
+		if err != nil {
+			t.Fatalf("error cleaning up shared localvolume reproducer: %v", err)
+		}
+		removeUdevSymlink(t, ctx, nodeEnv[0].node.Labels[corev1.LabelHostname], sharedScsi8Link)
+		removeUdevSymlink(t, ctx, nodeEnv[1].node.Labels[corev1.LabelHostname], sharedScsi8Link)
 
 		localVolume := getLocalVolume(selectedNode, selectedDisk.path, namespace)
 

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -5,6 +5,7 @@ import (
 	goctx "context"
 	"fmt"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -111,6 +112,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		thirtyGi := resource.MustParse("30G")
 		fiftyGi := resource.MustParse("50G")
 		hundredTi := resource.MustParse("100Ti")
+		one := int32(1)
 		two := int32(2)
 		three := int32(3)
 
@@ -150,6 +152,88 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		t.Log("creating and attaching disks")
 		createAndAttachAWSVolumes(t, ec2Client, ctx, namespace, nodeEnv)
 		nodeEnv = populateDeviceInfo(t, ctx, nodeEnv)
+
+		t.Log("TEST: duplicate by-id cache reproducer for LocalVolumeSet using shared scsi-8 alias")
+		addSharedUdevSymlink(t, ctx, cleanupFuncs, []sharedByIDSymlinkTarget{
+			{
+				nodeHostname: nodeEnv[0].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(nodeEnv[0].disks[0]),
+			},
+			{
+				nodeHostname: nodeEnv[1].node.Labels[corev1.LabelHostname],
+				currentLink:  currentSymlinkForDisk(nodeEnv[1].disks[0]),
+			},
+		}, sharedScsi8Link)
+
+		sharedLVSet := &localv1alpha1.LocalVolumeSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shared-byid-10g",
+				Namespace: namespace,
+			},
+			Spec: localv1alpha1.LocalVolumeSetSpec{
+				StorageClassName: "shared-byid-10g",
+				MaxDeviceCount:   &one,
+				VolumeMode:       localv1.PersistentVolumeBlock,
+				NodeSelector: &corev1.NodeSelector{NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							{
+								Key:      corev1.LabelHostname,
+								Operator: corev1.NodeSelectorOpIn,
+								Values:   []string{nodeEnv[0].node.ObjectMeta.Labels[corev1.LabelHostname]},
+							},
+						},
+					},
+				}},
+				DeviceInclusionSpec: &localv1alpha1.DeviceInclusionSpec{
+					DeviceTypes: []localv1alpha1.DeviceType{localv1alpha1.RawDisk},
+					MinSize:     &tenGi,
+					MaxSize:     &tenGi,
+				},
+			},
+		}
+
+		t.Logf("creating localvolumeset %q", sharedLVSet.GetName())
+		err = f.Client.Create(context.TODO(), sharedLVSet, &framework.CleanupOptions{TestContext: ctx})
+		matcher.Expect(err).NotTo(gomega.HaveOccurred(), "create shared localvolumeset reproducer")
+		lvSets = append(lvSets, sharedLVSet)
+
+		sharedPVs := eventuallyFindPVs(t, f, sharedLVSet.Spec.StorageClassName, 1)
+		matcher.Expect(filepath.Base(sharedPVs[0].Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+		sharedPVNames := []string{sharedPVs[0].Name}
+		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTarget(t, sharedLVDLs, sharedScsi8Link, 1)
+
+		matcher.Eventually(func() error {
+			t.Log("expanding shared localvolumeset reproducer to a second node")
+			key := types.NamespacedName{Name: sharedLVSet.GetName(), Namespace: sharedLVSet.GetNamespace()}
+			if err := f.Client.Get(context.TODO(), key, sharedLVSet); err != nil {
+				return err
+			}
+			sharedLVSet.Spec.MaxDeviceCount = &two
+			sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values = append(
+				sharedLVSet.Spec.NodeSelector.NodeSelectorTerms[0].MatchExpressions[0].Values,
+				nodeEnv[1].node.ObjectMeta.Labels[corev1.LabelHostname],
+			)
+			return f.Client.Update(context.TODO(), sharedLVSet)
+		}, time.Minute, time.Second*2).ShouldNot(gomega.HaveOccurred(), "updating shared localvolumeset reproducer")
+
+		sharedPVs = eventuallyFindPVs(t, f, sharedLVSet.Spec.StorageClassName, 2)
+		sharedPVNames = make([]string, 0, len(sharedPVs))
+		for _, pv := range sharedPVs {
+			matcher.Expect(filepath.Base(pv.Spec.Local.Path)).To(gomega.Equal(filepath.Base(sharedScsi8Link)))
+			sharedPVNames = append(sharedPVNames, pv.Name)
+		}
+		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
+		assertLVDLsContainTarget(t, sharedLVDLs, sharedScsi8Link, 2)
+
+		t.Log("cleaning up LocalVolumeSet duplicate by-id reproducer before continuing with standard test flow")
+		err = cleanupLVSetResources(t, &[]*localv1alpha1.LocalVolumeSet{sharedLVSet})
+		if err != nil {
+			t.Fatalf("error cleaning up shared localvolumeset reproducer: %v", err)
+		}
+		removeUdevSymlink(t, ctx, nodeEnv[0].node.Labels[corev1.LabelHostname], sharedScsi8Link)
+		removeUdevSymlink(t, ctx, nodeEnv[1].node.Labels[corev1.LabelHostname], sharedScsi8Link)
 
 		// create block and fs on two nodes parallely
 		// do cleanup job verification


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end reproducer for duplicate by-id cache behavior using shared by-id symlinks across two nodes.
  * New test flow provisions a shared local volume, expands node targeting to validate multi-node PV provisioning, and verifies device-link objects reference the shared alias.
  * Improved test assertions and logging for clearer per-item failures and added cleanup of created symlinks and resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->