### PR TITLE
OCPBUGS-99198: added required RBAC permissions for networking.k8s.io/networkpolicies

### DIFF
--- a/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
+++ b/config/manifests/stable/local-storage-operator.clusterserviceversion.yaml
@@ -302,6 +302,14 @@ spec:
                 - deployments/finalizers
               verbs:
                 - update
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - update
           serviceAccountName: local-storage-operator
         - rules:
             - apiGroups:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation permissions to support creating, updating, and deleting network policies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->