### PR TITLE
OCPBUGS-83305: record symlinkPath in LVDL

### DIFF
--- a/api/v1/localvolumedevicelink_types.go
+++ b/api/v1/localvolumedevicelink_types.go
@@ -95,6 +95,16 @@ type LocalVolumeDeviceLinkStatus struct {
 	// +listType=set
 	// +kubebuilder:validation:MaxItems=256
 	ValidLinkTargets []string `json:"validLinkTargets,omitempty"`
+	// persistentVolumeSymlinkPath is the symlink in /mnt/local-storage directory that points to
+	// the actual local device.
+	// This path is used by corresponding PersistentVolume (PV) object for all operations (e.g. mount).
+	// LSO creates and updates this symlink for the whole lifetime of the PV.
+	// This field is immutable once set, because the path in the corresponding
+	// PV object is immutable too.
+	// +optional
+	// +kubebuilder:validation:MaxLength=4096
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || oldSelf == ''",message="persistentVolumeSymlinkPath is immutable once set"
+	PersistentVolumeSymlinkPath string `json:"persistentVolumeSymlinkPath,omitempty"`
 	// filesystemUUID is the UUID of the filesystem found on the device (when available)
 	// +optional
 	// +kubebuilder:validation:MinLength=1

--- a/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
+++ b/config/manifests/stable/local.storage.openshift.io_localvolumedevicelinks.yaml
@@ -133,6 +133,19 @@ spec:
                 maxLength: 4096
                 minLength: 1
                 type: string
+              persistentVolumeSymlinkPath:
+                description: |-
+                  persistentVolumeSymlinkPath is the symlink in /mnt/local-storage directory that points to
+                  the actual local device.
+                  This path is used by corresponding PersistentVolume (PV) object for all operations (e.g. mount).
+                  LSO creates and updates this symlink for the whole lifetime of the PV.
+                  This field is immutable once set, because the path in the corresponding
+                  PV object is immutable too.
+                maxLength: 4096
+                type: string
+                x-kubernetes-validations:
+                - message: persistentVolumeSymlinkPath is immutable once set
+                  rule: self == oldSelf || oldSelf == ''
               preferredLinkTarget:
                 description: |-
                   preferredLinkTarget is the /dev/disk/by-id symlink for the device that the local storage

--- a/pkg/common/device_link_handler.go
+++ b/pkg/common/device_link_handler.go
@@ -129,7 +129,7 @@ func isNilOwnerObject(ownerObj runtime.Object) bool {
 	return value.Kind() == reflect.Ptr && value.IsNil()
 }
 
-func (dl *DeviceLinkHandler) ApplyStatus(ctx context.Context, pvName, namespace string, blockDevice internal.BlockDevice, ownerObj runtime.Object, currentSymlink string) (*v1.LocalVolumeDeviceLink, error) {
+func (dl *DeviceLinkHandler) ApplyStatus(ctx context.Context, pvName, namespace string, blockDevice internal.BlockDevice, ownerObj runtime.Object, currentSymlink, symlinkPath string) (*v1.LocalVolumeDeviceLink, error) {
 	devicePath, err := blockDevice.GetDevPath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get /dev path for %s: %w", blockDevice.Name, err)
@@ -152,7 +152,7 @@ func (dl *DeviceLinkHandler) ApplyStatus(ctx context.Context, pvName, namespace 
 	}
 
 	copyToUpdate := existing.DeepCopy()
-	copyToUpdate, err = dl.setStatusSymlinks(copyToUpdate, blockDevice, "", currentSymlink)
+	copyToUpdate, err = dl.setStatusSymlinks(copyToUpdate, blockDevice, "", currentSymlink, symlinkPath)
 	if err != nil {
 		klog.ErrorS(err, "error setting status symlinks")
 		return existing, err
@@ -180,7 +180,7 @@ func (dl *DeviceLinkHandler) ApplyStatus(ctx context.Context, pvName, namespace 
 	return copyToUpdate, err
 }
 
-func (dl *DeviceLinkHandler) setStatusSymlinks(lvdl *v1.LocalVolumeDeviceLink, blockDevice internal.BlockDevice, preferredLinkTarget, currentSymlink string) (*v1.LocalVolumeDeviceLink, error) {
+func (dl *DeviceLinkHandler) setStatusSymlinks(lvdl *v1.LocalVolumeDeviceLink, blockDevice internal.BlockDevice, preferredLinkTarget, currentSymlink, symlinkPath string) (*v1.LocalVolumeDeviceLink, error) {
 	devicePath, err := blockDevice.GetDevPath()
 	if err != nil {
 		return lvdl, fmt.Errorf("failed to get /dev path for %s: %w", blockDevice.Name, err)
@@ -215,6 +215,7 @@ func (dl *DeviceLinkHandler) setStatusSymlinks(lvdl *v1.LocalVolumeDeviceLink, b
 	lvdl.Status.PreferredLinkTarget = preferredLinkTarget
 	lvdl.Status.ValidLinkTargets = validLinks
 	lvdl.Status.FilesystemUUID = filesystemUUID
+	lvdl.Status.PersistentVolumeSymlinkPath = symlinkPath
 	return lvdl, nil
 }
 
@@ -266,7 +267,7 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 	if err != nil {
 		msg := fmt.Sprintf("couldn't find preferredLinkTarget for device %s with currentLink %s: %v", blockDevice.Name, currentTarget, err)
 		condition := getCondition("PreferredTargetNotFound", msg, operatorv1.ConditionTrue)
-		return dl.updateStatus(ctx, lvdl, condition, blockDevice, "", currentTarget)
+		return dl.updateStatus(ctx, lvdl, condition, blockDevice, "", currentTarget, symLinkPath)
 	}
 
 	klog.InfoS("RecreateSymlinkIfNeeded: symlink needs update",
@@ -277,7 +278,7 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 	if err != nil {
 		msg := fmt.Sprintf("failed to eval preferred target %s: %v", preferredTarget, err)
 		condition := getCondition("EvalSymlinkFailed", msg, operatorv1.ConditionTrue)
-		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget)
+		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget, symLinkPath)
 	}
 
 	symLinkDir := filepath.Dir(symLinkPath)
@@ -285,7 +286,7 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 	if err != nil {
 		msg := fmt.Sprintf("failed to list symlink dir %s: %v", symLinkDir, err)
 		condition := getCondition("ListDirFailed", msg, operatorv1.ConditionTrue)
-		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget)
+		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget, symLinkPath)
 	}
 	for _, entry := range entries {
 		if entry == symLinkPath {
@@ -298,7 +299,7 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 		if resolvedEntry == resolvedPreferred {
 			msg := fmt.Sprintf("preferred target %s is already claimed by symlink %s", preferredTarget, entry)
 			condition := getCondition("TargetAlreadyClaimed", msg, operatorv1.ConditionTrue)
-			return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget)
+			return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget, symLinkPath)
 		}
 	}
 
@@ -310,13 +311,13 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 	if err := os.Symlink(preferredTarget, tmpPath); err != nil {
 		msg := fmt.Sprintf("failed to create temp symlink %s -> %s: %v", tmpPath, preferredTarget, err)
 		condition := getCondition("TempSymlinkCreateFailed", msg, operatorv1.ConditionTrue)
-		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget)
+		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget, symLinkPath)
 	}
 
 	if err := os.Rename(tmpPath, symLinkPath); err != nil {
 		msg := fmt.Sprintf("failed to atomically replace symlink %s: %v", symLinkPath, err)
 		condition := getCondition("RenameSymlinkFailed", msg, operatorv1.ConditionTrue)
-		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget)
+		return dl.updateStatus(ctx, lvdl, condition, blockDevice, preferredTarget, currentTarget, symLinkPath)
 	}
 
 	klog.InfoS("RecreateSymlinkIfNeeded: successfully updated symlink",
@@ -326,7 +327,7 @@ func (dl *DeviceLinkHandler) RecreateSymlinkIfNeeded(ctx context.Context, lvdl *
 	copyToUpdate := lvdl.DeepCopy()
 
 	// After successful swap, the current symlink is now the preferred target
-	copyToUpdate, err = dl.setStatusSymlinks(copyToUpdate, blockDevice, preferredTarget, preferredTarget)
+	copyToUpdate, err = dl.setStatusSymlinks(copyToUpdate, blockDevice, preferredTarget, preferredTarget, symLinkPath)
 	if err != nil {
 		klog.ErrorS(err, "error refreshing lvdl status after symlink recreation", "lvdl", lvdl.Name)
 		return lvdl, fmt.Errorf("refreshing lvdl status after symlink recreation failed: %w", err)
@@ -382,9 +383,9 @@ func (dl *DeviceLinkHandler) resolveOwnerObjectFromLVDL(ctx context.Context, lvd
 	}
 }
 
-func (dl *DeviceLinkHandler) updateStatus(ctx context.Context, lvdl *v1.LocalVolumeDeviceLink, condition operatorv1.OperatorCondition, blockDevice internal.BlockDevice, preferredLinkTarget, currentSymlink string) (*v1.LocalVolumeDeviceLink, error) {
+func (dl *DeviceLinkHandler) updateStatus(ctx context.Context, lvdl *v1.LocalVolumeDeviceLink, condition operatorv1.OperatorCondition, blockDevice internal.BlockDevice, preferredLinkTarget, currentSymlink, symlinkPath string) (*v1.LocalVolumeDeviceLink, error) {
 	copyToUpdate := lvdl.DeepCopy()
-	copyToUpdate, err := dl.setStatusSymlinks(copyToUpdate, blockDevice, preferredLinkTarget, currentSymlink)
+	copyToUpdate, err := dl.setStatusSymlinks(copyToUpdate, blockDevice, preferredLinkTarget, currentSymlink, symlinkPath)
 	if err != nil {
 		klog.ErrorS(err, "error setting status symlinks")
 		return lvdl, fmt.Errorf("symlink recreation failed %s, setting conditions also failed with: %w", condition.Message, err)

--- a/pkg/common/device_link_handler_test.go
+++ b/pkg/common/device_link_handler_test.go
@@ -346,6 +346,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			assert.Equal(t, tc.expectedLVDL.Status.CurrentLinkTarget, fetched.Status.CurrentLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.PreferredLinkTarget, fetched.Status.PreferredLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.FilesystemUUID, fetched.Status.FilesystemUUID)
+			assert.Equal(t, tc.expectedLVDL.Status.PersistentVolumeSymlinkPath, fetched.Status.PersistentVolumeSymlinkPath)
 			assert.ElementsMatch(t, tc.expectedLVDL.Status.ValidLinkTargets, fetched.Status.ValidLinkTargets)
 			// Verify write-through cache was updated with the correct LVDL.
 			for _, target := range tc.expectedLVDL.Status.ValidLinkTargets {

--- a/pkg/common/device_link_handler_test.go
+++ b/pkg/common/device_link_handler_test.go
@@ -136,6 +136,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 		ownerObj       runtime.Object
 		existing       *v1.LocalVolumeDeviceLink
 		existingPV     *corev1.PersistentVolume
+		symlinkPath    string
 		globLinks      []string
 		filesystemUUID string
 		expectedLVDL   *v1.LocalVolumeDeviceLink
@@ -150,16 +151,50 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			ownerObj:       newLocalVolume("lv-statustest", "default", "11111111-aaaa-bbbb-cccc-111111111111"),
 			existing:       newLVDL("local-pv-statustest", "default", "local-pv-statustest"),
 			existingPV:     newPV("local-pv-statustest"),
+			symlinkPath:    "/mnt/local-storage/mysc/mylink",
 			globLinks:      []string{"/dev/disk/by-id/wwn-preferred", "/dev/disk/by-id/scsi-abcde"},
 			filesystemUUID: "550e8400-e29b-41d4-a716-446655440000",
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-statustest", Namespace: "default"},
 				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-statustest", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
+					CurrentLinkTarget:           "/dev/disk/by-id/wwn-current",
+					PreferredLinkTarget:         "/dev/disk/by-id/wwn-preferred",
+					FilesystemUUID:              "550e8400-e29b-41d4-a716-446655440000",
+					ValidLinkTargets:            []string{"/dev/disk/by-id/wwn-preferred", "/dev/disk/by-id/scsi-abcde"},
+					PersistentVolumeSymlinkPath: "/mnt/local-storage/mysc/mylink",
+				},
+			},
+		},
+		{
+			name:           "populates symlinkPath and UUID if it was missing",
+			pvName:         "local-pv-statustest",
+			namespace:      "default",
+			currentSymlink: "/dev/disk/by-id/wwn-current",
+			blockDevice:    internal.BlockDevice{KName: "sda", PathByID: "/dev/disk/by-id/wwn-preferred"},
+			ownerObj:       newLocalVolume("lv-statustest", "default", "11111111-aaaa-bbbb-cccc-111111111111"),
+			existing: &v1.LocalVolumeDeviceLink{
+				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-statustest", Namespace: "default"},
+				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-statustest", NodeName: testNodeName},
+				Status: v1.LocalVolumeDeviceLinkStatus{
 					CurrentLinkTarget:   "/dev/disk/by-id/wwn-current",
 					PreferredLinkTarget: "/dev/disk/by-id/wwn-preferred",
-					FilesystemUUID:      "550e8400-e29b-41d4-a716-446655440000",
 					ValidLinkTargets:    []string{"/dev/disk/by-id/wwn-preferred", "/dev/disk/by-id/scsi-abcde"},
+				},
+			},
+			existingPV:     newPV("local-pv-statustest"),
+			symlinkPath:    "/mnt/local-storage/mysc/mylink",
+			globLinks:      []string{"/dev/disk/by-id/wwn-preferred", "/dev/disk/by-id/scsi-abcde"},
+			filesystemUUID: "550e8400-e29b-41d4-a716-446655440000",
+			expectedLVDL: &v1.LocalVolumeDeviceLink{
+				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-statustest", Namespace: "default"},
+				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-statustest", NodeName: testNodeName},
+				Status: v1.LocalVolumeDeviceLinkStatus{
+					CurrentLinkTarget:           "/dev/disk/by-id/wwn-current",
+					PreferredLinkTarget:         "/dev/disk/by-id/wwn-preferred",
+					FilesystemUUID:              "550e8400-e29b-41d4-a716-446655440000",
+					ValidLinkTargets:            []string{"/dev/disk/by-id/wwn-preferred", "/dev/disk/by-id/scsi-abcde"},
+					PersistentVolumeSymlinkPath: "/mnt/local-storage/mysc/mylink",
 				},
 			},
 		},
@@ -172,14 +207,16 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			ownerObj:       newLocalVolume("lv-nolinks", "default", "22222222-aaaa-bbbb-cccc-222222222222"),
 			existing:       newLVDL("local-pv-nolinks", "default", "local-pv-nolinks"),
 			existingPV:     newPV("local-pv-nolinks"),
+			symlinkPath:    "/mnt/local-storage/mysc/mylink",
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-nolinks", Namespace: "default"},
 				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-nolinks", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
-					CurrentLinkTarget:   "/dev/sdb",
-					PreferredLinkTarget: "",
-					FilesystemUUID:      "",
-					ValidLinkTargets:    []string{},
+					CurrentLinkTarget:           "/dev/sdb",
+					PreferredLinkTarget:         "",
+					FilesystemUUID:              "",
+					ValidLinkTargets:            []string{},
+					PersistentVolumeSymlinkPath: "/mnt/local-storage/mysc/mylink",
 				},
 			},
 		},
@@ -192,26 +229,28 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			ownerObj:       newLocalVolume("lv-fullflow", "openshift-local-storage", "33333333-aaaa-bbbb-cccc-333333333333"),
 			existing:       newLVDL("local-pv-fullflow", "openshift-local-storage", "local-pv-fullflow"),
 			existingPV:     newPV("local-pv-fullflow"),
+			symlinkPath:    "/mnt/local-storage/mysc/mylink",
 			globLinks:      []string{"/dev/disk/by-id/wwn-preferred"},
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-fullflow", Namespace: "openshift-local-storage"},
 				Spec:       v1.LocalVolumeDeviceLinkSpec{PersistentVolumeName: "local-pv-fullflow", NodeName: testNodeName},
 				Status: v1.LocalVolumeDeviceLinkStatus{
-					CurrentLinkTarget:   "/dev/disk/by-id/scsi-current",
-					PreferredLinkTarget: "/dev/disk/by-id/wwn-preferred",
-					FilesystemUUID:      "",
-					ValidLinkTargets:    []string{"/dev/disk/by-id/wwn-preferred"},
+					CurrentLinkTarget:           "/dev/disk/by-id/scsi-current",
+					PreferredLinkTarget:         "/dev/disk/by-id/wwn-preferred",
+					FilesystemUUID:              "",
+					ValidLinkTargets:            []string{"/dev/disk/by-id/wwn-preferred"},
+					PersistentVolumeSymlinkPath: "/mnt/local-storage/mysc/mylink",
 				},
 			},
 		},
 		{
-			name:           "returns without updating when pv does not exist",
-			pvName:         "local-pv-missing",
-			namespace:      "default",
-			currentSymlink: "/dev/sdd",
-			blockDevice:    internal.BlockDevice{KName: "sdd"},
-			ownerObj:       newLocalVolume("lv-missing-pv", "default", "44444444-aaaa-bbbb-cccc-444444444444"),
-			existing:       newLVDL("local-pv-missing", "default", "local-pv-missing"),
+			name:        "returns without updating when pv does not exist",
+			pvName:      "local-pv-missing",
+			namespace:   "default",
+			symlinkPath: "/mnt/local-storage/mysc/mylink",
+			blockDevice: internal.BlockDevice{KName: "sdd"},
+			ownerObj:    newLocalVolume("lv-missing-pv", "default", "44444444-aaaa-bbbb-cccc-444444444444"),
+			existing:    newLVDL("local-pv-missing", "default", "local-pv-missing"),
 		},
 		{
 			name:           "creates lvdl during status update when pv exists and create was skipped",
@@ -221,6 +260,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			blockDevice:    internal.BlockDevice{KName: "sde"},
 			ownerObj:       newLocalVolume("lv-create-on-update", "default", "55555555-aaaa-bbbb-cccc-555555555555"),
 			existingPV:     newPV("local-pv-lvdl-missing"),
+			symlinkPath:    "/mnt/local-storage/mysc/mylink",
 			expectedLVDL: &v1.LocalVolumeDeviceLink{
 				ObjectMeta: metav1.ObjectMeta{Name: "local-pv-lvdl-missing", Namespace: "default"},
 				Spec: v1.LocalVolumeDeviceLinkSpec{
@@ -229,10 +269,11 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 					Policy:               v1.DeviceLinkPolicyNone,
 				},
 				Status: v1.LocalVolumeDeviceLinkStatus{
-					CurrentLinkTarget:   "/dev/sde",
-					PreferredLinkTarget: "",
-					FilesystemUUID:      "",
-					ValidLinkTargets:    []string{},
+					CurrentLinkTarget:           "/dev/sde",
+					PreferredLinkTarget:         "",
+					FilesystemUUID:              "",
+					ValidLinkTargets:            []string{},
+					PersistentVolumeSymlinkPath: "/mnt/local-storage/mysc/mylink",
 				},
 			},
 			verifyOwnerRef: true,
@@ -274,7 +315,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 				internal.CmdExecutor = fakeBlkidExecutor(tc.filesystemUUID)
 			}
 
-			updated, err := handler.ApplyStatus(context.TODO(), tc.pvName, tc.namespace, tc.blockDevice, tc.ownerObj, tc.currentSymlink)
+			updated, err := handler.ApplyStatus(context.TODO(), tc.pvName, tc.namespace, tc.blockDevice, tc.ownerObj, tc.currentSymlink, tc.symlinkPath)
 			if err != nil {
 				t.Fatalf("UpdateStatusAndPV returned unexpected error: %v", err)
 			}
@@ -291,6 +332,7 @@ func TestDeviceLinkHandler_UpdateStatusAndPV(t *testing.T) {
 			assert.Equal(t, tc.expectedLVDL.Status.CurrentLinkTarget, updated.Status.CurrentLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.PreferredLinkTarget, updated.Status.PreferredLinkTarget)
 			assert.Equal(t, tc.expectedLVDL.Status.FilesystemUUID, updated.Status.FilesystemUUID)
+			assert.Equal(t, tc.expectedLVDL.Status.PersistentVolumeSymlinkPath, updated.Status.PersistentVolumeSymlinkPath)
 			assert.ElementsMatch(t, tc.expectedLVDL.Status.ValidLinkTargets, updated.Status.ValidLinkTargets)
 
 			fetched := &v1.LocalVolumeDeviceLink{}

--- a/pkg/common/provisioner_utils.go
+++ b/pkg/common/provisioner_utils.go
@@ -285,7 +285,7 @@ func CreateLocalPV(ctx context.Context, args CreateLocalPVArgs) error {
 	// ApplyStatus creates/updates the LVDL after the PV exists. Skip it when
 	// RecreateSymlinkIfNeeded already updated the LVDL status above.
 	if !requiresSymlinkRecreation {
-		if _, err := deviceHandler.ApplyStatus(ctx, pvName, namespace, args.BlockDevice, obj, effectiveCurrentSource); err != nil {
+		if _, err := deviceHandler.ApplyStatus(ctx, pvName, namespace, args.BlockDevice, obj, effectiveCurrentSource, symLinkPath); err != nil {
 			return fmt.Errorf("error applying device link status: %w", err)
 		}
 	}

--- a/pkg/common/pv_link_cache.go
+++ b/pkg/common/pv_link_cache.go
@@ -70,7 +70,7 @@ func (c CurrentBlockDeviceInfo) GetSymlinkTargetPath(ctx context.Context, symlin
 		return "", fmt.Errorf("unexpected empty lvdl set for symlink %s", newSymlinkSourcePath)
 	}
 
-	lvdl, pv, err := c.getLVDLAndPV(ctx, client)
+	lvdl, symlinkPath, err := c.getLVDLAndSymlinkPath(ctx, client)
 	if err != nil {
 		return "", err
 	}
@@ -88,11 +88,7 @@ func (c CurrentBlockDeviceInfo) GetSymlinkTargetPath(ctx context.Context, symlin
 		return "", fmt.Errorf("currentSymlink %s still resolves to %s for %s", currentLinkTarget, resolvedCurrent, newSymlinkSourcePath)
 	}
 
-	if pv.Spec.Local == nil || pv.Spec.Local.Path == "" {
-		return "", fmt.Errorf("pv %s has empty local path", pv.Name)
-	}
-	currentTargetPath := pv.Spec.Local.Path
-	symlinkBaseName := filepath.Base(currentTargetPath)
+	symlinkBaseName := filepath.Base(symlinkPath)
 
 	if slices.Contains(validLinkTargets, newSymlinkSourcePath) {
 		return filepath.Join(symlinkDir, symlinkBaseName), nil
@@ -101,17 +97,39 @@ func (c CurrentBlockDeviceInfo) GetSymlinkTargetPath(ctx context.Context, symlin
 	return filepath.Join(symlinkDir, symlinkBaseName), nil
 }
 
-func (c CurrentBlockDeviceInfo) getLVDLAndPV(ctx context.Context, client client.Client) (*v1.LocalVolumeDeviceLink, *corev1.PersistentVolume, error) {
+// getLVDLAndSymlinkPath returns the LVDL and the symlink path for the current device.
+// The symlink path is either:
+// 1. The symlink path from LVDL status, if available.
+// 2. The symlink path from the PV, if not available in LVDL status.
+func (c CurrentBlockDeviceInfo) getLVDLAndSymlinkPath(ctx context.Context, client client.Client) (*v1.LocalVolumeDeviceLink, string, error) {
 	var lvdl *v1.LocalVolumeDeviceLink
 	for _, v := range c.lvdls {
 		lvdl = v
 		break
 	}
-	pv := &corev1.PersistentVolume{}
-	if err := client.Get(ctx, types.NamespacedName{Name: lvdl.Name}, pv); err != nil {
-		return lvdl, nil, fmt.Errorf("error getting associated pv object %s: %v", lvdl.Name, err)
+	if lvdl == nil {
+		// this should never happen, because the cache is populated with at least one LVDL.
+		return nil, "", fmt.Errorf("unexpected empty lvdl set for symlink")
 	}
-	return lvdl, pv, nil
+	// Prefer the symlinkPath from LVDL, it is available right away from the cache.
+	// It's set together with the path in PV when the PV is created and it's immutable afterwards.
+	// (Unless the LVDL was created before the symlinkPath field was added to LVDL and then it's set at the earliest opportunity).
+	if lvdl.Status.PersistentVolumeSymlinkPath != "" {
+		klog.V(4).Infof("found persistentVolumeSymlinkPath path %s from LVDL %s status", lvdl.Status.PersistentVolumeSymlinkPath, lvdl.Name)
+		return lvdl, lvdl.Status.PersistentVolumeSymlinkPath, nil
+	}
+	// if the symlink path is not set in LVDL, we need to read it from the PV.
+	pv := &corev1.PersistentVolume{}
+	if err := client.Get(ctx, types.NamespacedName{Name: lvdl.Spec.PersistentVolumeName}, pv); err != nil {
+		return lvdl, "", fmt.Errorf("error getting associated pv object %s: %v", lvdl.Name, err)
+	}
+	if pv.Spec.Local == nil || pv.Spec.Local.Path == "" {
+		return lvdl, "", fmt.Errorf("pv %s has empty local path", pv.Name)
+	}
+
+	symlinkPath := pv.Spec.Local.Path
+	klog.V(4).Infof("found symlink path %s from PV %s", symlinkPath, pv.Name)
+	return lvdl, symlinkPath, nil
 }
 
 func NewLocalVolumeDeviceLinkCache(client client.Client, mgr manager.Manager, localNodeName string) *LocalVolumeDeviceLinkCache {

--- a/pkg/common/pv_link_cache.go
+++ b/pkg/common/pv_link_cache.go
@@ -74,6 +74,11 @@ func (c CurrentBlockDeviceInfo) GetSymlinkTargetPath(ctx context.Context, symlin
 	if err != nil {
 		return "", err
 	}
+	discoveredSymlinkDir := filepath.Dir(symlinkPath)
+	if discoveredSymlinkDir != symlinkDir {
+		// A single device is used by multiple objects with different StorageClasses (= different symlinkDirs). That should never happen.
+		return "", fmt.Errorf("discovered symlink directory %s does not match expected symlink directory %s for device %s - is this device matched by multiple LocalVolumes / LocalVolumeSets?", discoveredSymlinkDir, symlinkDir, newSymlinkSourcePath)
+	}
 	currentLinkTarget := lvdl.Status.CurrentLinkTarget
 	validLinkTargets := lvdl.Status.ValidLinkTargets
 	policy := lvdl.Spec.Policy
@@ -88,13 +93,11 @@ func (c CurrentBlockDeviceInfo) GetSymlinkTargetPath(ctx context.Context, symlin
 		return "", fmt.Errorf("currentSymlink %s still resolves to %s for %s", currentLinkTarget, resolvedCurrent, newSymlinkSourcePath)
 	}
 
-	symlinkBaseName := filepath.Base(symlinkPath)
-
 	if slices.Contains(validLinkTargets, newSymlinkSourcePath) {
-		return filepath.Join(symlinkDir, symlinkBaseName), nil
+		return symlinkPath, nil
 	}
 	klog.Warningf("symlink source %s is not recorded in valid symlink target, but has stale PVs that use the device", newSymlinkSourcePath)
-	return filepath.Join(symlinkDir, symlinkBaseName), nil
+	return symlinkPath, nil
 }
 
 // getLVDLAndSymlinkPath returns the LVDL and the symlink path for the current device.

--- a/pkg/common/pv_link_cache_test.go
+++ b/pkg/common/pv_link_cache_test.go
@@ -154,7 +154,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Name: "pv-local"},
 					Spec: corev1.PersistentVolumeSpec{
 						PersistentVolumeSource: corev1.PersistentVolumeSource{
-							Local: &corev1.LocalVolumeSource{Path: "/mnt/local-storage/sc/from-pv-local"},
+							Local: &corev1.LocalVolumeSource{Path: "/mnt/local-storage/sc-a/from-pv-local"},
 						},
 					},
 				},
@@ -165,7 +165,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 			name: "prefers symlinkPath from LVDL when both LVDL and PV have one",
 			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
 				lvdl := newCacheLVDL("pv-local", cacheLocalNode, "/tmp/current-status", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
-				lvdl.Status.PersistentVolumeSymlinkPath = "/mnt/local-storage/sc/from-lvdl-status"
+				lvdl.Status.PersistentVolumeSymlinkPath = "/mnt/local-storage/sc-a/from-lvdl-status"
 				c.addOrUpdateLVDL(lvdl)
 				return c.localDeviceInfos[sourcePath], sourcePath
 			},
@@ -173,7 +173,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 				return "", os.ErrNotExist
 			},
 			apiObjects: []client.Object{
-				localPV("pv-local", "/mnt/local-storage/sc/from-pv-local"),
+				localPV("pv-local", "/mnt/local-storage/sc-a/from-pv-local"),
 			},
 			wantPath: filepath.Join(symlinkDir, "from-lvdl-status"),
 		},
@@ -221,6 +221,20 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 				csiPV("pv-csi", "example.com/csi", "volume-handle"),
 			},
 			wantErr: "pv pv-csi has empty local path",
+		},
+		{
+			name: "errors when LVDL symlinkPath is for a different storage class",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-empty-local", cacheLocalNode, "/tmp/empty-local", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = "/mnt/local-storage/sc-b/from-lvdl-status"
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{},
+			wantErr:    "does not match expected symlink directory",
 		},
 	}
 

--- a/pkg/common/pv_link_cache_test.go
+++ b/pkg/common/pv_link_cache_test.go
@@ -32,6 +32,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 		name            string
 		setup           func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string)
 		symlinkEvalFunc func(path string) (string, error)
+		apiObjects      []client.Object
 		wantPath        string
 		wantErr         string
 	}{
@@ -66,6 +67,9 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 				info := c.localDeviceInfos[sourcePath]
 				return info, sourcePath
 			},
+			apiObjects: []client.Object{
+				localPV("pv-none", "/mnt/local-storage/sc-a/current-none"),
+			},
 			wantErr: "found stale symlink link",
 		},
 		{
@@ -82,6 +86,9 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 				}
 				return "", os.ErrNotExist
 			},
+			apiObjects: []client.Object{
+				localPV("pv-resolves", "/mnt/local-storage/sc-a/current-resolves"),
+			},
 			wantErr: "currentSymlink /tmp/current-resolves still resolves",
 		},
 		{
@@ -94,6 +101,9 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 			},
 			symlinkEvalFunc: func(path string) (string, error) {
 				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{
+				localPV("pv-success", "/mnt/local-storage/sc-a/xxx"),
 			},
 			// old behavior derived basename from currentLinkTarget ("yyy"), but we must derive
 			// the final symlink name from the PV local path ("xxx").
@@ -109,7 +119,108 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 			symlinkEvalFunc: func(path string) (string, error) {
 				return "", os.ErrNotExist
 			},
+			apiObjects: []client.Object{
+				localPV("pv-invalid-target", "/mnt/local-storage/sc-a/current-invalid"),
+			},
 			wantPath: filepath.Join(symlinkDir, "current-invalid"),
+		},
+		{
+			name: "uses symlinkPath from LVDL status when available",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-status-symlink", cacheLocalNode, "/tmp/current-status", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = "/mnt/local-storage/sc-a/from-lvdl-status"
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			// pvObjectsForInfo would imply basename "current-status"; status SymlinkPath basename wins in getLVDLAndSymlinkPath.
+			wantPath: filepath.Join(symlinkDir, "from-lvdl-status"),
+		},
+		{
+			name: "uses symlinkPath from PV when LVDL has none",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-local", cacheLocalNode, "/tmp/current-status", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = ""
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{
+				&corev1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{Name: "pv-local"},
+					Spec: corev1.PersistentVolumeSpec{
+						PersistentVolumeSource: corev1.PersistentVolumeSource{
+							Local: &corev1.LocalVolumeSource{Path: "/mnt/local-storage/sc/from-pv-local"},
+						},
+					},
+				},
+			},
+			wantPath: filepath.Join(symlinkDir, "from-pv-local"),
+		},
+		{
+			name: "prefers symlinkPath from LVDL when both LVDL and PV have one",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-local", cacheLocalNode, "/tmp/current-status", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = "/mnt/local-storage/sc/from-lvdl-status"
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{
+				localPV("pv-local", "/mnt/local-storage/sc/from-pv-local"),
+			},
+			wantPath: filepath.Join(symlinkDir, "from-lvdl-status"),
+		},
+		{
+			name: "errors when LVDL symlinkPath is empty and associated PV is missing",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-missing", cacheLocalNode, "/tmp/missing", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = ""
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			wantErr: "error getting associated pv object pv-missing",
+		},
+		{
+			name: "errors when LVDL symlinkPath is empty and PV has empty local path",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-empty-local", cacheLocalNode, "/tmp/empty-local", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = ""
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{
+				localPV("pv-empty-local", ""),
+			},
+			wantErr: "pv pv-empty-local has empty local path",
+		},
+		{
+			name: "errors when LVDL symlinkPath is empty and PV has no Local volume source",
+			setup: func(t *testing.T, c *LocalVolumeDeviceLinkCache) (CurrentBlockDeviceInfo, string) {
+				lvdl := newCacheLVDL("pv-csi", cacheLocalNode, "/tmp/nil-local", v1api.DeviceLinkPolicyPreferredLinkTarget, sourcePath)
+				lvdl.Status.PersistentVolumeSymlinkPath = ""
+				c.addOrUpdateLVDL(lvdl)
+				return c.localDeviceInfos[sourcePath], sourcePath
+			},
+			symlinkEvalFunc: func(path string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			apiObjects: []client.Object{
+				csiPV("pv-csi", "example.com/csi", "volume-handle"),
+			},
+			wantErr: "pv pv-csi has empty local path",
 		},
 	}
 
@@ -130,7 +241,7 @@ func TestCurrentBlockDeviceInfoGetSymlinkTargetPath(t *testing.T) {
 
 			cache := NewLocalVolumeDeviceLinkCache(nil, nil, cacheLocalNode)
 			info, source := tc.setup(t, cache)
-			fakeClient := fakeClientForInfo(t, info)
+			fakeClient := fakeClientForObjects(t, tc.apiObjects...)
 
 			gotPath, err := info.GetSymlinkTargetPath(context.TODO(), symlinkDir, source, fakeClient)
 
@@ -382,25 +493,32 @@ func newCacheLVDL(name, nodeName, current string, policy v1api.DeviceLinkPolicy,
 	}
 }
 
-func fakeClientForInfo(t *testing.T, info CurrentBlockDeviceInfo) client.Client {
+// fakeClientWithObjects builds a fake client from an explicit object list.
+func fakeClientForObjects(t *testing.T, objects ...client.Object) client.Client {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	assert.NoError(t, corev1.AddToScheme(scheme))
-
-	objects := make([]client.Object, 0, len(info.lvdls))
-	for name, lvdl := range info.lvdls {
-		localPath := filepath.Join("/mnt/local-storage/sc-a", filepath.Base(lvdl.Status.CurrentLinkTarget))
-		if name == "pv-success" {
-			localPath = "/mnt/local-storage/sc-a/xxx"
-		}
-		objects = append(objects, &corev1.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{Name: name},
-			Spec: corev1.PersistentVolumeSpec{
-				PersistentVolumeSource: corev1.PersistentVolumeSource{
-					Local: &corev1.LocalVolumeSource{Path: localPath},
-				},
-			},
-		})
-	}
 	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func localPV(name, localPath string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				Local: &corev1.LocalVolumeSource{Path: localPath},
+			},
+		},
+	}
+}
+
+func csiPV(name, driver, handle string) *corev1.PersistentVolume {
+	return &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{Driver: driver, VolumeHandle: handle},
+			},
+		},
+	}
 }

--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -679,7 +679,7 @@ func (r *LocalVolumeReconciler) processRejectedDevicesForDeviceLinks(ctx context
 					klog.ErrorS(err, "failed to read current symlink target", "devicePath", symlinkPath)
 					continue
 				}
-				_, lvdlError = deviceHandler.ApplyStatus(ctx, lvdlName, r.runtimeConfig.Namespace, blockDevice, r.localVolume, currentLinkTarget)
+				_, lvdlError = deviceHandler.ApplyStatus(ctx, lvdlName, r.runtimeConfig.Namespace, blockDevice, r.localVolume, currentLinkTarget, symlinkPath)
 			}
 			if lvdlError != nil {
 				msg := fmt.Errorf("failed to process lvdl %w", lvdlError)

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -374,7 +374,7 @@ func (r *LocalVolumeSetReconciler) processRejectedDevicesForDeviceLinks(ctx cont
 				klog.ErrorS(err, "failed to read current symlink target", "devicePath", symlinkPath)
 				continue
 			}
-			_, lvdlError = deviceHandler.ApplyStatus(ctx, lvdlName, r.runtimeConfig.Namespace, blockDevice, lvset, currentLinkTarget)
+			_, lvdlError = deviceHandler.ApplyStatus(ctx, lvdlName, r.runtimeConfig.Namespace, blockDevice, lvset, currentLinkTarget, symlinkPath)
 		}
 
 		if lvdlError != nil {

--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -151,7 +151,7 @@ func eventuallyFindLVDLsForPVs(t *testing.T, f *framework.Framework, namespace s
 		for _, lvdl := range lvdlList.Items {
 			if ok := pvNameSet.Has(lvdl.Spec.PersistentVolumeName); ok {
 				// Wait until status fields are populated by the status update
-				if lvdl.Status.CurrentLinkTarget == "" || lvdl.Status.PreferredLinkTarget == "" {
+				if lvdl.Status.CurrentLinkTarget == "" || lvdl.Status.PreferredLinkTarget == "" || lvdl.Status.PersistentVolumeSymlinkPath == "" {
 					return false
 				}
 				foundLVDLs = append(foundLVDLs, lvdl)
@@ -344,8 +344,29 @@ func assertLVDLsContainTargetAndNodes(t *testing.T, lvdls []localv1.LocalVolumeD
 		matcher.Expect(lvdl.Status.ValidLinkTargets).To(gomega.ContainElement(expectedTarget),
 			"expected ValidLinkTargets for LVDL %q to contain %q", lvdl.Name, expectedTarget)
 		matcher.Expect(lvdl.Spec.NodeName).ToNot(gomega.BeEmpty(), "expected NodeName for LVDL %q", lvdl.Name)
+		matcher.Expect(lvdl.Status.PersistentVolumeSymlinkPath).ToNot(gomega.BeEmpty(), "expected PersistentVolumeSymlinkPath for LVDL %q", lvdl.Name)
 		foundNodeNames.Insert(lvdl.Spec.NodeName)
 	}
 	matcher.Expect(foundNodeNames.UnsortedList()).To(gomega.ConsistOf(expectedNodeNames),
 		"expected LVDL node names for target %q", expectedTarget)
+}
+
+// assertLVDLSymlinkPathMatchesPVs checks that each LVDL's status.symlinkPath matches the
+// corresponding PersistentVolume's spec.local.path (same as the on-disk symlink under /mnt/local-storage).
+func assertLVDLSymlinkPathMatchesPVs(t *testing.T, lvdls []localv1.LocalVolumeDeviceLink, pvs []corev1.PersistentVolume) {
+	matcher := gomega.NewWithT(t)
+	byName := make(map[string]corev1.PersistentVolume, len(pvs))
+	for _, pv := range pvs {
+		byName[pv.Name] = pv
+	}
+	for i := range lvdls {
+		lvdl := &lvdls[i]
+		pv, ok := byName[lvdl.Spec.PersistentVolumeName]
+		matcher.Expect(ok).To(gomega.BeTrue(), "missing PV %q for LVDL %q", lvdl.Spec.PersistentVolumeName, lvdl.Name)
+		matcher.Expect(lvdl.Status.PersistentVolumeSymlinkPath).ToNot(gomega.BeEmpty(), "expected PersistentVolumeSymlinkPath for LVDL %q", lvdl.Name)
+		if pv.Spec.Local != nil && pv.Spec.Local.Path != "" {
+			matcher.Expect(lvdl.Status.PersistentVolumeSymlinkPath).To(gomega.Equal(pv.Spec.Local.Path),
+				"LVDL %q status.symlinkPath should match PV %q spec.local.path", lvdl.Name, pv.Name)
+		}
+	}
 }

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -154,6 +154,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		sharedPVNames := []string{sharedPVs[0].Name}
 		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
 		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name})
+		assertLVDLSymlinkPathMatchesPVs(t, sharedLVDLs, sharedPVs)
 
 		matcher.Eventually(func() error {
 			t.Log("expanding shared localvolume reproducer to a second node")
@@ -183,6 +184,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		}
 		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
 		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name, nodeEnv[1].node.Name})
+		assertLVDLSymlinkPathMatchesPVs(t, sharedLVDLs, sharedPVs)
 
 		t.Log("cleaning up LocalVolume duplicate by-id reproducer before continuing with standard test flow")
 		cleanupLVAndWaitForOwnedPVsToDisappear(t, f, sharedLocalVolume)
@@ -250,6 +252,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 			matcher.Expect(lvdl.Status.PreferredLinkTarget).ToNot(gomega.BeEmpty(), "expected PreferredLinkTarget for LVDL %q", lvdl.Name)
 			matcher.Expect(lvdl.Status.ValidLinkTargets).ToNot(gomega.BeEmpty(), "expected ValidLinkTargets for LVDL %q", lvdl.Name)
 		}
+		assertLVDLSymlinkPathMatchesPVs(t, lvdls, pvs)
 
 		selectedPV := pvs[0]
 		currentSymlink := currentSymlinkForDisk(selectedDisk)
@@ -374,6 +377,10 @@ func verifyLVDLFilesystemUUIDForPVs(t *testing.T, f *framework.Framework, namesp
 			}
 			if lvdl.Status.FilesystemUUID == "" {
 				t.Logf("filesystemUUID not populated yet for LVDL %q / PV %q", lvdl.Name, lvdl.Spec.PersistentVolumeName)
+				return false
+			}
+			if lvdl.Status.PersistentVolumeSymlinkPath == "" {
+				t.Logf("SymlinkPath not populated yet for LVDL %q / PV %q", lvdl.Name, lvdl.Spec.PersistentVolumeName)
 				return false
 			}
 			uuidFoundCount++

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -200,6 +200,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		sharedPVNames := []string{sharedPVs[0].Name}
 		sharedLVDLs := eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
 		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name})
+		assertLVDLSymlinkPathMatchesPVs(t, sharedLVDLs, sharedPVs)
 
 		matcher.Eventually(func() error {
 			t.Log("expanding shared localvolumeset reproducer to a second node")
@@ -222,6 +223,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		}
 		sharedLVDLs = eventuallyFindLVDLsForPVs(t, f, namespace, sharedPVNames)
 		assertLVDLsContainTargetAndNodes(t, sharedLVDLs, sharedScsi8Link, []string{nodeEnv[0].node.Name, nodeEnv[1].node.Name})
+		assertLVDLSymlinkPathMatchesPVs(t, sharedLVDLs, sharedPVs)
 
 		t.Log("cleaning up LocalVolumeSet duplicate by-id reproducer before continuing with standard test flow")
 		eventuallyDelete(t, false, sharedLVSet)
@@ -449,6 +451,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 			matcher.Expect(lvdl.Status.PreferredLinkTarget).ToNot(gomega.BeEmpty(), "expected PreferredLinkTarget for LVDL %q", lvdl.Name)
 			matcher.Expect(lvdl.Status.ValidLinkTargets).ToNot(gomega.BeEmpty(), "expected ValidLinkTargets for LVDL %q", lvdl.Name)
 		}
+		assertLVDLSymlinkPathMatchesPVs(t, fsLVDLs, fsPVs)
 
 		selectedFSPV := fsPVs[0]
 		currentSymlink := findCurrentSymlinkForPV(t, nodeEnv, &selectedFSPV)

--- a/test/e2e/symlink_check.go
+++ b/test/e2e/symlink_check.go
@@ -319,6 +319,8 @@ func verifyMultiStepPreferredLinkReconciliation(
 			"step %d: LVDL PreferredLinkTarget after PV recreation", i+1)
 		matcher.Expect(lvdl.Spec.Policy).To(gomega.Equal(localv1.DeviceLinkPolicyPreferredLinkTarget),
 			"step %d: LVDL policy must remain PreferredLinkTarget after PV recreation", i+1)
+		matcher.Expect(lvdl.Status.PersistentVolumeSymlinkPath).To(gomega.Equal(pv.Spec.Local.Path),
+			"step %d: LVDL SymlinkPath after PV recreation should match PV local path", i+1)
 		// The policy is PreferredLinkTarget + the symlink has been fixed.
 		// All LVDL metrics should be removed at this point.
 		waitForMetric(t, prometheusClient, fmt.Sprintf("lso_device_link_mismatch{name=\"%s\"}", lvdl.Name), 0)
@@ -391,6 +393,8 @@ func verifySymlinkFallbackOnDisappearingLink(
 		"LVDL PreferredLinkTarget after fallback and PV recreation")
 	matcher.Expect(lvdls[0].Spec.Policy).To(gomega.Equal(localv1.DeviceLinkPolicyPreferredLinkTarget),
 		"LVDL policy must remain PreferredLinkTarget after fallback")
+	matcher.Expect(lvdls[0].Status.PersistentVolumeSymlinkPath).To(gomega.Equal(pv.Spec.Local.Path),
+		"LVDL SymlinkPath after fallback and PV recreation should match PV local path")
 
 	return pv
 }


### PR DESCRIPTION
For cases where PV does not exist, for example during PV re-creation after PVC was deleted, the diskmaker needs a way to discover `symlinkPath` of a device targeted by LocalVolumeSet to be able to re-create the PV. The current way of discovering the `symlinkPath` from PV won't work in this case.

Add a new field to LocalVolumeDeviceLink `status`. It is immutable, because the same `symlinkPath` is already used in PV `spec.local.path`, which is immutable already.

And since it's immutable, it does not really matter if the diskmaker loads the value from the PV first and if it's missing, them from LVDL status or the other way around - both ways should return the same result. (Unless the field has been just introduced in LVDL and is empty.) So let's read it from LVDL first and fall back to PV only if it's missing there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new optional status field to record the PersistentVolume symlink path (string, max 4096, immutable once set).

* **Behavior Changes**
  * Status symlink path is now preferred when resolving symlink targets and is persisted in status; resolution more explicitly handles missing/invalid PVs.

* **Tests**
  * Unit and e2e tests expanded to validate propagation, precedence, immutability, and error scenarios for the symlink path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->