### PR TITLE
OCPBUGS-79680: Emit correct metrics for orphan volumes.

### DIFF
--- a/pkg/diskmaker/controllers/lv/reconcile.go
+++ b/pkg/diskmaker/controllers/lv/reconcile.go
@@ -385,13 +385,14 @@ func (r *LocalVolumeReconciler) Reconcile(ctx context.Context, request ctrl.Requ
 		r.processValidDevices(ctx, validBlockDevices, diskConfig, mountPointMap)
 	}
 
+	r.updateOrphanedSymlinkMetrics(blockDevices, diskConfig)
+
 	return ctrl.Result{Requeue: true, RequeueAfter: r.effectiveRequeueTime}, nil
 }
 
 func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDevices []internal.BlockDevice, diskConfig *DiskConfig, mountPointMap sets.Set[string]) {
 	for storageClass, disks := range diskConfig.Disks {
 		var totalProvisionedPVs int
-		var blockDeviceList []internal.BlockDevice
 
 		devicePaths := disks.DevicePaths
 		forceWipe := disks.ForceWipeDevicesAndDestroyAllData
@@ -408,13 +409,31 @@ func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDe
 				continue
 			}
 
-			blockDeviceList = append(blockDeviceList, deviceLocation.BlockDevice)
 			if r.provisionValidDevice(ctx, storageClass, symLinkDirPath, devicePath, deviceLocation, mountPointMap) {
 				totalProvisionedPVs += 1
 			}
 		}
 		localmetrics.SetLVProvisionedPVMetric(nodeName, storageClass, totalProvisionedPVs)
-		orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDirPath, blockDeviceList)
+	}
+}
+
+// updateOrphanedSymlinkMetrics resolves each spec devicePath against the full
+// (unfiltered) block device list so that in-use devices with bind mounts or
+// children are still recognised as spec-managed and not counted as orphaned.
+func (r *LocalVolumeReconciler) updateOrphanedSymlinkMetrics(allBlockDevices []internal.BlockDevice, diskConfig *DiskConfig) {
+	for storageClass, disks := range diskConfig.Disks {
+		var specDevices []internal.BlockDevice
+		symLinkDirPath := path.Join(r.symlinkLocation, storageClass)
+
+		for _, devicePath := range disks.DevicePaths {
+			deviceLocation, matched, err := r.resolveValidDeviceLocation(devicePath, false, allBlockDevices)
+			if err != nil || !matched {
+				continue
+			}
+			specDevices = append(specDevices, deviceLocation.BlockDevice)
+		}
+
+		orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDirPath, specDevices)
 		if err != nil {
 			klog.ErrorS(err, "failed to get orphaned symlink devices in current reconcile")
 		}
@@ -424,7 +443,6 @@ func (r *LocalVolumeReconciler) processValidDevices(ctx context.Context, validDe
 				"scName", storageClass, "orphanedDevices", orphanSymlinkDevices)
 		}
 
-		// update metrics for orphaned symlink devices
 		localmetrics.SetLVOrphanedSymlinksMetric(nodeName, storageClass, len(orphanSymlinkDevices))
 	}
 }

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -1768,7 +1768,11 @@ func TestUpdateOrphanedSymlinkMetrics(t *testing.T) {
 
 			diskmakertest.WithInternalMocks(t, func() {
 				internal.FilePathEvalSymLinks = func(path string) (string, error) {
-					return filepath.EvalSymlinks(path)
+					target, err := os.Readlink(path)
+					if err != nil {
+						return filepath.EvalSymlinks(path)
+					}
+					return target, nil
 				}
 				internal.FilePathGlob = filepath.Glob
 			})

--- a/pkg/diskmaker/controllers/lv/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lv/reconcile_test.go
@@ -1690,3 +1690,94 @@ func TestUpdateMissingDevicePathMetrics(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateOrphanedSymlinkMetrics(t *testing.T) {
+	const testNodeName = "node-orphan-test"
+
+	tests := []struct {
+		name            string
+		devicePaths     []string
+		allBlockDevices []internal.BlockDevice
+		// symlinks maps basename -> resolved device name (e.g. "sda")
+		symlinks        map[string]string
+		evalSymlinkFn   func(string) (string, error)
+		expectedOrphans float64
+	}{
+		{
+			name:        "in-use device with bind mounts is not counted as orphan",
+			devicePaths: []string{"/dev/sda"},
+			allBlockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda"},
+			},
+			symlinks: map[string]string{"sda": "sda"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return "/dev/sda", nil
+			},
+			expectedOrphans: 0,
+		},
+		{
+			name:        "device removed from spec is counted as orphan",
+			devicePaths: []string{"/dev/sdb"},
+			allBlockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda"},
+				{KName: "sdb", Name: "sdb"},
+			},
+			symlinks: map[string]string{"sda": "sda", "sdb": "sdb"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return path, nil
+			},
+			expectedOrphans: 1,
+		},
+		{
+			name:        "no orphans when all symlinks match spec",
+			devicePaths: []string{"/dev/sda", "/dev/sdb"},
+			allBlockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda"},
+				{KName: "sdb", Name: "sdb"},
+			},
+			symlinks: map[string]string{"sda": "sda", "sdb": "sdb"},
+			evalSymlinkFn: func(path string) (string, error) {
+				return path, nil
+			},
+			expectedOrphans: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpRoot := diskmakertest.TempDir(t, "orphan-metrics-")
+			scDir := filepath.Join(tmpRoot, storageClassName)
+			assert.NoError(t, os.MkdirAll(scDir, 0755))
+
+			for name, target := range tc.symlinks {
+				assert.NoError(t, os.Symlink("/dev/"+target, filepath.Join(scDir, name)))
+			}
+
+			d, _ := getFakeDiskMaker(t, tmpRoot)
+			d.fsInterface = stubFileSystemInterface{evalFunc: tc.evalSymlinkFn}
+
+			diskConfig := &DiskConfig{
+				Disks: map[string]*Disks{
+					storageClassName: {DevicePaths: tc.devicePaths},
+				},
+			}
+
+			origNodeName := nodeName
+			nodeName = testNodeName
+			t.Cleanup(func() { nodeName = origNodeName })
+
+			diskmakertest.WithInternalMocks(t, func() {
+				internal.FilePathEvalSymLinks = func(path string) (string, error) {
+					return filepath.EvalSymlinks(path)
+				}
+				internal.FilePathGlob = filepath.Glob
+			})
+
+			d.updateOrphanedSymlinkMetrics(tc.allBlockDevices, diskConfig)
+
+			pb := &dto.Metric{}
+			assert.NoError(t, localmetrics.LVOrphanedSymlinksGauge(testNodeName, storageClassName).Write(pb))
+			assert.Equal(t, tc.expectedOrphans, pb.GetGauge().GetValue())
+		})
+	}
+}

--- a/pkg/diskmaker/controllers/lvset/device_age_test.go
+++ b/pkg/diskmaker/controllers/lvset/device_age_test.go
@@ -36,6 +36,7 @@ func TestDeviceAge(t *testing.T) {
 		exclusionMap = oldExclusionMap
 	}()
 
+	lvset := &localv1alpha1.LocalVolumeSet{}
 	r, tc := newFakeLocalVolumeSetReconciler(t)
 
 	blockDevices := make([]internal.BlockDevice, 0)
@@ -70,7 +71,7 @@ func TestDeviceAge(t *testing.T) {
 			blockDevices = append(blockDevices, internal.BlockDevice{KName: fmt.Sprintf("dev-%d", len(blockDevices))})
 		}
 
-		validDevices, delayedDevices, _ := r.getValidDevices(nil, blockDevices)
+		validDevices, delayedDevices, _ := r.getValidDevices(lvset, blockDevices)
 		assert.Lenf(t, validDevices, expectedValid[run], "validDevices")
 		assert.Lenf(t, delayedDevices, len(blockDevices)-expectedValid[run], "delayedDevices")
 

--- a/pkg/diskmaker/controllers/lvset/device_age_test.go
+++ b/pkg/diskmaker/controllers/lvset/device_age_test.go
@@ -20,8 +20,8 @@ func (f *fakeClock) getCurrentTime() time.Time {
 
 func TestDeviceAge(t *testing.T) {
 	// empty the filters and matchers
-	oldFilterMap := FilterMap
-	FilterMap = make(map[string]func(internal.BlockDevice, *localv1alpha1.DeviceInclusionSpec) (bool, error), 0)
+	oldFilterMap := DefaultFilterMap
+	DefaultFilterMap = make(map[string]func(internal.BlockDevice, *localv1alpha1.DeviceInclusionSpec) (bool, error), 0)
 
 	oldMatcherMap := matcherMap
 	matcherMap = make(map[string]func(internal.BlockDevice, *localv1alpha1.DeviceInclusionSpec) (bool, error), 0)
@@ -31,7 +31,7 @@ func TestDeviceAge(t *testing.T) {
 
 	// reset the filters and matchers
 	defer func() {
-		FilterMap = oldFilterMap
+		DefaultFilterMap = oldFilterMap
 		matcherMap = oldMatcherMap
 		exclusionMap = oldExclusionMap
 	}()

--- a/pkg/diskmaker/controllers/lvset/matcher.go
+++ b/pkg/diskmaker/controllers/lvset/matcher.go
@@ -41,7 +41,7 @@ var defaultMinSize = resource.MustParse("1Gi")
 // These are passed the localv1alpha1.DeviceInclusionSpec to make testing easier,
 // but they aren't expected to use it
 // they verify that the device itself is good to use
-var FilterMap = map[string]func(internal.BlockDevice, *localv1alpha1.DeviceInclusionSpec) (bool, error){
+var DefaultFilterMap = map[string]func(internal.BlockDevice, *localv1alpha1.DeviceInclusionSpec) (bool, error){
 	notReadOnly: func(dev internal.BlockDevice, spec *localv1alpha1.DeviceInclusionSpec) (bool, error) {
 		readOnly, err := dev.GetReadOnly()
 		return !readOnly, err

--- a/pkg/diskmaker/controllers/lvset/matcher_test.go
+++ b/pkg/diskmaker/controllers/lvset/matcher_test.go
@@ -19,7 +19,7 @@ const (
 // test filters
 
 func TestNotReadOnly(t *testing.T) {
-	matcherMap := FilterMap
+	matcherMap := DefaultFilterMap
 	matcher := notReadOnly
 	results := []knownMatcherResult{
 		// true, no error
@@ -65,7 +65,7 @@ func TestNotReadOnly(t *testing.T) {
 }
 
 func TestNotRemovable(t *testing.T) {
-	matcherMap := FilterMap
+	matcherMap := DefaultFilterMap
 	matcher := notRemovable
 	results := []knownMatcherResult{
 		// true, no error
@@ -111,7 +111,7 @@ func TestNotRemovable(t *testing.T) {
 }
 
 func TestNotSuspended(t *testing.T) {
-	matcherMap := FilterMap
+	matcherMap := DefaultFilterMap
 	matcher := notSuspended
 	results := []knownMatcherResult{
 		// true
@@ -140,7 +140,7 @@ func TestNotSuspended(t *testing.T) {
 	assertAll(t, results)
 }
 func TestNoBiosBootInPartLabel(t *testing.T) {
-	matcherMap := FilterMap
+	matcherMap := DefaultFilterMap
 	matcher := noBiosBootInPartLabel
 	results := []knownMatcherResult{
 		// true
@@ -200,7 +200,7 @@ func TestNoBiosBootInPartLabel(t *testing.T) {
 }
 
 func TestNoFilesystemSignature(t *testing.T) {
-	matcherMap := FilterMap
+	matcherMap := DefaultFilterMap
 	matcher := noFilesystemSignature
 	results := []knownMatcherResult{
 		// true

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -307,7 +307,8 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 	// update metrics for total persistent volumes provisioned
 	localmetrics.SetLVSProvisionedPVMetric(nodeName, storageClassName, totalProvisionedPVs)
 
-	orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDir, validDevices)
+	specMatchedDevices := getSpecMatchedDevices(lvset, blockDevices)
+	orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDir, specMatchedDevices)
 	if err != nil {
 		klog.ErrorS(err, "failed to get orphaned symlink devices in current reconcile")
 	}
@@ -500,6 +501,47 @@ DeviceLoop:
 
 	}
 	return validDevices, delayedDevices, rejectedDevices
+}
+
+// getSpecMatchedDevices returns devices that match the LVSet's inclusion and
+// exclusion spec criteria, ignoring provisioning-eligibility filters (such as
+// filesystem signature, exclusive access, bind mounts). This broader list is
+// used for orphan detection so that already-provisioned devices are not
+// incorrectly counted as orphaned.
+func getSpecMatchedDevices(
+	lvset *localv1alpha1.LocalVolumeSet,
+	blockDevices []internal.BlockDevice,
+) []internal.BlockDevice {
+	matched := make([]internal.BlockDevice, 0)
+DeviceLoop:
+	for _, blockDevice := range blockDevices {
+		for name, matcher := range matcherMap {
+			valid, err := matcher(blockDevice, lvset.Spec.DeviceInclusionSpec)
+			if err != nil {
+				klog.ErrorS(err, "spec match error", "device",
+					blockDevice.Name, "matcher", name)
+				continue DeviceLoop
+			}
+			if !valid {
+				continue DeviceLoop
+			}
+		}
+
+		for name, excluder := range exclusionMap {
+			valid, err := excluder(blockDevice, lvset.Spec.DeviceExclusionSpec)
+			if err != nil {
+				klog.ErrorS(err, "spec exclusion error", "device",
+					blockDevice.Name, "excluder", name)
+				continue DeviceLoop
+			}
+			if !valid {
+				continue DeviceLoop
+			}
+		}
+
+		matched = append(matched, blockDevice)
+	}
+	return matched
 }
 
 // getAlreadySymlinked returns:

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -309,6 +309,7 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 
 	specMatchedDevices := getSpecMatchedDevices(lvset, blockDevices)
 	orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDir, specMatchedDevices)
+
 	if err != nil {
 		klog.ErrorS(err, "failed to get orphaned symlink devices in current reconcile")
 	}
@@ -432,7 +433,7 @@ DeviceLoop:
 		// store device in deviceAgeMap
 		r.deviceAgeMap.storeDeviceAge(blockDevice.KName)
 
-		for name, filter := range FilterMap {
+		for name, filter := range DefaultFilterMap {
 			var valid bool
 			var err error
 			valid, err = filter(blockDevice, nil)

--- a/pkg/diskmaker/controllers/lvset/reconcile.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
@@ -259,7 +260,7 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 	}
 
 	// find disks that match lvset filters and matchers
-	validDevices, delayedDevices, rejectedDevices := r.getValidDevices(lvset, blockDevices)
+	validDevices, delayedDevices, rejectedButSpecMatchedDevices := r.getValidDevices(lvset, blockDevices)
 
 	// update metrics for unmatched disks
 	localmetrics.SetLVSUnmatchedDiskMetric(nodeName, storageClassName, len(blockDevices)-len(validDevices))
@@ -307,7 +308,7 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 	// update metrics for total persistent volumes provisioned
 	localmetrics.SetLVSProvisionedPVMetric(nodeName, storageClassName, totalProvisionedPVs)
 
-	specMatchedDevices := getSpecMatchedDevices(lvset, blockDevices)
+	specMatchedDevices := slices.Concat(validDevices, delayedDevices, rejectedButSpecMatchedDevices)
 	orphanSymlinkDevices, err := internal.GetOrphanedSymlinks(symLinkDir, specMatchedDevices)
 
 	if err != nil {
@@ -327,7 +328,7 @@ func (r *LocalVolumeSetReconciler) Reconcile(ctx context.Context, request ctrl.R
 			"paths", noMatch, "directory", symLinkDir)
 	}
 
-	r.processRejectedDevicesForDeviceLinks(ctx, lvset, rejectedDevices, symLinkDir, storageClassName)
+	r.processRejectedDevicesForDeviceLinks(ctx, lvset, rejectedButSpecMatchedDevices, symLinkDir, storageClassName)
 
 	// shorten the requeueTime if there are delayed devices
 	if len(delayedDevices) > 1 && requeueTime == defaultRequeueTime {
@@ -415,10 +416,50 @@ func (r *LocalVolumeSetReconciler) syncCaches() error {
 	return nil
 }
 
-// runs filters and matchers on the blockDeviceList and returns valid devices
-// and devices that are not considered old enough to be valid yet
-// i.e. if the device is younger than deviceMinAge
-// if the waitingDevices list is nonempty, the operator should requeueue
+func matchesDeviceSpec(
+	blockDevice internal.BlockDevice,
+	inclusionSpec *localv1alpha1.DeviceInclusionSpec,
+	exclusionSpec *localv1alpha1.DeviceExclusionSpec,
+) bool {
+	for name, matcher := range matcherMap {
+		valid, err := matcher(blockDevice, inclusionSpec)
+		if err != nil {
+			klog.ErrorS(err, "spec match error", "device",
+				blockDevice.Name, "matcher", name)
+			return false
+		}
+		if !valid {
+			klog.InfoS("spec match negative", "device",
+				blockDevice.Name, "matcher", name)
+			return false
+		}
+	}
+
+	for name, excluder := range exclusionMap {
+		valid, err := excluder(blockDevice, exclusionSpec)
+		if err != nil {
+			klog.ErrorS(err, "spec exclusion error", "device",
+				blockDevice.Name, "excluder", name)
+			return false
+		}
+		if !valid {
+			klog.InfoS("spec exclusion match", "device",
+				blockDevice.Name, "excluder", name)
+			return false
+		}
+	}
+	return true
+}
+
+// getValidDevices runs spec matchers/excluders, then provisioning-eligibility
+// filters on the blockDeviceList and returns three lists:
+//   - validDevices: devices that passed all checks and are ready to provision
+//   - delayedDevices: devices that matched spec and passed filters but are
+//     younger than deviceMinAge
+//   - rejectedDevices: devices that matched spec but failed provisioning filters
+//
+// The union of all three lists represents all spec-matched devices, which is
+// used for orphan detection.
 func (r *LocalVolumeSetReconciler) getValidDevices(
 	lvset *localv1alpha1.LocalVolumeSet,
 	blockDevices []internal.BlockDevice,
@@ -426,13 +467,19 @@ func (r *LocalVolumeSetReconciler) getValidDevices(
 	validDevices := make([]internal.BlockDevice, 0)
 	delayedDevices := make([]internal.BlockDevice, 0)
 	rejectedDevices := make([]internal.BlockDevice, 0)
-	// get valid devices
+
 DeviceLoop:
 	for _, blockDevice := range blockDevices {
+		if !matchesDeviceSpec(blockDevice, lvset.Spec.DeviceInclusionSpec, lvset.Spec.DeviceExclusionSpec) {
+			continue DeviceLoop
+		}
 
 		// store device in deviceAgeMap
 		r.deviceAgeMap.storeDeviceAge(blockDevice.KName)
 
+		// DefaultFilterMap is a map of filters which can filter out devices with a known set of
+		// filters that is hardcoded in LSO. Such as - device in-use, has file system or has children
+		// mount points.
 		for name, filter := range DefaultFilterMap {
 			var valid bool
 			var err error
@@ -440,7 +487,7 @@ DeviceLoop:
 			if err != nil {
 				klog.ErrorS(err, "filter error", "device",
 					blockDevice.Name, "filter", name)
-				valid = false
+				rejectedDevices = append(rejectedDevices, blockDevice)
 				continue DeviceLoop
 			} else if !valid {
 				klog.InfoS("filter negative", "device", blockDevice.Name, "filter", name)
@@ -455,7 +502,6 @@ DeviceLoop:
 		// skip devices younger than deviceMinAge
 		if !isOldEnough {
 			delayedDevices = append(delayedDevices, blockDevice)
-			// record DiscoveredDevice event
 			if lvset != nil {
 				r.eventReporter.Report(
 					lvset,
@@ -469,80 +515,10 @@ DeviceLoop:
 			continue DeviceLoop
 		}
 
-		for name, matcher := range matcherMap {
-			valid, err := matcher(blockDevice, lvset.Spec.DeviceInclusionSpec)
-			if err != nil {
-				klog.ErrorS(err, "match error", "device",
-					blockDevice.Name, "filter", name)
-				valid = false
-				continue DeviceLoop
-			} else if !valid {
-				klog.InfoS("match negative", "device",
-					blockDevice.Name, "filter", name)
-				continue DeviceLoop
-			}
-		}
-
-		for name, excluder := range exclusionMap {
-			valid, err := excluder(blockDevice, lvset.Spec.DeviceExclusionSpec)
-			if err != nil {
-				klog.ErrorS(err, "exclusion error", "device",
-					blockDevice.Name, "filter", name)
-				valid = false
-				continue DeviceLoop
-			} else if !valid {
-				klog.InfoS("exclusion match", "device",
-					blockDevice.Name, "filter", name)
-				continue DeviceLoop
-			}
-		}
 		klog.InfoS("matched disk", "device", blockDevice.Name)
-		// handle valid disk
 		validDevices = append(validDevices, blockDevice)
-
 	}
 	return validDevices, delayedDevices, rejectedDevices
-}
-
-// getSpecMatchedDevices returns devices that match the LVSet's inclusion and
-// exclusion spec criteria, ignoring provisioning-eligibility filters (such as
-// filesystem signature, exclusive access, bind mounts). This broader list is
-// used for orphan detection so that already-provisioned devices are not
-// incorrectly counted as orphaned.
-func getSpecMatchedDevices(
-	lvset *localv1alpha1.LocalVolumeSet,
-	blockDevices []internal.BlockDevice,
-) []internal.BlockDevice {
-	matched := make([]internal.BlockDevice, 0)
-DeviceLoop:
-	for _, blockDevice := range blockDevices {
-		for name, matcher := range matcherMap {
-			valid, err := matcher(blockDevice, lvset.Spec.DeviceInclusionSpec)
-			if err != nil {
-				klog.ErrorS(err, "spec match error", "device",
-					blockDevice.Name, "matcher", name)
-				continue DeviceLoop
-			}
-			if !valid {
-				continue DeviceLoop
-			}
-		}
-
-		for name, excluder := range exclusionMap {
-			valid, err := excluder(blockDevice, lvset.Spec.DeviceExclusionSpec)
-			if err != nil {
-				klog.ErrorS(err, "spec exclusion error", "device",
-					blockDevice.Name, "excluder", name)
-				continue DeviceLoop
-			}
-			if !valid {
-				continue DeviceLoop
-			}
-		}
-
-		matched = append(matched, blockDevice)
-	}
-	return matched
 }
 
 // getAlreadySymlinked returns:

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -18,6 +18,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -754,6 +755,84 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 				return
 			}
 			assert.Empty(t, fetched.Status.Conditions)
+		})
+	}
+}
+
+func TestGetSpecMatchedDevices(t *testing.T) {
+	tenGi := "10737418240"
+	hundredGi := "107374182400"
+	minSize := resource.MustParse("5Gi")
+	maxSize := resource.MustParse("50Gi")
+
+	testCases := []struct {
+		name           string
+		blockDevices   []internal.BlockDevice
+		inclusionSpec  *v1alphav1api.DeviceInclusionSpec
+		exclusionSpec  *v1alphav1api.DeviceExclusionSpec
+		expectedKNames []string
+	}{
+		{
+			name: "includes device with filesystem (in-use) that matches spec",
+			blockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
+			},
+			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectedKNames: []string{"sda"},
+		},
+		{
+			name: "includes device without filesystem that matches spec",
+			blockDevices: []internal.BlockDevice{
+				{KName: "sdb", Name: "sdb", Size: tenGi, Type: "disk", FSType: ""},
+			},
+			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectedKNames: []string{"sdb"},
+		},
+		{
+			name: "excludes device outside size range",
+			blockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
+				{KName: "sdb", Name: "sdb", Size: hundredGi, Type: "disk", FSType: ""},
+			},
+			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectedKNames: []string{"sda"},
+		},
+		{
+			name: "excludes device by name filter",
+			blockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: ""},
+				{KName: "nvme0n1", Name: "nvme0n1", Size: tenGi, Type: "disk", FSType: ""},
+			},
+			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			exclusionSpec:  &v1alphav1api.DeviceExclusionSpec{DeviceNameFilter: []string{"nvme*"}},
+			expectedKNames: []string{"sda"},
+		},
+		{
+			name: "includes multiple in-use devices matching spec",
+			blockDevices: []internal.BlockDevice{
+				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
+				{KName: "sdb", Name: "sdb", Size: tenGi, Type: "disk", FSType: "xfs"},
+				{KName: "sdc", Name: "sdc", Size: tenGi, Type: "disk", FSType: ""},
+			},
+			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectedKNames: []string{"sda", "sdb", "sdc"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			lvset := &v1alphav1api.LocalVolumeSet{
+				Spec: v1alphav1api.LocalVolumeSetSpec{
+					DeviceInclusionSpec: tc.inclusionSpec,
+					DeviceExclusionSpec: tc.exclusionSpec,
+				},
+			}
+			matched := getSpecMatchedDevices(lvset, tc.blockDevices)
+			var gotKNames []string
+			for _, d := range matched {
+				gotKNames = append(gotKNames, d.KName)
+			}
+			assert.ElementsMatch(t, tc.expectedKNames, gotKNames)
 		})
 	}
 }

--- a/pkg/diskmaker/controllers/lvset/reconcile_test.go
+++ b/pkg/diskmaker/controllers/lvset/reconcile_test.go
@@ -759,80 +759,57 @@ func TestProcessRejectedDevicesForDeviceLinks(t *testing.T) {
 	}
 }
 
-func TestGetSpecMatchedDevices(t *testing.T) {
+func TestMatchesDeviceSpec(t *testing.T) {
 	tenGi := "10737418240"
 	hundredGi := "107374182400"
 	minSize := resource.MustParse("5Gi")
 	maxSize := resource.MustParse("50Gi")
 
 	testCases := []struct {
-		name           string
-		blockDevices   []internal.BlockDevice
-		inclusionSpec  *v1alphav1api.DeviceInclusionSpec
-		exclusionSpec  *v1alphav1api.DeviceExclusionSpec
-		expectedKNames []string
+		name          string
+		blockDevice   internal.BlockDevice
+		inclusionSpec *v1alphav1api.DeviceInclusionSpec
+		exclusionSpec *v1alphav1api.DeviceExclusionSpec
+		expectMatch   bool
 	}{
 		{
-			name: "includes device with filesystem (in-use) that matches spec",
-			blockDevices: []internal.BlockDevice{
-				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
-			},
-			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
-			expectedKNames: []string{"sda"},
+			name:          "matches device with filesystem (in-use) within size range",
+			blockDevice:   internal.BlockDevice{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
+			inclusionSpec: &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectMatch:   true,
 		},
 		{
-			name: "includes device without filesystem that matches spec",
-			blockDevices: []internal.BlockDevice{
-				{KName: "sdb", Name: "sdb", Size: tenGi, Type: "disk", FSType: ""},
-			},
-			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
-			expectedKNames: []string{"sdb"},
+			name:          "matches device without filesystem within size range",
+			blockDevice:   internal.BlockDevice{KName: "sdb", Name: "sdb", Size: tenGi, Type: "disk", FSType: ""},
+			inclusionSpec: &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectMatch:   true,
 		},
 		{
-			name: "excludes device outside size range",
-			blockDevices: []internal.BlockDevice{
-				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
-				{KName: "sdb", Name: "sdb", Size: hundredGi, Type: "disk", FSType: ""},
-			},
-			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
-			expectedKNames: []string{"sda"},
+			name:          "rejects device outside size range",
+			blockDevice:   internal.BlockDevice{KName: "sdb", Name: "sdb", Size: hundredGi, Type: "disk", FSType: ""},
+			inclusionSpec: &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			expectMatch:   false,
 		},
 		{
-			name: "excludes device by name filter",
-			blockDevices: []internal.BlockDevice{
-				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: ""},
-				{KName: "nvme0n1", Name: "nvme0n1", Size: tenGi, Type: "disk", FSType: ""},
-			},
-			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
-			exclusionSpec:  &v1alphav1api.DeviceExclusionSpec{DeviceNameFilter: []string{"nvme*"}},
-			expectedKNames: []string{"sda"},
+			name:          "rejects device matching name exclusion filter",
+			blockDevice:   internal.BlockDevice{KName: "nvme0n1", Name: "nvme0n1", Size: tenGi, Type: "disk", FSType: ""},
+			inclusionSpec: &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			exclusionSpec: &v1alphav1api.DeviceExclusionSpec{DeviceNameFilter: []string{"nvme*"}},
+			expectMatch:   false,
 		},
 		{
-			name: "includes multiple in-use devices matching spec",
-			blockDevices: []internal.BlockDevice{
-				{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: "ext4"},
-				{KName: "sdb", Name: "sdb", Size: tenGi, Type: "disk", FSType: "xfs"},
-				{KName: "sdc", Name: "sdc", Size: tenGi, Type: "disk", FSType: ""},
-			},
-			inclusionSpec:  &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
-			expectedKNames: []string{"sda", "sdb", "sdc"},
+			name:          "matches device not excluded by name filter",
+			blockDevice:   internal.BlockDevice{KName: "sda", Name: "sda", Size: tenGi, Type: "disk", FSType: ""},
+			inclusionSpec: &v1alphav1api.DeviceInclusionSpec{MinSize: &minSize, MaxSize: &maxSize},
+			exclusionSpec: &v1alphav1api.DeviceExclusionSpec{DeviceNameFilter: []string{"nvme*"}},
+			expectMatch:   true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			lvset := &v1alphav1api.LocalVolumeSet{
-				Spec: v1alphav1api.LocalVolumeSetSpec{
-					DeviceInclusionSpec: tc.inclusionSpec,
-					DeviceExclusionSpec: tc.exclusionSpec,
-				},
-			}
-			matched := getSpecMatchedDevices(lvset, tc.blockDevices)
-			var gotKNames []string
-			for _, d := range matched {
-				gotKNames = append(gotKNames, d.KName)
-			}
-			assert.ElementsMatch(t, tc.expectedKNames, gotKNames)
+			got := matchesDeviceSpec(tc.blockDevice, tc.inclusionSpec, tc.exclusionSpec)
+			assert.Equal(t, tc.expectMatch, got)
 		})
 	}
 }

--- a/pkg/diskmaker/discovery/discovery.go
+++ b/pkg/diskmaker/discovery/discovery.go
@@ -254,7 +254,7 @@ func getDeviceStatus(dev internal.BlockDevice) v1alpha1.DeviceStatus {
 		return status
 	}
 
-	noBiosBootInPartLabel, err := lvset.FilterMap["noBiosBootInPartLabel"](dev, nil)
+	noBiosBootInPartLabel, err := lvset.DefaultFilterMap["noBiosBootInPartLabel"](dev, nil)
 	if err != nil {
 		status.State = v1alpha1.Unknown
 		return status
@@ -265,7 +265,7 @@ func getDeviceStatus(dev internal.BlockDevice) v1alpha1.DeviceStatus {
 		return status
 	}
 
-	canOpen, err := lvset.FilterMap["canOpenExclusively"](dev, nil)
+	canOpen, err := lvset.DefaultFilterMap["canOpenExclusively"](dev, nil)
 	if err != nil {
 		status.State = v1alpha1.Unknown
 		return status

--- a/pkg/localmetrics/localmetrics.go
+++ b/pkg/localmetrics/localmetrics.go
@@ -121,3 +121,15 @@ func LVMissingDevicePathGauge(nodeName, storageClassName string) prometheus.Gaug
 		"nodeName": nodeName, "storageClass": storageClassName,
 	})
 }
+
+func LVOrphanedSymlinksGauge(nodeName, storageClassName string) prometheus.Gauge {
+	return metricLocalVolumeOrphanedSymlinks.With(prometheus.Labels{
+		"nodeName": nodeName, "storageClass": storageClassName,
+	})
+}
+
+func LVSOrphanedSymlinksGauge(nodeName, storageClassName string) prometheus.Gauge {
+	return metricLocalVolumeSetOrphanedSymlinks.With(prometheus.Labels{
+		"nodeName": nodeName, "storageClass": storageClassName,
+	})
+}


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-79680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus gauges to monitor orphaned symlinks for LocalVolume and LocalVolumeSet.

* **Improvements**
  * Reconciler now separates spec-matched devices from provisioning-eligible devices for more accurate orphan detection.
  * Default device-filtering behavior renamed/clarified to improve inclusion/exclusion semantics.

* **Tests**
  * New unit tests for orphaned-symlink metric calculation and spec-matching device selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->