### PR TITLE
STOR-3059: Add LocalVolume tolerations e2e test for provisioning and consumption on tainted nodes

### DIFF
--- a/test/e2e/gomega_util.go
+++ b/test/e2e/gomega_util.go
@@ -172,6 +172,10 @@ func eventuallyFindAvailablePVs(f *framework.Framework, storageClassName string,
 }
 
 func consumePV(namespace string, pv corev1.PersistentVolume) (*corev1.PersistentVolumeClaim, *batchv1.Job, *corev1.Pod) {
+	return consumePVWithTolerations(namespace, pv, nil)
+}
+
+func consumePVWithTolerations(namespace string, pv corev1.PersistentVolume, tolerations []corev1.Toleration) (*corev1.PersistentVolumeClaim, *batchv1.Job, *corev1.Pod) {
 	f := framework.Global
 	f.Logf("consuming PV: %q", pv.Name)
 	name := fmt.Sprintf("%s-consumer", pv.ObjectMeta.Name)
@@ -211,6 +215,7 @@ func consumePV(namespace string, pv corev1.PersistentVolume) (*corev1.Persistent
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
+					Tolerations:   tolerations,
 					Containers: []corev1.Container{
 						{
 							Name:    "busybox",

--- a/test/e2e/localvolume_test.go
+++ b/test/e2e/localvolume_test.go
@@ -43,6 +43,7 @@ const (
 	diskIndexXfsFsType     = 2
 	diskIndexBlockMode     = 3
 	diskIndexLVDL          = 4
+	diskIndexTolerations   = 0
 )
 
 type fsTypeTestCase struct {
@@ -290,6 +291,65 @@ var _ = Describe("LocalVolume", Label("LocalVolume"), Ordered, func() {
 				eventuallyFindAvailablePVs(f, tc.storageClassName, pvs)
 			})
 		}
+	})
+
+	Context("localvolume with tolerations", func() {
+		It("schedules and consumes PV on tainted node", func() {
+			selectedNode := nodeEnv[1].node
+			testDisk := nodeEnv[1].disks[diskIndexTolerations]
+			Expect(testDisk.path).ShouldNot(BeZero(), "device path should not be empty for tolerations test")
+
+			originalNodeTaints := append([]corev1.Taint(nil), selectedNode.Spec.Taints...)
+			selectedNode.Spec.Taints = []corev1.Taint{localVolumeNodeTaint()}
+			var err error
+			selectedNode, err = waitForNodeTaintUpdate(f.KubeClient, selectedNode, retryInterval, hourTimeout)
+			Expect(err).NotTo(HaveOccurred(), "tainting node for tolerations test")
+			DeferCleanup(func() error {
+				selectedNode.Spec.Taints = originalNodeTaints
+				_, restoreErr := waitForNodeTaintUpdate(f.KubeClient, selectedNode, retryInterval, hourTimeout)
+				if restoreErr != nil {
+					f.Logf("error restoring original taints on node: %v", restoreErr)
+				}
+				return restoreErr
+			})
+
+			localVolume := getLocalVolumeWithFSType(
+				selectedNode,
+				testDisk.path,
+				namespace,
+				lvStorageClassName,
+				"ext4",
+				localv1.PersistentVolumeFilesystem,
+				"test-local-disk-tolerations",
+				localVolumeTolerations(),
+			)
+			DeferCleanup(func() { cleanupLVResources(f, localVolume) })
+
+			Eventually(func(ctx context.Context) error {
+				f.Logf("creating localvolume for tolerations test")
+				return f.Client.Create(ctx, localVolume, nil)
+			}, time.Minute, time.Second*2).WithContext(context.Background()).ShouldNot(HaveOccurred(), "creating localvolume for tolerations test")
+
+			err = waitForDaemonSet(f.KubeClient, namespace, nodedaemon.DiskMakerName, retryInterval, hourTimeout)
+			Expect(err).NotTo(HaveOccurred(), "waiting for diskmaker daemonset for tolerations test")
+
+			err = verifyLocalVolume(localVolume, f.Client)
+			Expect(err).NotTo(HaveOccurred(), "verifying localvolume cr for tolerations test")
+
+			err = checkLocalVolumeStatus(localVolume)
+			Expect(err).NotTo(HaveOccurred(), "checking localvolume condition for tolerations test")
+
+			pvs := eventuallyFindPVs(f, lvStorageClassName, 1)
+			expectedPath := testDisk.name
+			if testDisk.id != "" {
+				expectedPath = testDisk.id
+			}
+			Expect(filepath.Base(pvs[0].Spec.Local.Path)).To(Equal(expectedPath))
+
+			f.Logf("consuming PV with tolerations")
+			pvc, job, pod := consumePVWithTolerations(namespace, pvs[0], localVolumeTolerations())
+			eventuallyDelete(job, pvc, pod)
+		})
 	})
 
 	Context("standard LocalVolume lifecycle", Ordered, func() {
@@ -792,14 +852,26 @@ func getLocalVolume(selectedNode corev1.Node, selectedDisk, namespace string) *l
 		"",
 		localv1.PersistentVolumeFilesystem,
 		"test-local-disk",
-		[]corev1.Toleration{
-			{
-				Key:      "localstorage",
-				Value:    "testvalue",
-				Operator: "Equal",
-			},
-		},
+		localVolumeTolerations(),
 	)
+}
+
+func localVolumeTolerations() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      "localstorage",
+			Value:    "testvalue",
+			Operator: corev1.TolerationOpEqual,
+		},
+	}
+}
+
+func localVolumeNodeTaint() corev1.Taint {
+	return corev1.Taint{
+		Key:    "localstorage",
+		Value:  "testvalue",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
 }
 
 // getLocalVolumeWithFSType creates a LocalVolume CR with specific FSType and VolumeMode


### PR DESCRIPTION
## Summary
- Add a LocalVolume e2e test that verifies tolerations work end-to-end on a tainted worker node
- Extract shared `localVolumeTolerations()` and `localVolumeNodeTaint()` helpers for reuse with existing LocalVolume tests
- Add `consumePVWithTolerations()` so consumer pods can schedule on tainted nodes without changing existing `consumePV()` callers

## Background
This covers the openshift-tests-private scenario where a LocalVolume CR with tolerations must provision storage and allow a workload to consume the PV on a tainted node

## What the test verifies
- A worker node is tainted with `localstorage=testvalue:NoSchedule`
- A LocalVolume CR with matching tolerations provisions a PV on that node
- A consumer pod with the same toleration schedules, mounts the volume, and completes successfully

## Test plan
- [ ] Run the focused e2e test:
  `hack/test-e2e.sh --suite LocalVolume --ginkgo.focus "schedules and consumes PV on tainted node"`
- [ ] Run the full LocalVolume suite:
  `hack/test-e2e.sh --suite LocalVolume`
  
```
  $ go test -timeout 0 ./test/e2e/... -root="$(pwd)" -kubeconfig="$KUBECONFIG" -v --ginkgo.v
.
.
.
Ran 31 of 31 Specs in 1861.465 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (1861.47s)
PASS
ok  	github.com/openshift/local-storage-operator/test/e2e	1861.486s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local storage workflow on tainted nodes by honoring configured tolerations during PV consumption, including setting tolerations on the consuming pod.
* **Tests**
  * Added end-to-end coverage for local volumes with tolerations: taints an additional worker node, provisions a LocalVolume/PV on the toleration-matched target, validates the PV local path, and verifies consumption and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->