### PR TITLE
Fix must-gather image references for 4.22

### DIFF
--- a/config/manifests/stable/image-references
+++ b/config/manifests/stable/image-references
@@ -18,4 +18,4 @@ spec:
   - name: local-storage-mustgather
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.21.0
+      name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -494,7 +494,7 @@ spec:
                       - name: MUSTGATHER_IMAGE
                         # This env. var is not used by the operator.
                         # It is here only to be matched by ART pipeline and added to related-images automatically.
-                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.21.0
+                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0
   customresourcedefinitions:
     owned:
       - displayName: Local Volume


### PR DESCRIPTION
## Summary
- Update `image-references`: must-gather entry from `v4.21.0` to `v4.22.0`
- Update CSV `MUSTGATHER_IMAGE` env var from `v4.21.0` to `v4.22.0`
- The stale `v4.21.0` references prevented doozer from correctly resolving and pinning the must-gather image during bundle rebase
- This caused Konflux Enterprise Contract verification failure (`olm.unpinned_references`), blocking the prepare-release-konflux pipeline

## Details
The CSV `operators.openshift.io/must-gather-image` annotation already referenced `v4.22.0`, but the `image-references` file and the `MUSTGATHER_IMAGE` env var in the CSV were still pointing to `v4.21.0`. Without consistent references, doozer couldn't pin the image to a digest, and EC rejected the unpinned tag reference.

## Test plan
- [ ] Verify bundle builds pass EC verification after this change