### PR TITLE
STOR-2920: Bump OLM metadata to 5.0

### DIFF
--- a/config/manifests/local-storage-operator.package.yaml
+++ b/config/manifests/local-storage-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: local-storage-operator
 channels:
   - name: stable
-    currentCSV: local-storage-operator.v4.22.0
+    currentCSV: local-storage-operator.v5.0.0

--- a/config/manifests/stable/image-references
+++ b/config/manifests/stable/image-references
@@ -3,19 +3,19 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: local-storage-operator
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-local-storage-operator:latest
-  - name: local-storage-diskmaker
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-local-storage-diskmaker:latest
-  - name: kube-rbac-proxy
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:latest
-  - name: local-storage-mustgather
-    from:
-      kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0
+    - name: local-storage-operator
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-local-storage-operator:latest
+    - name: local-storage-diskmaker
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-local-storage-diskmaker:latest
+    - name: kube-rbac-proxy
+      from:
+        kind: DockerImage
+        name: quay.io/openshift/origin-kube-rbac-proxy:latest
+    - name: local-storage-mustgather
+      from:
+        kind: DockerImage
+        name: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v5.0.0

--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: local-storage-operator.v4.22.0
+  name: local-storage-operator.v5.0.0
   namespace: placeholder
   annotations:
     alm-examples: |-
@@ -126,11 +126,11 @@ metadata:
     repository: https://github.com/openshift/local-storage-operator
     createdAt: "2019-08-14T00:00:00Z"
     description: Configure and use local storage volumes.
-    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"4.23"}]'
-    olm.skipRange: ">=4.3.0 <4.22.0"
+    olm.properties: '[{"type":"olm.maxOpenShiftVersion","value":"5.1"}]'
+    olm.skipRange: ">=4.3.0 <5.0.0"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.local.storage.openshift.io"]'
-    operators.openshift.io/must-gather-image: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0
+    operators.openshift.io/must-gather-image: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v5.0.0
     # This annotation injection is a workaround for BZ-1950047, since the associated
     # annotation in spec.install.spec.deployments.template.metadata is presently ignored.
     # TODO: remove the next line after BZ-1950047 is resolved.
@@ -165,7 +165,7 @@ spec:
       url: https://github.com/openshift/local-storage-operator/tree/main/docs
     - name: Source Repository
       url: https://github.com/openshift/local-storage-operator
-  version: 4.22.0
+  version: 5.0.0
   maturity: stable
   maintainers:
     - email: aos-storage-staff@redhat.com
@@ -175,7 +175,7 @@ spec:
     name: Red Hat
   labels:
     alm-owner-metering: local-storage-operator
-    alm-status-descriptors: local-storage-operator.v4.22.0
+    alm-status-descriptors: local-storage-operator.v5.0.0
   selector:
     matchLabels:
       alm-owner-metering: local-storage-operator
@@ -494,7 +494,7 @@ spec:
                       - name: MUSTGATHER_IMAGE
                         # This env. var is not used by the operator.
                         # It is here only to be matched by ART pipeline and added to related-images automatically.
-                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v4.22.0
+                        value: registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel9:v5.0.0
   customresourcedefinitions:
     owned:
       - displayName: Local Volume

--- a/hack/update-metadata.sh
+++ b/hack/update-metadata.sh
@@ -80,6 +80,7 @@ yq -i '
   .metadata.annotations["olm.properties"] = strenv(NEW_OLM_PROPERTIES) |
   .metadata.annotations["operators.openshift.io/must-gather-image"] = strenv(NEW_MUST_GATHER_IMAGE) |
   .spec.version = strenv(NEW_SPEC_VERSION) |
-  .spec.labels.alm-status-descriptors = strenv(NEW_ALM_STATUS_DESC)
+  .spec.labels.alm-status-descriptors = strenv(NEW_ALM_STATUS_DESC) |
+  (.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] | select(.name == "MUSTGATHER_IMAGE")).value = strenv(NEW_MUST_GATHER_IMAGE)
 ' ${CSV_MANIFEST}
 

--- a/hack/update-metadata.sh
+++ b/hack/update-metadata.sh
@@ -45,6 +45,8 @@ if [ -z "${METADATA_NAME}" ] ||
 	exit 1
 fi
 
+IMAGE_REFERENCES_MANIFEST=config/manifests/stable/image-references
+
 OCP_VERSION=${1:-${PACKAGE_VERSION}}
 IFS='.' read -r MAJOR_VERSION MINOR_VERSION PATCH_VERSION <<< "${OCP_VERSION}"
 PATCH_VERSION=${PATCH_VERSION:-0}
@@ -83,4 +85,7 @@ yq -i '
   .spec.labels.alm-status-descriptors = strenv(NEW_ALM_STATUS_DESC) |
   (.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[] | select(.name == "MUSTGATHER_IMAGE")).value = strenv(NEW_MUST_GATHER_IMAGE)
 ' ${CSV_MANIFEST}
+
+echo "Updating image references to ${PACKAGE_VERSION}"
+yq -i '(.spec.tags[] | select(.name == "local-storage-mustgather")).from.name = strenv(NEW_MUST_GATHER_IMAGE)' ${IMAGE_REFERENCES_MANIFEST}
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/STOR-2920

Updated `hack/update-metadata.sh` to bump the must-gather image, then generated changes with:

`make metadata OCP_VERSION=5.0.0`

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Chores**
  * Released **local-storage-operator v5.0.0**.
  * Updated OLM compatibility metadata (max OpenShift version to **5.1**) and adjusted the supported version skip range.
  * Updated the operator **must-gather** image to **v5.0.0** and refreshed the related must-gather image reference accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->