### PR TITLE
NO-JIRA: Bump must-gather images to 4.22

### DIFF
--- a/config/manifests/stable/image-references
+++ b/config/manifests/stable/image-references
@@ -18,4 +18,4 @@ spec:
   - name: local-storage-mustgather
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.21.0
+      name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -494,7 +494,7 @@ spec:
                       - name: MUSTGATHER_IMAGE
                         # This env. var is not used by the operator.
                         # It is here only to be matched by ART pipeline and added to related-images automatically.
-                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.21.0
+                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0
   customresourcedefinitions:
     owned:
       - displayName: Local Volume


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local storage operator to version 4.22.0 with refreshed mustgather image references across configuration manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->