### PR TITLE
NO-JIRA: Fix envtest download for 4.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 
 test: ## Run unit tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.7.2/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR)
+        $(call go-get-tool,$(ENVTEST_ASSETS_DIR),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19)
 	go test ./pkg/... -coverprofile cover.out
 .PHONY: test
 


### PR DESCRIPTION
junit tests are failing for LSO CI so opening this PR to fix this. 
