### PR TITLE
OCPBUGS-83729: Improve cleanup of resources in e2e tests

### DIFF
--- a/test/e2e/cleanup_hostdirs.go
+++ b/test/e2e/cleanup_hostdirs.go
@@ -35,7 +35,7 @@ func cleanupSymlinkDir(t *testing.T, ctx *framework.TestCtx, nodeEnv []nodeDisks
 	for _, cleanupJob := range cleanupJobs {
 		waitForJobCompletion(t, cleanupJob, fmt.Sprintf("waiting for cleanup job to complete: %q", cleanupJob.GetName()))
 		cleanupJob.TypeMeta.Kind = "Job"
-		eventuallyDelete(t, false, cleanupJob)
+		eventuallyDelete(t, cleanupJob)
 	}
 
 	return nil

--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -26,7 +26,7 @@ import (
 var pvConsumerLabel = "pv-consumer"
 
 // eventuallyDelete objs, removing the finalizer if necessary
-func eventuallyDelete(t *testing.T, removeFinalizers bool, objs ...client.Object) {
+func eventuallyDelete(t *testing.T, objs ...client.Object) {
 	f := framework.Global
 	matcher := gomega.NewWithT(t)
 	for _, obj := range objs {
@@ -53,27 +53,6 @@ func eventuallyDelete(t *testing.T, removeFinalizers bool, objs ...client.Object
 				t.Logf("object has finalizers: %+v", finalizers)
 			}
 			propPolicy := dynclient.PropagationPolicy(metav1.DeletePropagationBackground)
-			if removeFinalizers {
-				propPolicy = dynclient.PropagationPolicy(metav1.DeletePropagationForeground)
-				accessor.SetFinalizers([]string{})
-				err = f.Client.Update(context.TODO(), obj)
-				if errors.IsNotFound(err) || errors.IsGone(err) {
-					t.Logf("object already deleted: %s", err)
-					return nil
-				} else if err != nil {
-					return fmt.Errorf("could not remove finalizers: %+v", finalizers)
-				}
-				accessor, err = meta.Accessor(obj)
-				if err != nil {
-					t.Fatalf("deletion failed, cannot get accessor for object: %+v, obj: %+v", err, obj)
-				}
-				// recheck finalizers
-				finalizers = accessor.GetFinalizers()
-				if len(finalizers) > 0 {
-					return fmt.Errorf("could not remove finalizers: %+v", finalizers)
-				}
-
-			}
 			err = f.Client.Delete(context.TODO(), obj, propPolicy)
 			if errors.IsNotFound(err) || errors.IsGone(err) {
 				t.Logf("object already deleted: %s", err)

--- a/test/e2e/hostudev.go
+++ b/test/e2e/hostudev.go
@@ -32,7 +32,7 @@ func addNewUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string
 
 	waitForJobCompletion(t, symlinkJob, fmt.Sprintf("waiting for check-symlink job to complete: %q", symlinkJob.GetName()))
 	symlinkJob.TypeMeta.Kind = "Job"
-	eventuallyDelete(t, false, symlinkJob)
+	eventuallyDelete(t, symlinkJob)
 	t.Logf("added udev symlink %s -> %s on node %s", currentLink, newLink, nodeHostname)
 }
 
@@ -61,7 +61,7 @@ func removeUdevSymlink(t *testing.T, ctx *framework.TestCtx, nodeHostname string
 
 	waitForJobCompletion(t, symlinkJob, fmt.Sprintf("waiting for check-symlink job to complete: %q", symlinkJob.GetName()))
 	symlinkJob.TypeMeta.Kind = "Job"
-	eventuallyDelete(t, false, symlinkJob)
+	eventuallyDelete(t, symlinkJob)
 	t.Logf("removed udev symlinks matching %s on node %s", linkPattern, nodeHostname)
 }
 

--- a/test/e2e/jobs.go
+++ b/test/e2e/jobs.go
@@ -150,7 +150,7 @@ func createOrReplaceJob(t *testing.T, ctx *framework.TestCtx, job *batchv1.Job, 
 			}
 			if j.CreationTimestamp.Before(&started) {
 				j.TypeMeta.Kind = "Job"
-				eventuallyDelete(t, false, j)
+				eventuallyDelete(t, j)
 				return fmt.Errorf("deleted stale job %s/%s, retrying creation", j.GetNamespace(), j.GetName())
 			}
 		}

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -20,7 +20,6 @@ import (
 	framework "github.com/openshift/local-storage-operator/test/framework"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -485,39 +484,77 @@ func cleanupLVAndWaitForOwnedPVsToDisappear(t *testing.T, f *framework.Framework
 	waitForLocalVolumeAndOwnedPVsToDisappear(t, f, localVolume)
 }
 
-func cleanupLVResources(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) error {
-	// first mark lv for deletion without removing finalizer
-	eventuallyDelete(t, false, localVolume)
-	pvList := &corev1.PersistentVolumeList{}
+// The caller is responsible for releasing all resources, so we only check here that StorageClass does not exist
+func checkForStorageClass(t *testing.T, f *framework.Framework, scName string) error {
 	matcher := gomega.NewWithT(t)
 	matcher.Eventually(func() error {
-		err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
-			common.PVOwnerKindLabel:      localv1.LocalVolumeKind,
-			common.PVOwnerNamespaceLabel: localVolume.Namespace,
-			common.PVOwnerNameLabel:      localVolume.Name,
-		})
-		if err != nil {
-			return err
+		_, err := f.KubeClient.StorageV1().StorageClasses().Get(goctx.TODO(), scName, metav1.GetOptions{})
+		if err == nil {
+			return fmt.Errorf("checkForStorageClass: StorageClass %s still exists", scName)
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("checkForStorageClass: failed to Get() StorageClass %s: %v", scName, err)
 		}
-		t.Logf("Deleting %d PVs", len(pvList.Items))
-		for _, pv := range pvList.Items {
-			eventuallyDelete(t, false, &pv)
-		}
+		t.Logf("checkForStorageClass: StorageClass %s not found -- OK", scName)
 		return nil
-	}, time.Minute*3, time.Second*2).ShouldNot(gomega.HaveOccurred(), "cleaning up pvs for lv: %q", localVolume.GetName())
-
-	// Delete the owning resources after their PVs are fully gone so the
-	// diskmaker cleanup path can remove PV finalizers first.
-	eventuallyDelete(t, true, localVolume)
-	sc := &storagev1.StorageClass{
-		TypeMeta:   metav1.TypeMeta{Kind: localv1.LocalVolumeKind},
-		ObjectMeta: metav1.ObjectMeta{Name: localVolume.Spec.StorageClassDevices[0].StorageClassName},
-	}
-	eventuallyDelete(t, false, sc)
+	}, time.Second*10, time.Second*2).ShouldNot(gomega.HaveOccurred(), "check for StorageClass %s", scName)
 
 	return nil
-
 }
+
+// The caller is responsible for releasing all resources, so we only check here that LocalVolume does not exist
+func checkForLocalVolume(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) error {
+	name := localVolume.Name
+	namespace := localVolume.Namespace
+
+	matcher := gomega.NewWithT(t)
+	matcher.Eventually(func() error {
+		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, localVolume)
+		if err == nil {
+			return fmt.Errorf("checkForLocalVolume: LocalVolume %s still exists", name)
+		} else if !errors.IsNotFound(err) && !errors.IsGone(err) {
+			return fmt.Errorf("checkForLocalVolume: failed to Get() LocalVolume %s: %v", name, err)
+		}
+		t.Logf("checkForLocalVolume: LocalVolume %s not found -- OK", name)
+		return nil
+	}, time.Second*10, time.Second*2).ShouldNot(gomega.HaveOccurred(), "check for LocalVolume %s", name)
+
+	return nil
+}
+
+// The caller is responsible for releasing all resources, so we only check here that PVs do not exist
+func checkForPersistentVolumes(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) error {
+	name := localVolume.Name
+	namespace := localVolume.Namespace
+
+	matcher := gomega.NewWithT(t)
+	matcher.Eventually(func() error {
+		pvList := &corev1.PersistentVolumeList{}
+
+		err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+			common.PVOwnerKindLabel:      localv1.LocalVolumeKind,
+			common.PVOwnerNamespaceLabel: namespace,
+			common.PVOwnerNameLabel:      name,
+		})
+		if err != nil {
+			return fmt.Errorf("checkForPersistentVolumes: cannot List() PVs for LocalVolume %s: %v", name, err)
+		}
+		if len(pvList.Items) != 0 {
+			return fmt.Errorf("checkForPersistentVolumes: %d PVs still exist for LocalVolume %s", len(pvList.Items), name)
+		}
+		t.Logf("checkForPersistentVolumes: no PVs found for LocalVolume %s -- OK", name)
+		return nil
+	}, time.Second*10, time.Second*2).ShouldNot(gomega.HaveOccurred(), "check for LocalVolume %s", name)
+
+	return nil
+}
+
+func cleanupLVResources(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) error {
+	checkForLocalVolume(t, f, localVolume)
+	checkForPersistentVolumes(t, f, localVolume)
+	checkForStorageClass(t, f, localVolume.Spec.StorageClassDevices[0].StorageClassName)
+	return nil
+}
+
 func verifyLocalVolume(t *testing.T, lv *localv1.LocalVolume, client framework.FrameworkClient) error {
 	waitErr := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
 		objectKey := dynclient.ObjectKey{

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -296,7 +296,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 			verifyLVDLFilesystemUUIDForPVs(t, f, namespace, filesystemConsumedPVNames)
 		}
 		// release pvs
-		eventuallyDelete(t, false, consumingObjectList...)
+		eventuallyDelete(t, consumingObjectList...)
 
 		// verify that PVs eventually come back
 		eventuallyFindAvailablePVs(t, f, localVolume.Spec.StorageClassDevices[0].StorageClassName, pvs)
@@ -305,7 +305,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		consumingObjectList = make([]client.Object, 0)
 
 		addToCleanupFuncs(cleanupFuncs, "pv-consumer", func(t *testing.T) error {
-			eventuallyDelete(t, false, consumingObjectList...)
+			eventuallyDelete(t, consumingObjectList...)
 			return nil
 		})
 		for _, pv := range pvs[:1] {
@@ -333,7 +333,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		}, time.Second*15, time.Second*3).Should(gomega.BeTrue(), "checking finalizer exists with bound PVs")
 		// release PV
 		t.Logf("releasing pvs")
-		eventuallyDelete(t, false, consumingObjectList...)
+		eventuallyDelete(t, consumingObjectList...)
 		// verify localVolume deletion
 		matcher.Eventually(func() bool {
 			t.Log("verifying LocalVolume deletion")
@@ -480,7 +480,7 @@ func waitForLocalVolumeAndOwnedPVsToDisappear(t *testing.T, f *framework.Framewo
 }
 
 func cleanupLVAndWaitForOwnedPVsToDisappear(t *testing.T, f *framework.Framework, localVolume *localv1.LocalVolume) {
-	eventuallyDelete(t, false, localVolume)
+	eventuallyDelete(t, localVolume)
 	waitForLocalVolumeAndOwnedPVsToDisappear(t, f, localVolume)
 }
 

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -346,7 +346,7 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 			}
 			t.Logf("LocalVolume found: %q with finalizers: %+v", localVolume.Name, localVolume.ObjectMeta.Finalizers)
 			return false
-		}).Should(gomega.BeTrue(), "verifying LocalVolume has been deleted", localVolume.Name)
+		}, time.Second*15, time.Second*3).Should(gomega.BeTrue(), "verifying LocalVolume has been deleted", localVolume.Name)
 
 		t.Log("verifying LocalVolumeDeviceLink objects are deleted after LocalVolume deletion")
 		verifyLVDLsDeleted(t, f, namespace, lvdlNames)

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -265,9 +265,11 @@ func LocalVolumeTest(ctx *framework.Context, cleanupFuncs *[]cleanupFn) func(*te
 		selectedPV, multiStepCleanups := verifyMultiStepPreferredLinkReconciliation(
 			t, ctx, f, namespace, selectedPV, currentSymlink,
 		)
-		for i := range multiStepCleanups {
-			*cleanupFuncs = append(*cleanupFuncs, multiStepCleanups[i])
+		// multiStepCleanups ops must be done after deleting LV, so put them in the beginning of the list.
+		for i := range *cleanupFuncs {
+			multiStepCleanups = append(multiStepCleanups, (*cleanupFuncs)[i])
 		}
+		*cleanupFuncs = multiStepCleanups
 
 		// Symlink fallback test: after multi-step left the PV on the wwn link,
 		// remove it and verify LSO falls back to the next-best scsi-3 link.

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/openshift/local-storage-operator/pkg/common"
 	framework "github.com/openshift/local-storage-operator/test/framework"
 	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	provCommon "sigs.k8s.io/sig-storage-local-static-provisioner/pkg/common"
 )
@@ -583,6 +582,11 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		// check for leftover symlinks before cleanup
 		symLinkPath := path.Join(common.GetLocalDiskLocationPath(), twentyToFifty.Spec.StorageClassName)
 		checkForSymlinks(t, ctx, nodeEnv, symLinkPath)
+
+		// delete remaining LVSets explicitly, cleanupLVSetResources() will only check that everything has gone
+		eventuallyDelete(t, false, noOpLVSet)
+		eventuallyDelete(t, false, tenToThirty)
+		eventuallyDelete(t, false, twentyToFiftyFilesystem)
 	}
 
 }
@@ -624,36 +628,60 @@ func waitForLVSetAndOwnedPVsToDisappear(t *testing.T, lvset *localv1alpha1.Local
 	}, time.Minute*8, time.Second*5).ShouldNot(gomega.HaveOccurred(), "waiting for localvolumeset %q and owned PVs to be deleted", lvset.Name)
 }
 
+// The caller is responsible for releasing all resources, so we only check here that LocalVolume does not exist
+func checkForLocalVolumeSet(t *testing.T, f *framework.Framework, lvset *localv1alpha1.LocalVolumeSet) error {
+	name := lvset.Name
+	namespace := lvset.Namespace
+
+	matcher := gomega.NewWithT(t)
+	matcher.Eventually(func() error {
+		err := f.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, lvset)
+		if err == nil {
+			return fmt.Errorf("checkForLocalVolumeSet: LocalVolumeSet %s still exists", name)
+		} else if !errors.IsNotFound(err) && !errors.IsGone(err) {
+			return fmt.Errorf("checkForLocalVolumeSet: failed to Get() LocalVolumeSet %s: %v", name, err)
+		}
+		t.Logf("checkForLocalVolumeSet: LocalVolumeSet %s not found -- OK", name)
+		return nil
+	}, time.Second*10, time.Second*2).ShouldNot(gomega.HaveOccurred(), "check for LocalVolumeSet %s", name)
+
+	return nil
+}
+
+// The caller is responsible for releasing all resources, so we only check here that PVs do not exist
+func checkForPersistentVolumesLVS(t *testing.T, f *framework.Framework, lvset *localv1alpha1.LocalVolumeSet) error {
+	name := lvset.Name
+	namespace := lvset.Namespace
+
+	matcher := gomega.NewWithT(t)
+	matcher.Eventually(func() error {
+		pvList := &corev1.PersistentVolumeList{}
+
+		err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
+			common.PVOwnerKindLabel:      localv1.LocalVolumeSetKind,
+			common.PVOwnerNamespaceLabel: namespace,
+			common.PVOwnerNameLabel:      name,
+		})
+		if err != nil {
+			return fmt.Errorf("checkForPersistentVolumes: cannot List() PVs for LocalVolumeSet %s: %v", name, err)
+		}
+		if len(pvList.Items) != 0 {
+			return fmt.Errorf("checkForPersistentVolumes: %d PVs still exist for LocalVolumeSet %s", len(pvList.Items), name)
+		}
+		t.Logf("checkForPersistentVolumes: no PVs found for LocalVolumeSet %s -- OK", name)
+		return nil
+	}, time.Second*10, time.Second*2).ShouldNot(gomega.HaveOccurred(), "check for LocalVolumeSet %s", name)
+
+	return nil
+}
+
 func cleanupLVSetResources(t *testing.T, lvsets *[]*localv1alpha1.LocalVolumeSet) error {
 	for _, lvset := range *lvsets {
-		t.Logf("cleaning up pvs and storageclasses: %q", lvset.GetName())
+		t.Logf("check that lvset %q and friends (SC, PVs) have gone", lvset.GetName())
 		f := framework.Global
-		matcher := gomega.NewWithT(t)
-		// delete lvset without removing finalizer, so as it doesn't
-		// automatically recreate the PVs we delete below
-		eventuallyDelete(t, false, lvset)
-
-		pvList := &corev1.PersistentVolumeList{}
-		t.Logf("listing pvs for lvset: %q", lvset.GetName())
-		matcher.Eventually(func() error {
-			err := f.Client.List(context.TODO(), pvList, client.MatchingLabels{
-				common.PVOwnerKindLabel:      localv1.LocalVolumeSetKind,
-				common.PVOwnerNamespaceLabel: lvset.Namespace,
-				common.PVOwnerNameLabel:      lvset.Name,
-			})
-			if err != nil {
-				return err
-			}
-			t.Logf("Deleting %d PVs", len(pvList.Items))
-			for _, pv := range pvList.Items {
-				eventuallyDelete(t, false, &pv)
-			}
-			return nil
-		}, time.Minute*3, time.Second*2).ShouldNot(gomega.HaveOccurred(), "cleaning up pvs for lvset: %q", lvset.GetName())
-
-		sc := &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: lvset.Spec.StorageClassName}}
-		eventuallyDelete(t, true, lvset)
-		eventuallyDelete(t, false, sc)
+		checkForLocalVolumeSet(t, f, lvset)
+		checkForPersistentVolumesLVS(t, f, lvset)
+		checkForStorageClass(t, f, lvset.Spec.StorageClassName)
 	}
 
 	return nil

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -464,9 +464,11 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 			t, ctx, f, namespace, selectedFSPV, currentSymlink,
 		)
 		fsPVs[0] = selectedFSPV
-		for i := range multiStepCleanups {
-			*cleanupFuncs = append(*cleanupFuncs, multiStepCleanups[i])
+		// multiStepCleanups ops must be done after deleting LVS, so put them in the beginning of the list.
+		for i := range *cleanupFuncs {
+			multiStepCleanups = append(multiStepCleanups, (*cleanupFuncs)[i])
 		}
+		*cleanupFuncs = multiStepCleanups
 
 		// Symlink fallback test: after multi-step left the PV on the wwn link,
 		// remove it and verify LSO falls back to the next-best scsi-3 link.

--- a/test/e2e/localvolumeset_test.go
+++ b/test/e2e/localvolumeset_test.go
@@ -225,7 +225,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		assertLVDLSymlinkPathMatchesPVs(t, sharedLVDLs, sharedPVs)
 
 		t.Log("cleaning up LocalVolumeSet duplicate by-id reproducer before continuing with standard test flow")
-		eventuallyDelete(t, false, sharedLVSet)
+		eventuallyDelete(t, sharedLVSet)
 		waitForLVSetAndOwnedPVsToDisappear(t, sharedLVSet)
 		removeUdevSymlink(t, ctx, nodeEnv[0].node.Labels[corev1.LabelHostname], sharedScsi8Link)
 		removeUdevSymlink(t, ctx, nodeEnv[1].node.Labels[corev1.LabelHostname], sharedScsi8Link)
@@ -492,7 +492,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		// record consuming objects for cleanup
 		consumingObjectList := make([]client.Object, 0)
 		addToCleanupFuncs(cleanupFuncs, "pv-consumer", func(t *testing.T) error {
-			eventuallyDelete(t, false, consumingObjectList...)
+			eventuallyDelete(t, consumingObjectList...)
 			return nil
 		})
 		for _, pv := range fsPVs[:1] {
@@ -506,7 +506,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		t.Log("verifying filesystemUUID is populated on LVDL for consumed filesystem PVs")
 		verifyLVDLFilesystemUUIDForPVs(t, f, namespace, consumedFSPVNames)
 		// release pvs
-		eventuallyDelete(t, false, consumingObjectList...)
+		eventuallyDelete(t, consumingObjectList...)
 		// verify that PVs eventually come back
 		eventuallyFindAvailablePVs(t, f, twentyToFiftyFilesystem.Spec.StorageClassName, fsPVs)
 
@@ -519,7 +519,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 			consumingObjectList = append(consumingObjectList, job, pvc, pod)
 		}
 		// release pvs
-		eventuallyDelete(t, false, consumingObjectList...)
+		eventuallyDelete(t, consumingObjectList...)
 		// verify that PVs eventually come back
 		twentyToFiftyBlockPVs = eventuallyFindAvailablePVs(t, f, twentyToFifty.Spec.StorageClassName, twentyToFiftyBlockPVs)
 
@@ -556,7 +556,7 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		t.Logf("finalizers not removed with bound PVs: %q", finalizers)
 		// release PV
 		t.Logf("releasing pvs")
-		eventuallyDelete(t, false, consumingObjectList...)
+		eventuallyDelete(t, consumingObjectList...)
 		twentyToFiftyLVDLNames := make([]string, 0, len(twentyToFiftyBlockPVs))
 		for _, pv := range twentyToFiftyBlockPVs {
 			twentyToFiftyLVDLNames = append(twentyToFiftyLVDLNames, pv.Name)
@@ -584,9 +584,9 @@ func LocalVolumeSetTest(ctx *framework.TestCtx, cleanupFuncs *[]cleanupFn) func(
 		checkForSymlinks(t, ctx, nodeEnv, symLinkPath)
 
 		// delete remaining LVSets explicitly, cleanupLVSetResources() will only check that everything has gone
-		eventuallyDelete(t, false, noOpLVSet)
-		eventuallyDelete(t, false, tenToThirty)
-		eventuallyDelete(t, false, twentyToFiftyFilesystem)
+		eventuallyDelete(t, noOpLVSet)
+		eventuallyDelete(t, tenToThirty)
+		eventuallyDelete(t, twentyToFiftyFilesystem)
 	}
 
 }

--- a/test/e2e/symlink_check.go
+++ b/test/e2e/symlink_check.go
@@ -40,7 +40,7 @@ func checkForSymlinks(t *testing.T, ctx *framework.TestCtx, nodeEnv []nodeDisks,
 	for _, checkSymlinkJob := range checkSymlinkJobs {
 		waitForJobCompletion(t, checkSymlinkJob, fmt.Sprintf("waiting for check-symlink job to complete: %q", checkSymlinkJob.GetName()))
 		checkSymlinkJob.TypeMeta.Kind = "Job"
-		eventuallyDelete(t, false, checkSymlinkJob)
+		eventuallyDelete(t, checkSymlinkJob)
 	}
 
 	return nil
@@ -435,5 +435,5 @@ func verifyNodeSymlinkTarget(t *testing.T, ctx *framework.TestCtx, nodeHostname,
 	createOrReplaceJob(t, ctx, job, fmt.Sprintf("creating symlink target check job on node: %q", nodeHostname))
 	waitForJobCompletion(t, job, fmt.Sprintf("waiting for symlink target check job to complete: %q", job.GetName()))
 	job.TypeMeta.Kind = "Job"
-	eventuallyDelete(t, false, job)
+	eventuallyDelete(t, job)
 }


### PR DESCRIPTION
The PR reworks e2e test to make sure that PVs and SCs are removed automatically along with removal of LV/LVSet. After that, the PR removes functionality explicitly deleting PVs, finalizers, and SCs.

https://redhat.atlassian.net/browse/OCPBUGS-83729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified end-to-end test cleanup and resource-deletion handling to reduce flakiness.
  * Standardized deletion behavior to always use background deletion (removed special finalizer-removal flow).
  * Adjusted cleanup ordering for multi-step reconciliation scenarios.
  * Replaced some active deletions with post-cleanup checks that verify resources are eventually absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->