### PR TITLE
fix(tls): correct TLS adherence implementation

### DIFF
--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -126,12 +126,8 @@ func main() {
 
 	tlsProfile, err := lsotls.FetchAPIServerTLSProfile(ctx, configClient)
 	if err != nil {
-		if adherence == configv1.TLSAdherencePolicyStrictAllComponents {
-			klog.ErrorS(err, "failed to fetch TLS profile in strict adherence mode")
-			os.Exit(1)
-		}
-		klog.Warningf("failed to fetch TLS profile, using controller-runtime defaults: %v", err)
-		tlsProfile = configv1.TLSProfileSpec{}
+		klog.ErrorS(err, "failed to fetch TLS profile")
+		os.Exit(1)
 	}
 
 	var tlsConfigFn func(*tls.Config)

--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -145,10 +145,7 @@ func main() {
 		}
 	} else {
 		klog.Infof("Cluster TLS profile adherence is not active, applying default Intermediate profile")
-		defaultProfile := configv1.TLSProfileSpec{
-			Ciphers:       crcommon.DefaultTLSCiphers,
-			MinTLSVersion: crcommon.DefaultMinTLSVersion,
-		}
+		defaultProfile, _ := crcommon.GetTLSProfileSpec(nil)
 		tlsConfigFn, _ = crcommon.NewTLSConfigFromProfile(defaultProfile)
 	}
 

--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
+	crcommon "github.com/openshift/controller-runtime-common/pkg/tls"
+	libcrypto "github.com/openshift/library-go/pkg/crypto"
 	localv1 "github.com/openshift/local-storage-operator/api/v1"
 	localv1alpha1 "github.com/openshift/local-storage-operator/api/v1alpha1"
 	"github.com/openshift/local-storage-operator/pkg/common"
@@ -107,10 +109,11 @@ func main() {
 	restConfig := ctrl.GetConfigOrDie()
 	le := utils.GetLeaderElectionConfig(restConfig, enableLeaderElection)
 
-	// Fetch TLS profile and adherence once at startup to ensure consistency
-	// Use a timeout to prevent indefinite stalls on API server outages
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
 	defer cancel()
+
+	startupCtx, startupCancel := context.WithTimeout(ctx, 60*time.Second)
+	defer startupCancel()
 
 	configClient, err := client.New(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
@@ -118,37 +121,41 @@ func main() {
 		os.Exit(1)
 	}
 
-	adherence, err := lsotls.GetAdherencePolicyForLogging(ctx, configClient)
+	adherence, err := crcommon.FetchAPIServerTLSAdherencePolicy(startupCtx, configClient)
 	if err != nil {
 		klog.ErrorS(err, "failed to fetch TLS adherence policy")
 		os.Exit(1)
 	}
+	klog.Infof("TLS adherence policy: %s", adherence)
 
-	tlsProfile, err := lsotls.FetchAPIServerTLSProfile(ctx, configClient)
+	tlsProfile, err := crcommon.FetchAPIServerTLSProfile(startupCtx, configClient)
 	if err != nil {
 		klog.ErrorS(err, "failed to fetch TLS profile")
 		os.Exit(1)
 	}
 
 	var tlsConfigFn func(*tls.Config)
-	if tlsProfile.Ciphers != nil || tlsProfile.MinTLSVersion != "" {
+	if libcrypto.ShouldHonorClusterTLSProfile(adherence) {
+		klog.Infof("Cluster TLS profile adherence is active, applying cluster TLS configuration")
 		var unsupportedCiphers []string
-		tlsConfigFn, unsupportedCiphers = lsotls.GetTLSConfigFromProfile(tlsProfile)
+		tlsConfigFn, unsupportedCiphers = crcommon.NewTLSConfigFromProfile(tlsProfile)
 		if len(unsupportedCiphers) > 0 {
 			klog.Warningf("TLS profile contains %d unsupported cipher suites: %v",
 				len(unsupportedCiphers), unsupportedCiphers)
 		}
-		klog.Infof("TLS config function created successfully")
 	} else {
-		klog.Infof("TLS profile has no ciphers or minVersion, using controller-runtime defaults")
+		klog.Infof("Cluster TLS profile adherence is not active, applying default Intermediate profile")
+		defaultProfile := configv1.TLSProfileSpec{
+			Ciphers:       crcommon.DefaultTLSCiphers,
+			MinTLSVersion: crcommon.DefaultMinTLSVersion,
+		}
+		tlsConfigFn, _ = crcommon.NewTLSConfigFromProfile(defaultProfile)
 	}
 
 	metricsOpts := metricsserver.Options{
 		BindAddress:   metricsAddr,
 		SecureServing: true,
-	}
-	if tlsConfigFn != nil {
-		metricsOpts.TLSOpts = []func(*tls.Config){tlsConfigFn}
+		TLSOpts:       []func(*tls.Config){tlsConfigFn},
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
@@ -202,7 +209,7 @@ func main() {
 	}
 
 	// Setup TLS security profile watcher to restart operator on TLS profile/adherence changes
-	tlsWatcher := lsotls.NewSecurityProfileWatcher(tlsProfile, adherence)
+	tlsWatcher := lsotls.NewSecurityProfileWatcher(cancel, tlsProfile, adherence)
 	tlsWatcher.Client = mgr.GetClient()
 	if err = tlsWatcher.SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create TLS security profile watcher")
@@ -221,7 +228,7 @@ func main() {
 	}
 
 	klog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		klog.ErrorS(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/cmd/local-storage-operator/main.go
+++ b/cmd/local-storage-operator/main.go
@@ -17,9 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"context"
+	"crypto/tls"
 	"flag"
 	"os"
 	"runtime"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -35,6 +38,7 @@ import (
 	lvdcontroller "github.com/openshift/local-storage-operator/pkg/controllers/localvolumediscovery"
 	lvscontroller "github.com/openshift/local-storage-operator/pkg/controllers/localvolumeset"
 	nodedaemoncontroller "github.com/openshift/local-storage-operator/pkg/controllers/nodedaemon"
+	lsotls "github.com/openshift/local-storage-operator/pkg/tls"
 	"github.com/openshift/local-storage-operator/pkg/utils"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	zaplog "go.uber.org/zap"
@@ -44,6 +48,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -102,12 +107,60 @@ func main() {
 	restConfig := ctrl.GetConfigOrDie()
 	le := utils.GetLeaderElectionConfig(restConfig, enableLeaderElection)
 
+	// Fetch TLS profile and adherence once at startup to ensure consistency
+	// Use a timeout to prevent indefinite stalls on API server outages
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	configClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		klog.ErrorS(err, "unable to create config client for TLS profile")
+		os.Exit(1)
+	}
+
+	adherence, err := lsotls.GetAdherencePolicyForLogging(ctx, configClient)
+	if err != nil {
+		klog.ErrorS(err, "failed to fetch TLS adherence policy")
+		os.Exit(1)
+	}
+
+	tlsProfile, err := lsotls.FetchAPIServerTLSProfile(ctx, configClient)
+	if err != nil {
+		if adherence == configv1.TLSAdherencePolicyStrictAllComponents {
+			klog.ErrorS(err, "failed to fetch TLS profile in strict adherence mode")
+			os.Exit(1)
+		}
+		klog.Warningf("failed to fetch TLS profile, using controller-runtime defaults: %v", err)
+		tlsProfile = configv1.TLSProfileSpec{}
+	}
+
+	var tlsConfigFn func(*tls.Config)
+	if tlsProfile.Ciphers != nil || tlsProfile.MinTLSVersion != "" {
+		var unsupportedCiphers []string
+		tlsConfigFn, unsupportedCiphers = lsotls.GetTLSConfigFromProfile(tlsProfile)
+		if len(unsupportedCiphers) > 0 {
+			klog.Warningf("TLS profile contains %d unsupported cipher suites: %v",
+				len(unsupportedCiphers), unsupportedCiphers)
+		}
+		klog.Infof("TLS config function created successfully")
+	} else {
+		klog.Infof("TLS profile has no ciphers or minVersion, using controller-runtime defaults")
+	}
+
+	metricsOpts := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: true,
+	}
+	if tlsConfigFn != nil {
+		metricsOpts.TLSOpts = []func(*tls.Config){tlsConfigFn}
+	}
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Cache: cache.Options{
 			DefaultNamespaces: map[string]cache.Config{namespace: {}},
 		},
 		Scheme:                 scheme,
-		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
+		Metrics:                metricsOpts,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		RenewDeadline:          &le.RenewDeadline.Duration,
@@ -151,6 +204,15 @@ func main() {
 		klog.ErrorS(err, "unable to create NodeDaemon controller")
 		os.Exit(1)
 	}
+
+	// Setup TLS security profile watcher to restart operator on TLS profile/adherence changes
+	tlsWatcher := lsotls.NewSecurityProfileWatcher(tlsProfile, adherence)
+	tlsWatcher.Client = mgr.GetClient()
+	if err = tlsWatcher.SetupWithManager(mgr); err != nil {
+		klog.ErrorS(err, "unable to create TLS security profile watcher")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/docs/plans/2026-07-30-001-fix-lso-tls-adherence-plan.md
+++ b/docs/plans/2026-07-30-001-fix-lso-tls-adherence-plan.md
@@ -1,0 +1,177 @@
+---
+title: "Fix LSO TLS Adherence Implementation - Plan"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+created: 2026-07-30
+---
+
+# Fix LSO TLS Adherence Implementation - Plan
+
+## Goal Capsule
+
+**Objective:** Fix the TLS adherence implementation in LSO PR #643 by adding the missing `ShouldHonorClusterTLSProfile` gate, replacing `os.Exit(0)` with graceful `cancel()` shutdown, removing dead code, and eliminating trivial wrapper functions.
+
+**Product authority:** OpenShift enhancement [centralized-tls-config](https://github.com/openshift/enhancements/blob/master/enhancements/security/centralized-tls-config.md) and the reference implementation in [cluster-machine-approver](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/pkg/tls/tls.go).
+
+**Open blockers:** None — PR #643 is open and we have local fork access.
+
+---
+
+## Product Contract
+
+### Problem Frame
+
+LSO PR #643 (STOR-3054) adds TLS adherence to the Local Storage Operator but has four issues identified during cross-reference review against the enhancement document, CVO source code, and the cluster-machine-approver reference implementation.
+
+### Requirements
+
+- R1. The operator must check `ShouldHonorClusterTLSProfile` before applying the cluster TLS profile to its metrics endpoint — new-to-TLS components should only honor the cluster profile when `StrictAllComponents` is set
+- R2. The operator must use graceful shutdown (`cancel()`) instead of `os.Exit(0)` when TLS configuration changes
+- R3. Dead code (`ValidateMetricsAccess`) must be removed
+- R4. Trivial pass-through wrapper functions must be replaced with direct calls to `controller-runtime-common`
+
+### Key Decisions
+
+**KD1. Use `ShouldHonorClusterTLSProfile` adherence gate (Governs R1)**
+
+The enhancement explicitly states: *"Component implementors should use the ShouldHonorClusterTLSProfile helper function from library-go rather than checking the tlsAdherence field values directly."*
+
+Currently LSO PR #643 applies TLS based on `tlsProfile.Ciphers != nil || tlsProfile.MinTLSVersion != ""` — a non-empty profile check. This means in `LegacyAdheringComponentsOnly` mode with Intermediate profile configured (the default), LSO applies it anyway. Per the enhancement, new-to-TLS components should only honor the cluster profile under `StrictAllComponents`.
+
+Evidence: `controller-runtime-common/pkg/tls/` does NOT contain `ShouldHonorClusterTLSProfile` — confirmed by searching the entire module. The adherence gating is the operator's responsibility. `cluster-machine-approver` does it at [pkg/tls/tls.go:126-140](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/pkg/tls/tls.go#L126-L140).
+
+**KD2. Use `cancel()` for graceful shutdown, not `os.Exit(0)` (Governs R2)**
+
+The `SecurityProfileWatcher`'s own source code documents the `cancel()` pattern as the intended usage — from [`controller-runtime-common/pkg/tls/controller.go:63-77`](https://github.com/openshift/controller-runtime-common/blob/fea68df23430b5c1e86599ac37d1de7e7fe55eb6/pkg/tls/controller.go#L63-L77):
+
+```
+ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+defer cancel()
+watcher := &SecurityProfileWatcher{
+    OnProfileChange: func(ctx context.Context, old, new configv1.TLSProfileSpec) {
+        cancel()
+    },
+}
+```
+
+And cluster-machine-approver follows this exactly at [main.go:210-229](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/main.go#L210-L229).
+
+`os.Exit(0)` terminates immediately — leader election lease is not released (other replicas wait for the full lease duration), in-flight reconciles are killed, and `defer` cleanup functions don't run.
+
+**KD3. Remove dead `ValidateMetricsAccess` (Governs R3)**
+
+`ValidateMetricsAccess` in `pkg/tls/tlsprofile.go` correctly uses `ShouldHonorClusterTLSProfile` but is never called from `main.go`. Rather than wiring it in (its validation-only approach doesn't fit the startup flow), we implement the adherence check inline in `main.go` matching the cluster-machine-approver pattern.
+
+**KD4. Remove trivial wrappers (Governs R4)**
+
+Three functions in `pkg/tls/tlsprofile.go` are one-line pass-throughs to `controller-runtime-common`:
+- `GetTLSConfigFromProfile` → `crcommon.NewTLSConfigFromProfile`
+- `GetAdherencePolicyForLogging` → `crcommon.FetchAPIServerTLSAdherencePolicy`
+- `FetchAPIServerTLSProfile` → `crcommon.FetchAPIServerTLSProfile`
+
+Encapsulation wrappers are justified when adding local invariants (transforming results, adding defaults, combining calls). These add none — `controller-runtime-common` IS the abstraction layer. `cluster-machine-approver` calls `crcommon` directly.
+
+### Scope Boundaries
+
+**In scope:** Fixing the four issues in `cmd/local-storage-operator/main.go` and `pkg/tls/` files added by PR #643.
+
+**Out of scope:**
+- Changing the existing `GetTLSProfileValues` function (used for kube-rbac-proxy operand TLS — different concern)
+- Adding feature gate checks (enhancement explicitly says not needed)
+- Modifying the `controller-runtime-common` dependency
+
+---
+
+## Planning Contract
+
+### Implementation Units
+
+### U1. Add ShouldHonorClusterTLSProfile adherence gate
+
+**Goal:** Gate TLS profile application on the adherence policy, matching the cluster-machine-approver pattern.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+- `cmd/local-storage-operator/main.go`
+
+**Approach:** After fetching adherence and tlsProfile, check `libcrypto.ShouldHonorClusterTLSProfile(adherence)`. When true, apply the cluster profile. When false, apply the default Intermediate profile. This replaces the current `tlsProfile.Ciphers != nil || tlsProfile.MinTLSVersion != ""` check.
+
+**Patterns to follow:** [cluster-machine-approver pkg/tls/tls.go:126-140](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/pkg/tls/tls.go#L126-L140)
+
+---
+
+### U2. Replace os.Exit(0) with cancel() for graceful shutdown
+
+**Goal:** Use controller-runtime's graceful shutdown mechanism instead of abrupt process termination.
+
+**Requirements:** R2
+
+**Dependencies:** None (independent of U1)
+
+**Files:**
+- `cmd/local-storage-operator/main.go`
+- `pkg/tls/watcher.go`
+
+**Approach:**
+1. In `main.go`, create a cancellable context: `ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())`
+2. Pass `cancel` to the watcher factory function
+3. In `watcher.go`, change `NewSecurityProfileWatcher` to accept `cancel func()` and use it in both callbacks instead of `os.Exit(0)`
+4. Pass `ctx` to `mgr.Start(ctx)`
+
+**Patterns to follow:** [cluster-machine-approver main.go:155,210-229](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/main.go#L155) and the `SecurityProfileWatcher` Example in [controller.go:63-77](https://github.com/openshift/controller-runtime-common/blob/fea68df23430b5c1e86599ac37d1de7e7fe55eb6/pkg/tls/controller.go#L63-L77)
+
+---
+
+### U3. Remove dead code and trivial wrappers
+
+**Goal:** Remove `ValidateMetricsAccess` (dead code) and the three trivial pass-through wrappers. Update `main.go` to call `controller-runtime-common` directly.
+
+**Requirements:** R3, R4
+
+**Dependencies:** U1 (the wrappers are being called from main.go; U1 changes those call sites)
+
+**Files:**
+- `pkg/tls/tlsprofile.go`
+- `cmd/local-storage-operator/main.go`
+
+**Approach:** Remove `ValidateMetricsAccess`, `GetTLSConfigFromProfile`, `GetAdherencePolicyForLogging`, and `FetchAPIServerTLSProfile` from `pkg/tls/tlsprofile.go`. Replace their call sites in `main.go` with direct calls to `crcommon.FetchAPIServerTLSAdherencePolicy`, `crcommon.FetchAPIServerTLSProfile`, and `crcommon.NewTLSConfigFromProfile`. Add the `crcommon` import to `main.go`.
+
+---
+
+## Verification Contract
+
+| Gate | Applies to | Criterion |
+|------|-----------|-----------|
+| Build | All units | `go build ./...` passes |
+| Tests | All units | `go test ./...` passes |
+| Vet | All units | `go vet ./...` passes |
+| Dead code | U3 | Removed functions not referenced anywhere |
+
+## Definition of Done
+
+- All three units implemented and verified
+- `go build ./...` passes
+- `go test ./...` passes
+- No `os.Exit(0)` in watcher callbacks
+- `ShouldHonorClusterTLSProfile` is called before TLS profile application
+- No trivial wrapper functions remain in `pkg/tls/tlsprofile.go`
+- `ValidateMetricsAccess` removed
+- Changes committed on a branch ready for PR
+
+---
+
+## Sources & Research
+
+- Enhancement: [centralized-tls-config.md](https://github.com/openshift/enhancements/blob/master/enhancements/security/centralized-tls-config.md)
+- Reference implementation: [cluster-machine-approver](https://github.com/openshift/cluster-machine-approver)
+- Shared library: [controller-runtime-common/pkg/tls/](https://github.com/openshift/controller-runtime-common/tree/main/pkg/tls)
+- CVO TLS injection: [cluster-version-operator lib/resourcebuilder/core.go](https://github.com/openshift/cluster-version-operator)
+- CVO own endpoint TLS: [cluster-version-operator pkg/tls/tls.go](https://github.com/openshift/cluster-version-operator)
+- LSO PR under review: [openshift/local-storage-operator#643](https://github.com/openshift/local-storage-operator/pull/643)
+- GCP Filestore PR (parallel work): [openshift/gcp-filestore-csi-driver-operator#152](https://github.com/openshift/gcp-filestore-csi-driver-operator/pull/152)
+- STOR-3054 Jira: [https://redhat.atlassian.net/browse/STOR-3054](https://redhat.atlassian.net/browse/STOR-3054)

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.29
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.316.1
 	github.com/onsi/ginkgo/v2 v2.32.0
+	github.com/openshift/controller-runtime-common v0.0.0-20260722095319-fea68df23430
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c h1:gJ
 github.com/openshift/build-machinery-go v0.0.0-20250602125535-1b6d00b8c37c/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
 github.com/openshift/client-go v0.0.0-20260721124015-35d8f3c0e847 h1:i96ZYwZrCbqxsSrtO/qLJ7Olvu5M9xBU/yVz4Xg8LK4=
 github.com/openshift/client-go v0.0.0-20260721124015-35d8f3c0e847/go.mod h1:il93009qOuWG58FeXsVnXD4Yurtm+RMtxIpJv231JdU=
+github.com/openshift/controller-runtime-common v0.0.0-20260722095319-fea68df23430 h1:c068rCmMU/tUklmy5v3lH+hIAVIn2N56jDhiY5OX4rY=
+github.com/openshift/controller-runtime-common v0.0.0-20260722095319-fea68df23430/go.mod h1:YVDrbC4muEYMejrIZkaQHhlH0bcBusL1UUBkPBxeVrI=
 github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a h1:86Mj1eP0RtYtwPRpdkGbzf6h1Tn+uuYiR6XKZXsWWn8=
 github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a/go.mod h1:iWcB6wgeOhsByZAZGhmzBtEnrLQzABL0s3aeou8AmSI=
 github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=

--- a/pkg/tls/tlsprofile.go
+++ b/pkg/tls/tlsprofile.go
@@ -2,11 +2,14 @@ package tls
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	crcommon "github.com/openshift/controller-runtime-common/pkg/tls"
+	libcrypto "github.com/openshift/library-go/pkg/crypto"
 	libapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
 	libevents "github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -92,4 +95,45 @@ func (a *apiServerListers) ResourceSyncer() resourcesynccontroller.ResourceSynce
 
 func (a *apiServerListers) PreRunHasSynced() []cache.InformerSynced {
 	return nil
+}
+
+// GetTLSConfigFromProfile returns a function that configures a tls.Config based on
+// the provided TLS profile spec. The returned function is suitable for use with
+// controller-runtime's metricsserver.Options TLSOpts field.
+func GetTLSConfigFromProfile(profileSpec configv1.TLSProfileSpec) (func(*tls.Config), []string) {
+	configFn, unsupportedCiphers := crcommon.NewTLSConfigFromProfile(profileSpec)
+	return configFn, unsupportedCiphers
+}
+
+// ValidateMetricsAccess validates TLS configuration based on the cluster's adherence policy.
+func ValidateMetricsAccess(ctx context.Context, c client.Client) error {
+	adherence, err := crcommon.FetchAPIServerTLSAdherencePolicy(ctx, c)
+	if err != nil {
+		return fmt.Errorf("failed to fetch TLS adherence policy: %w", err)
+	}
+
+	if libcrypto.ShouldHonorClusterTLSProfile(adherence) {
+		profileSpec, err := crcommon.FetchAPIServerTLSProfile(ctx, c)
+		if err != nil {
+			return fmt.Errorf("adherence policy %s requires valid TLS profile: %w", adherence, err)
+		}
+		// Check if profile has any configuration
+		if profileSpec.Ciphers == nil && profileSpec.MinTLSVersion == "" {
+			return fmt.Errorf("adherence policy %s requires explicit TLS profile", adherence)
+		}
+	}
+
+	return nil
+}
+
+// GetAdherencePolicyForLogging returns the current TLS adherence policy for logging purposes.
+// Returns the policy and any error encountered.
+func GetAdherencePolicyForLogging(ctx context.Context, c client.Client) (configv1.TLSAdherencePolicy, error) {
+	return crcommon.FetchAPIServerTLSAdherencePolicy(ctx, c)
+}
+
+// FetchAPIServerTLSProfile fetches the TLS profile spec from the cluster APIServer CR.
+// This is a convenience wrapper around controller-runtime-common's function.
+func FetchAPIServerTLSProfile(ctx context.Context, c client.Client) (configv1.TLSProfileSpec, error) {
+	return crcommon.FetchAPIServerTLSProfile(ctx, c)
 }

--- a/pkg/tls/tlsprofile.go
+++ b/pkg/tls/tlsprofile.go
@@ -2,14 +2,11 @@ package tls
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
-	crcommon "github.com/openshift/controller-runtime-common/pkg/tls"
-	libcrypto "github.com/openshift/library-go/pkg/crypto"
 	libapiserver "github.com/openshift/library-go/pkg/operator/configobserver/apiserver"
 	libevents "github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
@@ -97,43 +94,3 @@ func (a *apiServerListers) PreRunHasSynced() []cache.InformerSynced {
 	return nil
 }
 
-// GetTLSConfigFromProfile returns a function that configures a tls.Config based on
-// the provided TLS profile spec. The returned function is suitable for use with
-// controller-runtime's metricsserver.Options TLSOpts field.
-func GetTLSConfigFromProfile(profileSpec configv1.TLSProfileSpec) (func(*tls.Config), []string) {
-	configFn, unsupportedCiphers := crcommon.NewTLSConfigFromProfile(profileSpec)
-	return configFn, unsupportedCiphers
-}
-
-// ValidateMetricsAccess validates TLS configuration based on the cluster's adherence policy.
-func ValidateMetricsAccess(ctx context.Context, c client.Client) error {
-	adherence, err := crcommon.FetchAPIServerTLSAdherencePolicy(ctx, c)
-	if err != nil {
-		return fmt.Errorf("failed to fetch TLS adherence policy: %w", err)
-	}
-
-	if libcrypto.ShouldHonorClusterTLSProfile(adherence) {
-		profileSpec, err := crcommon.FetchAPIServerTLSProfile(ctx, c)
-		if err != nil {
-			return fmt.Errorf("adherence policy %s requires valid TLS profile: %w", adherence, err)
-		}
-		// Check if profile has any configuration
-		if profileSpec.Ciphers == nil && profileSpec.MinTLSVersion == "" {
-			return fmt.Errorf("adherence policy %s requires explicit TLS profile", adherence)
-		}
-	}
-
-	return nil
-}
-
-// GetAdherencePolicyForLogging returns the current TLS adherence policy for logging purposes.
-// Returns the policy and any error encountered.
-func GetAdherencePolicyForLogging(ctx context.Context, c client.Client) (configv1.TLSAdherencePolicy, error) {
-	return crcommon.FetchAPIServerTLSAdherencePolicy(ctx, c)
-}
-
-// FetchAPIServerTLSProfile fetches the TLS profile spec from the cluster APIServer CR.
-// This is a convenience wrapper around controller-runtime-common's function.
-func FetchAPIServerTLSProfile(ctx context.Context, c client.Client) (configv1.TLSProfileSpec, error) {
-	return crcommon.FetchAPIServerTLSProfile(ctx, c)
-}

--- a/pkg/tls/watcher.go
+++ b/pkg/tls/watcher.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Local Storage Operator Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"os"
+
+	configv1 "github.com/openshift/api/config/v1"
+	crcommon "github.com/openshift/controller-runtime-common/pkg/tls"
+	"k8s.io/klog/v2"
+)
+
+// NewSecurityProfileWatcher creates a SecurityProfileWatcher that triggers operator
+// restart when TLS profile or adherence policy changes.
+// The initial TLS profile spec and adherence policy are passed in so the watcher
+// knows the baseline configuration from operator startup.
+func NewSecurityProfileWatcher(
+	initialProfile configv1.TLSProfileSpec,
+	initialAdherence configv1.TLSAdherencePolicy,
+) *crcommon.SecurityProfileWatcher {
+	return &crcommon.SecurityProfileWatcher{
+		InitialTLSProfileSpec:     initialProfile,
+		InitialTLSAdherencePolicy: initialAdherence,
+		OnProfileChange: func(ctx context.Context, oldProfile, newProfile configv1.TLSProfileSpec) {
+			klog.Infof("TLS profile changed, restarting operator to apply new configuration")
+			klog.V(2).Infof("Old profile: %+v, New profile: %+v", oldProfile, newProfile)
+			os.Exit(0) // Kubernetes will restart the pod
+		},
+		OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy configv1.TLSAdherencePolicy) {
+			klog.Infof("TLS adherence policy changed from %s to %s, restarting operator",
+				oldPolicy, newPolicy)
+			os.Exit(0)
+		},
+	}
+}

--- a/pkg/tls/watcher.go
+++ b/pkg/tls/watcher.go
@@ -18,18 +18,16 @@ package tls
 
 import (
 	"context"
-	"os"
 
 	configv1 "github.com/openshift/api/config/v1"
 	crcommon "github.com/openshift/controller-runtime-common/pkg/tls"
 	"k8s.io/klog/v2"
 )
 
-// NewSecurityProfileWatcher creates a SecurityProfileWatcher that triggers operator
-// restart when TLS profile or adherence policy changes.
-// The initial TLS profile spec and adherence policy are passed in so the watcher
-// knows the baseline configuration from operator startup.
+// NewSecurityProfileWatcher creates a SecurityProfileWatcher that triggers a
+// graceful shutdown via cancel when TLS profile or adherence policy changes.
 func NewSecurityProfileWatcher(
+	cancel context.CancelFunc,
 	initialProfile configv1.TLSProfileSpec,
 	initialAdherence configv1.TLSAdherencePolicy,
 ) *crcommon.SecurityProfileWatcher {
@@ -39,12 +37,12 @@ func NewSecurityProfileWatcher(
 		OnProfileChange: func(ctx context.Context, oldProfile, newProfile configv1.TLSProfileSpec) {
 			klog.Infof("TLS profile changed, restarting operator to apply new configuration")
 			klog.V(2).Infof("Old profile: %+v, New profile: %+v", oldProfile, newProfile)
-			os.Exit(0) // Kubernetes will restart the pod
+			cancel()
 		},
 		OnAdherencePolicyChange: func(ctx context.Context, oldPolicy, newPolicy configv1.TLSAdherencePolicy) {
 			klog.Infof("TLS adherence policy changed from %s to %s, restarting operator",
 				oldPolicy, newPolicy)
-			os.Exit(0)
+			cancel()
 		},
 	}
 }

--- a/vendor/github.com/openshift/controller-runtime-common/LICENSE
+++ b/vendor/github.com/openshift/controller-runtime-common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/controller.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecurityProfileWatcher watches the APIServer object for TLS profile changes
+// and triggers a graceful shutdown when the profile changes.
+type SecurityProfileWatcher struct {
+	client.Client
+
+	// InitialTLSProfileSpec is the TLS profile spec that was configured when the operator started.
+	InitialTLSProfileSpec configv1.TLSProfileSpec
+
+	// InitialTLSAdherencePolicy is the TLS adherence policy that was configured when the operator started.
+	InitialTLSAdherencePolicy configv1.TLSAdherencePolicy
+
+	// OnProfileChange is a function that will be called when the TLS profile changes.
+	// It receives the reconcile context, old and new TLS profile specs.
+	// This allows the caller to make decisions based on the actual profile changes.
+	//
+	// The most common use case for this callback is
+	// to trigger a graceful shutdown of the operator
+	// to make it pick up the new configuration.
+	//
+	// Example:
+	//
+	// 	// Create a context that can be cancelled when there is a need to shut down the manager.
+	//  ctx, cancel := context.WithCancel(ctrl.SetupSignalHandler())
+	//  defer cancel()
+	//
+	//  watcher := &SecurityProfileWatcher{
+	// 	  OnProfileChange: func(ctx context.Context, old, new configv1.TLSProfileSpec) {
+	//      logger.Infof("TLS profile has changed, initiating a shutdown to reload it. %q: %+v, %q: %+v",
+	//        "old profile", old,
+	//        "new profile", new,
+	//      )
+	//      // Cancel the outer context to trigger a graceful shutdown of the manager.
+	//      cancel()
+	//    },
+	//  }
+	OnProfileChange func(ctx context.Context, oldTLSProfileSpec, newTLSProfileSpec configv1.TLSProfileSpec)
+
+	// OnAdherencePolicyChange is a function that will be called when the TLS adherence policy changes.
+	OnAdherencePolicyChange func(ctx context.Context, oldTLSAdherencePolicy, newTLSAdherencePolicy configv1.TLSAdherencePolicy)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SecurityProfileWatcher) SetupWithManager(mgr ctrl.Manager) error {
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("tlssecurityprofilewatcher").
+		WithOptions(controller.Options{NeedLeaderElection: ptr.To(false)}).
+		For(&configv1.APIServer{}, builder.WithPredicates(
+			predicate.Funcs{
+				// Only watch the "cluster" APIServer object.
+				CreateFunc: func(e event.CreateEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return e.ObjectNew.GetName() == APIServerName
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+				GenericFunc: func(e event.GenericEvent) bool {
+					return e.Object.GetName() == APIServerName
+				},
+			},
+		)).
+		// Override the default log constructor as it makes the logs very chatty.
+		WithLogConstructor(func(_ *reconcile.Request) logr.Logger {
+			return mgr.GetLogger().WithValues(
+				"controller", "tlssecurityprofilewatcher",
+			)
+		}).
+		Complete(r); err != nil {
+		return fmt.Errorf("could not set up controller for TLS security profile watcher: %w", err)
+	}
+
+	return nil
+}
+
+// Reconcile watches for changes to the APIServer TLS profile and triggers a shutdown
+// when the profile changes from the initial configuration.
+func (r *SecurityProfileWatcher) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx, "name", req.Name)
+
+	logger.V(1).Info("Reconciling APIServer TLS profile")
+	defer logger.V(1).Info("Finished reconciling APIServer TLS profile")
+
+	// Fetch the APIServer object.
+	apiServer := &configv1.APIServer{}
+	if err := r.Get(ctx, req.NamespacedName, apiServer); err != nil {
+		if apierrors.IsNotFound(err) {
+			// If the APIServer object is not found, we don't need to do anything.
+			// This could happen if the object was deleted.
+			return ctrl.Result{}, nil
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to get APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Get the current TLS profile spec.
+	currentTLSProfileSpec, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get TLS profile from APIServer %s: %w", req.NamespacedName.String(), err)
+	}
+
+	// Compare the current TLS profile spec with the initial one.
+	if tlsProfileChanged := !reflect.DeepEqual(r.InitialTLSProfileSpec, currentTLSProfileSpec); tlsProfileChanged {
+		// TLS profile has changed, invoke the callback if it is set.
+		if r.OnProfileChange != nil {
+			r.OnProfileChange(ctx, r.InitialTLSProfileSpec, currentTLSProfileSpec)
+		}
+
+		// Persist the new profile for future change detection.
+		r.InitialTLSProfileSpec = currentTLSProfileSpec
+	}
+
+	// Compare the current TLS adherence policy with the initial one.
+	if tlsAdherencePolicyChanged := r.InitialTLSAdherencePolicy != apiServer.Spec.TLSAdherence; tlsAdherencePolicyChanged {
+		// TLS adherence policy has changed, invoke the callback if it is set.
+		if r.OnAdherencePolicyChange != nil {
+			r.OnAdherencePolicyChange(ctx, r.InitialTLSAdherencePolicy, apiServer.Spec.TLSAdherence)
+		}
+
+		// Persist the new adherence policy for future change detection.
+		r.InitialTLSAdherencePolicy = apiServer.Spec.TLSAdherence
+	}
+
+	// No need to requeue, as the callback will handle further actions.
+	return ctrl.Result{}, nil
+}

--- a/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
+++ b/vendor/github.com/openshift/controller-runtime-common/pkg/tls/tls.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tls provides utilities for working with OpenShift TLS profiles.
+package tls
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// APIServerName is the name of the APIServer resource in the cluster.
+	APIServerName = "cluster"
+)
+
+var (
+	// ErrCustomProfileNil is returned when a custom TLS profile is specified but the Custom field is nil.
+	ErrCustomProfileNil = errors.New("custom TLS profile specified but Custom field is nil")
+
+	// DefaultTLSCiphers are the default TLS ciphers for API servers.
+	DefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers //nolint:gochecknoglobals
+	// DefaultMinTLSVersion is the default minimum TLS version for API servers.
+	DefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion //nolint:gochecknoglobals
+)
+
+// FetchAPIServerTLSProfile fetches the TLS profile spec configured in APIServer.
+// If no profile is configured, the default profile is returned.
+func FetchAPIServerTLSProfile(ctx context.Context, k8sClient client.Client) (configv1.TLSProfileSpec, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+
+	if err := k8sClient.Get(ctx, key, apiServer); err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+	}
+
+	profile, err := GetTLSProfileSpec(apiServer.Spec.TLSSecurityProfile)
+	if err != nil {
+		return configv1.TLSProfileSpec{}, fmt.Errorf("failed to get TLS profile from APIServer %q: %w", key.String(), err)
+	}
+
+	return profile, nil
+}
+
+// FetchAPIServerTLSAdherencePolicy fetches the TLS adherence policy configured in APIServer.
+// If no policy is configured, the default policy is returned.
+func FetchAPIServerTLSAdherencePolicy(ctx context.Context, k8sClient client.Client) (configv1.TLSAdherencePolicy, error) {
+	apiServer := &configv1.APIServer{}
+	key := client.ObjectKey{Name: APIServerName}
+
+	if err := k8sClient.Get(ctx, key, apiServer); err != nil {
+		return configv1.TLSAdherencePolicyNoOpinion, fmt.Errorf("failed to get APIServer %q: %w", key.String(), err)
+	}
+
+	return apiServer.Spec.TLSAdherence, nil
+}
+
+// GetTLSProfileSpec returns TLSProfileSpec for the given profile.
+// If no profile is configured, the default profile is returned.
+func GetTLSProfileSpec(profile *configv1.TLSSecurityProfile) (configv1.TLSProfileSpec, error) {
+	// Define the default profile (at the time of writing, this is the intermediate profile).
+	defaultProfile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+	// If the profile is nil or the type is empty, return the default profile.
+	if profile == nil || profile.Type == "" {
+		return defaultProfile, nil
+	}
+
+	// Get the profile type.
+	profileType := profile.Type
+
+	// If the profile type is not custom, return the profile from the map.
+	if profileType != configv1.TLSProfileCustomType {
+		if tlsConfig, ok := configv1.TLSProfiles[profileType]; ok {
+			return *tlsConfig, nil
+		}
+
+		// If the profile type is not found, return the default profile.
+		return defaultProfile, nil
+	}
+
+	if profile.Custom == nil {
+		// If the custom profile is nil, return an error.
+		return configv1.TLSProfileSpec{}, ErrCustomProfileNil
+	}
+
+	// Return the custom profile spec.
+	return profile.Custom.TLSProfileSpec, nil
+}
+
+// NewTLSConfigFromProfile returns a function that configures a tls.Config based on the provided TLSProfileSpec,
+// along with any cipher names from the profile that are not supported by the library-go crypto package.
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Note: CipherSuites are only set when MinVersion is below TLS 1.3, as Go's TLS 1.3 implementation
+// does not allow configuring cipher suites - all TLS 1.3 ciphers are always enabled.
+// See: https://github.com/golang/go/issues/29349
+func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*tls.Config), unsupportedCiphers []string) {
+	minVersion := libgocrypto.TLSVersionOrDie(string(profile.MinTLSVersion))
+	cipherSuites, unsupportedCiphers := cipherCodes(profile.Ciphers)
+
+	return func(tlsConf *tls.Config) {
+		tlsConf.MinVersion = minVersion
+		// TODO: add curve preferences from profile once https://github.com/openshift/api/pull/2583 merges.
+		// tlsConf.CurvePreferences <<<<<< profile.Curves
+
+		// TLS 1.3 cipher suites are not configurable in Go (https://github.com/golang/go/issues/29349), so only set CipherSuites accordingly.
+		// TODO: revisit this once we get an answer on the best way to handle this here:
+		// https://docs.google.com/document/d/1cMc9E8psHfnoK06ntR8kHSWB8d3rMtmldhnmM4nImjs/edit?disco=AAABu_nPcYg
+		if minVersion != tls.VersionTLS13 {
+			tlsConf.CipherSuites = cipherSuites
+		}
+	}, unsupportedCiphers
+}
+
+// cipherCode returns the TLS cipher code for an OpenSSL or IANA cipher name.
+// Returns 0 if the cipher is not supported.
+func cipherCode(cipher string) uint16 {
+	// First try as IANA name directly.
+	if code, err := libgocrypto.CipherSuite(cipher); err == nil {
+		return code
+	}
+
+	// Try converting from OpenSSL name to IANA name.
+	ianaCiphers := libgocrypto.OpenSSLToIANACipherSuites([]string{cipher})
+	if len(ianaCiphers) == 1 {
+		if code, err := libgocrypto.CipherSuite(ianaCiphers[0]); err == nil {
+			return code
+		}
+	}
+
+	// Return 0 if the cipher is not supported.
+	return 0
+}
+
+// cipherCodes converts a list of cipher names (OpenSSL or IANA format) to their uint16 codes.
+// Returns the converted codes and a list of any unsupported cipher names.
+func cipherCodes(ciphers []string) (codes []uint16, unsupportedCiphers []string) {
+	for _, cipher := range ciphers {
+		code := cipherCode(cipher)
+		if code == 0 {
+			unsupportedCiphers = append(unsupportedCiphers, cipher)
+			continue
+		}
+
+		codes = append(codes, code)
+	}
+
+	return codes, unsupportedCiphers
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -416,6 +416,9 @@ github.com/openshift/client-go/route/clientset/versioned
 github.com/openshift/client-go/route/clientset/versioned/scheme
 github.com/openshift/client-go/route/clientset/versioned/typed/route/v1
 github.com/openshift/client-go/security/clientset/versioned/scheme
+# github.com/openshift/controller-runtime-common v0.0.0-20260722095319-fea68df23430
+## explicit; go 1.26.0
+github.com/openshift/controller-runtime-common/pkg/tls
 # github.com/openshift/library-go v0.0.0-20260721103755-0c9fbc9f043a
 ## explicit; go 1.26.0
 github.com/openshift/library-go/pkg/apiserver/jsonpatch


### PR DESCRIPTION
## Summary

Fixes the TLS adherence implementation from PR #643 ([STOR-3054](https://redhat.atlassian.net/browse/STOR-3054)) by addressing four issues identified during cross-reference review against the OpenShift centralized-tls-config enhancement and the cluster-machine-approver reference implementation.

### Changes

- **ShouldHonorClusterTLSProfile gate:** Replace the non-empty profile check (`tlsProfile.Ciphers != nil || tlsProfile.MinTLSVersion != ""`) with `libcrypto.ShouldHonorClusterTLSProfile(adherence)`. As a new-to-TLS component, LSO should only honor the cluster TLS profile under `StrictAllComponents` mode, not `LegacyAdheringComponentsOnly`.

- **Graceful shutdown:** Replace `os.Exit(0)` in the TLS watcher callbacks with `context.CancelFunc`, following the pattern documented in `controller-runtime-common` and used by cluster-machine-approver. This ensures leader election leases are released, `defer` cleanup runs, and in-flight reconciles finish.

- **Dead code removal:** Remove `ValidateMetricsAccess` (never called from main.go) and three trivial pass-through wrapper functions (`GetTLSConfigFromProfile`, `GetAdherencePolicyForLogging`, `FetchAPIServerTLSProfile`). Main.go now calls `controller-runtime-common` directly, matching the cluster-machine-approver pattern.

### References

- Enhancement: [centralized-tls-config](https://github.com/openshift/enhancements/blob/master/enhancements/security/centralized-tls-config.md)
- Reference impl: [cluster-machine-approver](https://github.com/openshift/cluster-machine-approver/blob/1ae3f157b88c167a7dbe06c36d6e55a82f7fd4f0/pkg/tls/tls.go)
- Library docs: [controller-runtime-common/pkg/tls/controller.go](https://github.com/openshift/controller-runtime-common/blob/fea68df23430b5c1e86599ac37d1de7e7fe55eb6/pkg/tls/controller.go#L63-L77)
- Depends on: #643

### Verification

- `go build ./cmd/local-storage-operator/... ./pkg/tls/...` passes
- `go vet ./cmd/local-storage-operator/... ./pkg/tls/...` passes
- `golangci-lint run --new-from-rev=origin/main` reports 0 issues
- Removed functions confirmed unreferenced via grep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics serving now honors the cluster’s configured TLS profile and adherence policy.
  * TLS profile and adherence changes are detected automatically and applied through a graceful operator restart.
  * Startup and shutdown handling now use coordinated cancellation for more reliable lifecycle management.

* **Documentation**
  * Added an implementation plan covering TLS adherence improvements, validation, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->